### PR TITLE
Fixed broken link in manual installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ First, install Python(2.7) on your machine, then run the following:
 .. code:: bash
 
    # Clone the repository
-   $ git clone git@github.com:awslabs/aws-sam-cli.git
+   $ git clone git@github.com/awslabs/aws-sam-cli.git
 
    # cd into the git
    $ cd aws-sam-cli


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When attempting to manually install I noticed that the link for cloning the repo was incorrect, just a quick fix for it for future users.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
