### PR TITLE
Allow for case insensitve header names

### DIFF
--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -15,14 +15,15 @@ LOG = logging.getLogger(__name__)
 
 
 class CaseInsensitiveDict(dict):
-    def __setitem__(self, key, value):
-        super(CaseInsensitiveDict, self).__setitem__(key.title(), value)
 
     def __getitem__(self, key):
-        return super(CaseInsensitiveDict, self).__getitem__(key.title())
+        try:
+            return [v for k, v in self.items() if k.lower() == key.lower()][0]
+        except IndexError:
+            raise KeyError
 
     def __contains__(self, key):
-        return key.title() in [k.title() for k in self.keys()]
+        return key.lower() in [k.lower() for k in self.keys()]
 
 
 class Route(object):

--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -14,6 +14,17 @@ from .path_converter import PathConverter
 LOG = logging.getLogger(__name__)
 
 
+class CaseInsensitiveDict(dict):
+    def __setitem__(self, key, value):
+        super(CaseInsensitiveDict, self).__setitem__(key.title(), value)
+
+    def __getitem__(self, key):
+        return super(CaseInsensitiveDict, self).__getitem__(key.title())
+
+    def __contains__(self, key):
+        return key.title() in [k.title() for k in self.keys()]
+
+
 class Route(object):
 
     def __init__(self, methods, function_name, path, binary_types=None):
@@ -270,7 +281,7 @@ class Service(object):
             raise TypeError("Lambda returned %{s} instead of dict", type(json_output))
 
         status_code = json_output.get("statusCode") or 200
-        headers = json_output.get("headers") or {}
+        headers = CaseInsensitiveDict(json_output.get("headers") or {})
         body = json_output.get("body") or "no data"
         is_base_64_encoded = json_output.get("isBase64Encoded") or False
 

--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -15,12 +15,17 @@ LOG = logging.getLogger(__name__)
 
 
 class CaseInsensitiveDict(dict):
+    """
+    Implement a simple case insensitive dictionary for storing headers. To preserve the original
+    case of the given Header (e.g. X-FooBar-Fizz) this only touches the get and contains magic
+    methods rather than implementing a __setitem__ where we normalize the case of the headers.
+    """
 
     def __getitem__(self, key):
-        try:
-            return [v for k, v in self.items() if k.lower() == key.lower()][0]
-        except IndexError:
-            raise KeyError
+        matches = [v for k, v in self.items() if k.lower() == key.lower()]
+        if not matches:
+            raise KeyError(key)
+        return matches[0]
 
     def __contains__(self, key):
         return key.lower() in [k.lower() for k in self.keys()]

