### PR TITLE
Fix typo in github repo name under sam init --help

### DIFF
--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -46,9 +46,9 @@ def cli(ctx, location, runtime, output_dir, name, no_input):
         Initializes a new SAM project using custom template in a Git/Mercurial repository
         \b
         # gh being expanded to github url
-        $ sam init --location gh:aws-samples/cookiecutter-sam-python
+        $ sam init --location gh:aws-samples/cookiecutter-aws-sam-python
         \b
-        $ sam init --location git+ssh://git@github.com/aws-samples/cookiecutter-sam-python.git
+        $ sam init --location git+ssh://git@github.com/aws-samples/cookiecutter-aws-sam-python.git
         \b
         $ sam init --location hg+ssh://hg@bitbucket.org/repo/template-name
         \b


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Quick fix for a typo in github name when displaying ``sam init --help`` for an advanced custom template

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
