### PR TITLE
fix: Value of QueryString in the API event should only be a string

### DIFF
--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -352,11 +352,16 @@ class Service(object):
         event_headers["X-Forwarded-Proto"] = flask_request.scheme
         event_headers["X-Forwarded-Port"] = str(port)
 
+        # APIGW does not support duplicate query parameters. Flask gives query params as a list so
+        # we need to convert only grab the first item unless many were given, were we grab the last to be consistent
+        # with APIGW
+        query_string_dict = Service._query_string_params(flask_request)
+
         event = ApiGatewayLambdaEvent(http_method=method,
                                       body=request_data,
                                       resource=endpoint,
                                       request_context=context,
-                                      query_string_params=flask_request.args,
+                                      query_string_params=query_string_dict,
                                       headers=event_headers,
                                       path_parameters=flask_request.view_args,
                                       path=flask_request.path,
@@ -365,6 +370,37 @@ class Service(object):
         event_str = json.dumps(event.to_dict())
         LOG.debug("Constructed String representation of Event to invoke Lambda. Event: %s", event_str)
         return event_str
+
+    @staticmethod
+    def _query_string_params(flask_request):
+        """
+        Constructs an APIGW equivalent query string dictionary
+
+        Parameters
+        ----------
+        flask_request request
+            Request from Flask
+
+        Returns dict (str: str)
+        -------
+            Empty dict if no query params where in the request otherwise returns a dictionary of key to value
+
+        """
+        query_string_dict = {}
+
+        # Flask returns an ImmutableMultiDict so convert to a dictionary that becomes
+        # a dict(str: list) then iterate over
+        for query_string_key, query_string_list in dict(flask_request.args).items():
+            query_string_value_length = len(query_string_list)
+
+            # if the list is empty, default to empty string
+            if not query_string_value_length:
+                query_string_dict[query_string_key] = ""
+            else:
+                # APIGW doesn't handle duplicate query string keys, picking the last one in the list
+                query_string_dict[query_string_key] = query_string_list[-1]
+
+        return query_string_dict
 
     @staticmethod
     def _should_base64_encode(binary_types, request_mimetype):

--- a/tests/functional/local/apigw/test_service.py
+++ b/tests/functional/local/apigw/test_service.py
@@ -220,7 +220,7 @@ class TestService_EventSerialization(TestCase):
                                          resolvedResourcePath=path,
                                          pathParameters={"event": "event1"},
                                          body=json.dumps(body),
-                                         queryParams={"key": ["value"]},
+                                         queryParams={"key": "value"},
                                          headers={"X-Test": "TestValue", "Content-Length": "16",
                                                   "Content-Type": "application/json"})
 

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -380,7 +380,20 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         response_data = response.json()
 
-        self.assertEquals(response_data.get("queryStringParameters"), {"key": ["value"]})
+        self.assertEquals(response_data.get("queryStringParameters"), {"key": "value"})
+
+    def test_request_with_list_of_query_params(self):
+        """
+        Query params given should be put into the Event to Lambda
+        """
+        response = requests.get(self.url + "/id/4",
+                                params={"key": ["value", "value2"]})
+
+        self.assertEquals(response.status_code, 200)
+
+        response_data = response.json()
+
+        self.assertEquals(response_data.get("queryStringParameters"), {"key": "value2"})
 
     def test_request_with_path_params(self):
         """

--- a/tests/unit/local/apigw/test_service.py
+++ b/tests/unit/local/apigw/test_service.py
@@ -444,7 +444,7 @@ class TestService_construct_event(TestCase):
         self.request_mock.method = "GET"
         self.request_mock.remote_addr = "190.0.0.0"
         self.request_mock.data = b"DATA!!!!"
-        self.request_mock.args = {"query": "params"}
+        self.request_mock.args = {"query": ["params"]}
         self.request_mock.headers = {"Content-Type": "application/json", "X-Test": "Value"}
         self.request_mock.view_args = {"path": "params"}
         self.request_mock.scheme = "http"
@@ -488,6 +488,27 @@ class TestService_construct_event(TestCase):
 
         actual_event_str = Service._construct_event(self.request_mock, 3000, binary_types=[])
         self.assertEquals(json.loads(actual_event_str), self.expected_dict)
+
+    def test_query_string_params_with_empty_params(self):
+        request_mock = Mock()
+        request_mock.args = {}
+
+        actual_query_string = Service._query_string_params(request_mock)
+        self.assertEquals(actual_query_string, {})
+
+    def test_query_string_params_with_param_value_being_empty_list(self):
+        request_mock = Mock()
+        request_mock.args = {"param": []}
+
+        actual_query_string = Service._query_string_params(request_mock)
+        self.assertEquals(actual_query_string, {"param": ""})
+
+    def test_query_string_params_with_param_value_being_non_empty_list(self):
+        request_mock = Mock()
+        request_mock.args = {"param": ["a", "b"]}
+
+        actual_query_string = Service._query_string_params(request_mock)
+        self.assertEquals(actual_query_string, {"param": "b"})
 
 
 class TestService_service_response(TestCase):


### PR DESCRIPTION
Fixes the bug reported in #404

*Issue #, if available:* #404

*Description of changes:*

APIGW only supports one value for a query string key. 0.3.0 assumed this was a list. This PR aligns the Event that is sent to Lambda on a request with how APIGW handles Query Strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