--- a/tests/functional/function_code.py
+++ b/tests/functional/function_code.py
@@ -63,6 +63,15 @@ exports.handler = function(event, context, callback){
 }
 """
 
+API_GATEWAY_CONTENT_TYPE_LOWER = """
+exports.handler = function(event, context, callback){
+    body = JSON.stringify("hello")
+
+    response = {"statusCode":200,"headers":{"content-type":"text/plain"},"body":body,"isBase64Encoded":false}
+    context.done(null, response);
+}
+"""
+
 API_GATEWAY_ECHO_BASE64_EVENT = """
 exports.base54request = function(event, context, callback){
 

--- a/tests/functional/local/apigw/test_service.py
+++ b/tests/functional/local/apigw/test_service.py
@@ -9,7 +9,7 @@ import requests
 import random
 from mock import Mock
 
-from samcli.local.apigw.service import Route, Service, CaseInsensitiveDict
+from samcli.local.apigw.service import Route, Service
 from tests.functional.function_code import nodejs_lambda, API_GATEWAY_ECHO_EVENT, API_GATEWAY_BAD_PROXY_RESPONSE, API_GATEWAY_ECHO_BASE64_EVENT, API_GATEWAY_CONTENT_TYPE_LOWER
 from samcli.commands.local.lib import provider
 from samcli.local.lambdafn.runtime import LambdaRuntime
@@ -500,33 +500,6 @@ class TestService_PostingBinary(TestCase):
         self.assertEquals(actual, expected)
         self.assertEquals(response.status_code, 502)
         self.assertEquals(response.headers.get('Content-Type'), "application/json")
-
-
-class TestService_CaseInsensiveDict(TestCase):
-    def test_contains(self):
-        data = CaseInsensitiveDict({
-            'Content-Type': 'text/html',
-            'Browser': 'APIGW',
-        })
-
-        self.assertTrue('content-type' in data)
-        self.assertTrue('Content-Type' in data)
-        self.assertTrue('CONTENT-TYPE' in data)
-        self.assertTrue('Browser' in data)
-        self.assertTrue('Dog-Food' not in data)
-
-    def test_getitem(self):
-        data = CaseInsensitiveDict({
-            'Content-Type': 'text/html'
-        })
-        data['Browser'] = 'APIGW'
-
-        self.assertTrue(data['content-type'])
-        self.assertTrue(data['Content-Type'])
-        self.assertTrue(data['CONTENT-TYPE'])
-        self.assertTrue(data['browser'])
-        with self.assertRaises(KeyError):
-            data['does-not-exist']
 
 
 def make_service(list_of_routes, function_provider, cwd):

--- a/tests/functional/local/apigw/test_service.py
+++ b/tests/functional/local/apigw/test_service.py
@@ -9,7 +9,7 @@ import requests
 import random
 from mock import Mock
 
-from samcli.local.apigw.service import Route, Service
+from samcli.local.apigw.service import Route, Service, CaseInsensitiveDict
 from tests.functional.function_code import nodejs_lambda, API_GATEWAY_ECHO_EVENT, API_GATEWAY_BAD_PROXY_RESPONSE, API_GATEWAY_ECHO_BASE64_EVENT, API_GATEWAY_CONTENT_TYPE_LOWER
 from samcli.commands.local.lib import provider
 from samcli.local.lambdafn.runtime import LambdaRuntime
@@ -500,6 +500,33 @@ class TestService_PostingBinary(TestCase):
         self.assertEquals(actual, expected)
         self.assertEquals(response.status_code, 502)
         self.assertEquals(response.headers.get('Content-Type'), "application/json")
+
+
+class TestService_CaseInsensiveDict(TestCase):
+    def test_contains(self):
+        data = CaseInsensitiveDict({
+            'Content-Type': 'text/html',
+            'Browser': 'APIGW',
+        })
+
+        self.assertTrue('content-type' in data)
+        self.assertTrue('Content-Type' in data)
+        self.assertTrue('CONTENT-TYPE' in data)
+        self.assertTrue('Browser' in data)
+        self.assertTrue('Dog-Food' not in data)
+
+    def test_getitem(self):
+        data = CaseInsensitiveDict({
+            'Content-Type': 'text/html'
+        })
+        data['Browser'] = 'APIGW'
+
+        self.assertTrue(data['content-type'])
+        self.assertTrue(data['Content-Type'])
+        self.assertTrue(data['CONTENT-TYPE'])
+        self.assertTrue(data['browser'])
+        with self.assertRaises(KeyError):
+            data['does-not-exist']
 
 
 def make_service(list_of_routes, function_provider, cwd):

--- a/tests/unit/local/apigw/test_service.py
+++ b/tests/unit/local/apigw/test_service.py
@@ -5,7 +5,7 @@ import base64
 
 from parameterized import parameterized, param
 
-from samcli.local.apigw.service import Service, Route
+from samcli.local.apigw.service import Service, Route, CaseInsensitiveDict
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 
 
@@ -525,3 +525,36 @@ class TestService_should_base64_encode(TestCase):
     ])
     def test_should_base64_encode_returns_false(self, test_case_name, binary_types, mimetype):
         self.assertFalse(Service._should_base64_encode(binary_types, mimetype))
+
+
+class TestService_CaseInsensiveDict(TestCase):
+
+    def setUp(self):
+        self.data = CaseInsensitiveDict({
+            'Content-Type': 'text/html',
+            'Browser': 'APIGW',
+        })
+
+    def test_contains_lower(self):
+        self.assertTrue('content-type' in self.data)
+
+    def test_contains_title(self):
+        self.assertTrue('Content-Type' in self.data)
+
+    def test_contains_upper(self):
+        self.assertTrue('CONTENT-TYPE' in self.data)
+
+    def test_contains_browser_key(self):
+        self.assertTrue('Browser' in self.data)
+
+    def test_contains_not_in(self):
+        self.assertTrue('Dog-Food' not in self.data)
+
+    def test_setitem_found(self):
+        self.data['Browser'] = 'APIGW'
+
+        self.assertTrue(self.data['browser'])
+
+    def test_keyerror(self):
+        with self.assertRaises(KeyError):
+            self.data['does-not-exist']


### PR DESCRIPTION
In testing with a local served files, I noted that Content-Type headers were being compared in a case-sensitive way.  Which means that for an express application which is serving headers up in lowercase, sam local was adding a second 'Content-Type: application/json header.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
