### PR TITLE
Adding X-Amzn-Trace-Id in APIGW headers.

### DIFF
--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -3,7 +3,6 @@ import io
 import json
 import logging
 import base64
-import uuid
 
 from flask import Flask, request, Response
 
@@ -352,7 +351,7 @@ class Service(object):
         event_headers = dict(flask_request.headers)
         event_headers["X-Forwarded-Proto"] = flask_request.scheme
         event_headers["X-Forwarded-Port"] = str(port)
-        event_headers["X-Amzn-Trace-Id"] = uuid.uuid4()
+        event_headers["X-Amzn-Trace-Id"] = 'Root=1-00000000-000000000000000000000000'
 
         event = ApiGatewayLambdaEvent(http_method=method,
                                       body=request_data,

--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import base64
+import uuid
 
 from flask import Flask, request, Response
 
@@ -351,6 +352,7 @@ class Service(object):
         event_headers = dict(flask_request.headers)
         event_headers["X-Forwarded-Proto"] = flask_request.scheme
         event_headers["X-Forwarded-Port"] = str(port)
+        event_headers["X-Amzn-Trace-Id"] = uuid.uuid4()
 
         event = ApiGatewayLambdaEvent(http_method=method,
                                       body=request_data,

--- a/tests/unit/local/apigw/test_service.py
+++ b/tests/unit/local/apigw/test_service.py
@@ -458,7 +458,8 @@ class TestService_construct_event(TestCase):
                    '"cognitoAuthenticationProvider": null, "cognitoIdentityPoolId": null, "userAgent": ' \
                    '"Custom User Agent String", "caller": null, "cognitoAuthenticationType": null, "sourceIp": ' \
                    '"190.0.0.0", "user": null}, "accountId": "123456789012"}, "headers": {"Content-Type": ' \
-                   '"application/json", "X-Test": "Value", "X-Forwarded-Port": "3000", "X-Forwarded-Proto": "http"}, ' \
+                   '"application/json", "X-Test": "Value", "X-Forwarded-Port": "3000", "X-Forwarded-Proto": "http", ' \
+                   '"X-Amzn-Trace-Id": "Root=1-00000000-000000000000000000000000"}, ' \
                    '"stageVariables": null, "path": "path", "pathParameters": {"path": "params"}, ' \
                    '"isBase64Encoded": false}'
 


### PR DESCRIPTION
*Description of changes:*
Adding `X-Amzn-Trace-Id` in the API Gateway headers. Often required in the logging strategy.
Not very useful per say, but having it in the headers avoid some nasty code workaround.