### PR TITLE
Add explicit note on lack of python3 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,9 @@ Installation
 Prerequisites
 ~~~~~~~~~~~~~
 
+- Docker
+- Python2.7 (Python3+ not yet supported)
+
 Running Serverless projects and functions locally with SAM CLI requires
 Docker to be installed and running. SAM CLI will use the ``DOCKER_HOST``
 environment variable to contact the docker daemon.


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Upfront emphasis in README on the pre-reqs and the lack of Python3 support.

Considering the number of duplicate GitHub issues and hits on stackoverflow involving improper installation (i.e. using the wrong python/pip), it would be nice to advertise the lack of python3 support upfront.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
