### PR TITLE
fix issue with content-type being overwritten

### DIFF
--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -298,8 +298,11 @@ class Service(object):
 
         # If the customer doesn't define Content-Type default to application/json
         if "Content-Type" not in headers:
-            LOG.info("No Content-Type given. Defaulting to 'application/json'.")
-            headers["Content-Type"] = "application/json"
+            if "content-type" in headers:
+                headers["Content-Type"] = headers["content-type"]
+            else:
+                LOG.info("No Content-Type given. Defaulting to 'application/json'.")
+                headers["Content-Type"] = "application/json"
 
         if Service._should_base64_decode_body(binary_types, flask_request, headers, is_base_64_encoded):
             body = base64.b64decode(body)


### PR DESCRIPTION
I was running into issues where an express server, imported using https://github.com/awslabs/aws-serverless-express/tree/master/example and using custom middleware was returning header names in lowercase. This is valid according to the spec: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2 and so aws-sam-cli should not force servers to use a capitalized header name (i.e. `content-type` is as good as `Content-Type` .

The issues were that a `content-type` of `text/html` was being returned, but aws-sam-cli would replace it with `application/json`.

*Description of changes:*
sometimes servers return headers keys in lowercase. This looks for those and uppercases the Content-Type header appropriately

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
