### PR TITLE
Update README.md; add warning for Yarn users

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ Verify that docker is working, and that you can run docker commands from the CLI
 
 ### Windows, Linux, macOS with NPM [Recommended]
 
-The easiest way to install **`sam`** is to use [NPM](https://www.npmjs.com).
+The easiest way to install **`sam`** is to use [npm](https://www.npmjs.com).
 
 ```bash
 npm install -g aws-sam-local
 ```
+
+Note to Yarn users: running `yarn global add aws-sam-local` will not work. You must use npm.
 
 Verify the installation worked:
 ```bash


### PR DESCRIPTION
*Issue #, if available:*

Related to #349, but not a complete solution.

*Description of changes:*

You cannot use `yarn global` to install `aws-sam-local`, which could be a little unintuitive for some Yarn users. This adds a warning so they don't get stuck.

Also fixes the styling of "npm", which should always be lowercase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
