### PR TITLE
Fix a glitch that a tamplate CodeUri has like `../` relative path

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -55,6 +55,7 @@ type Runtime struct {
 	Image           string
 	Cwd             string
 	DecompressedCwd string
+	TemplateDir     string
 	Function        cloudformation.AWSServerlessFunction
 	EnvOverrideFile string
 	DebugPort       string
@@ -131,6 +132,7 @@ func NewRuntime(opt NewRuntimeOpt) (Invoker, error) {
 		LogicalID:       opt.LogicalID,
 		Name:            opt.Function.Runtime,
 		Cwd:             getWorkingDir(opt.Cwd),
+		TemplateDir:     getWorkingDir(opt.Cwd),
 		Image:           image,
 		Function:        opt.Function,
 		EnvOverrideFile: opt.EnvOverrideFile,
@@ -268,7 +270,7 @@ func (r *Runtime) Invoke(event string, profile string) (io.Reader, io.Reader, er
 
 	// If the CodeUri has been specified as a .jar or .zip file, unzip it on the fly
 	if r.Function.CodeUri != nil && r.Function.CodeUri.String != nil {
-		codeuri := filepath.Join(r.Cwd, *r.Function.CodeUri.String)
+		codeuri := filepath.Join(r.TemplateDir, *r.Function.CodeUri.String)
 
 		// Check if the CodeUri exists on the local filesystem
 		if _, err := os.Stat(codeuri); err == nil {


### PR DESCRIPTION
# Encountered problem

I encounterd a problem like following problem. A sample project reproducing the problem is here: https://github.com/mozamimy/aws-sam-test

Following log is local API server,

```
[15:03:14]mozamimy@P861:aws-sam-test (master) (-'x'-).oO(
(cmd)> ed aws-sam-local local start-api --template=deploy/template/staging.yml
2018/01/27 15:03:22 Connected to Docker 1.35
2018/01/27 15:03:22 Fetching lambci/lambda:nodejs6.10 image for nodejs6.10 runtime...
nodejs6.10: Pulling from lambci/lambda
Digest: sha256:b72789e8a544e658a76d71a0abbb2fa8b4122cc882bcd27097037bd28f657c9b
Status: Image is up to date for lambci/lambda:nodejs6.10

Mounting index.handler (nodejs6.10) at http://127.0.0.1:3000/ [GET]

You can now browse to the above endpoints to invoke your functions.
You do not need to restart/reload SAM CLI while working on your functions,
changes will be reflected instantly/automatically. You only need to restart
SAM CLI if you update your AWS SAM template.

2018/01/27 15:03:29 Invoking index.handler (nodejs6.10)
2018/01/27 15:03:29 Mounting /Users/mozamimy/var/repo/private/aws-sam-test as /var/task:ro inside runtime container
START RequestId: eb86fa0d-956f-1a9a-4e26-d4926b1e00d5 Version: $LATEST
2018-01-27T06:03:31.609Z        eb86fa0d-956f-1a9a-4e26-d4926b1e00d5    {
  "httpMethod": "GET",
  "body": "cute bunny",
  "resource": "/",
  "requestContext": {
    "resourcePath": "/",
    "httpMethod": "GET",
    "stage": "prod",
    "identity": {
      "sourceIp": "127.0.0.1:50969"
    }
  },
  "queryStringParameters": {},
  "headers": {
    "Accept": "*/*",
    "Content-Length": "10",
    "Content-Type": "application/x-www-form-urlencoded",
    "User-Agent": "curl/7.54.0"
  },
  "pathParameters": null,
  "stageVariables": null,
  "path": "/"
}
END RequestId: eb86fa0d-956f-1a9a-4e26-d4926b1e00d5
REPORT RequestId: eb86fa0d-956f-1a9a-4e26-d4926b1e00d5  Duration: 11.78 ms      Billed Duration: 100 ms Memory Size: 128 MB     Max Memory Used: 28 MB
2018/01/27 15:03:33 Invoking index.handler (nodejs6.10)
2018/01/27 15:03:33 Mounting /Users/mozamimy/var/repo as /var/task:ro inside runtime container
START RequestId: 29ddcbfd-31ef-19c4-e757-11ded9f6809b Version: $LATEST
Unable to import module 'index': Error
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
END RequestId: 29ddcbfd-31ef-19c4-e757-11ded9f6809b
REPORT RequestId: 29ddcbfd-31ef-19c4-e757-11ded9f6809b  Duration: 13.31 ms      Billed Duration: 100 ms Memory Size: 128 MB     Max Memory Used: 28 MB
2018/01/27 15:03:34 Function returned an invalid response (must include one of: body, headers or statusCode in the response object): %!s(<nil>)
```

And following log shows two consecutive executions of curl,

```
[15:03:30]mozamimy@P861:aws-sam-test (master) (-'x'-).oO(
(cmd)> curl -XGET -d 'cute bunny' http://127.0.0.1:3000/
hello, cute bunny![15:03:30]mozamimy@P861:aws-sam-test (master) (-'x'-).oO(
(cmd)> curl -XGET -d 'cute bunny' http://127.0.0.1:3000/
{ "message": "Internal server error" }[15:03:34]mozamimy@P861:aws-sam-test (master) (-'x'-).oO(
```

I confirmed the problem with macOS 10.12.6 and Docker 17.12.0-ce-mac49.

# How to fix the problem in this patch

This problem is caused by a relative file path `../../` of `CodeUri` in a template `deploy/template/staging.yml`. I want to manage SAM templates and buildspecs like following example.

```
📃index.js
📂deploy
┣📂template
┃┣📃staging.yml
┃┗📃production.yml
┗📂buildspec
　┣📃staging.yml
　┗📃production.yml
```

So this patch let `Runtime` struct to store directory path of specified template with `TemplateDir` property and use it on initializing `codeuri` variable.
