### PR TITLE
Fix examples link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -869,15 +869,14 @@ A special thank you
 
 SAM CLI uses the open source
 `docker-lambda <https://github.com/lambci/docker-lambda>`__ Docker
-images created by [@mhart](https://github.com/mhart).
+images created by `@mhart <https://github.com/mhart>`__.
 
 Examples
 --------
 
-You can find sample functions code and a SAM template used in this
-README under the
-`samples <https://github.com/awslabs/aws-sam-local/tree/master/samples>`__
-folder within this repo.
+You can find sample code and SAM templates in this
+`examples <https://github.com/awslabs/serverless-application-model/tree/master/examples>`__
+folder within the `serverless-application-model <https://github.com/awslabs/serverless-application-model>`__ repository.
 
 .. raw:: html
 
@@ -885,7 +884,6 @@ folder within this repo.
 
 .. |Build Status| image:: https://travis-ci.org/awslabs/aws-sam-local.svg?branch=develop
 .. |Apache-2.0| image:: https://img.shields.io/npm/l/aws-sam-local.svg?maxAge=2592000
-.. |Contributers| image:: https://img.shields.io/github/contributors/awslabs/aws-sam-local.svg?maxAge=2592000
+.. |Contributors| image:: https://img.shields.io/github/contributors/awslabs/aws-sam-local.svg?maxAge=2592000
 .. |GitHub-release| image:: https://img.shields.io/github/release/awslabs/aws-sam-local.svg?maxAge=2592000
 .. |PyPI version| image:: https://badge.fury.io/py/aws-sam-cli.svg
-

--- a/README.rst
+++ b/README.rst
@@ -57,10 +57,10 @@ Lambda Runtime.
    -  `Advanced <#advanced>`__
 
       -  `Compiled Languages <#compiled-languages>`__
-         
+
          -  `Java <#compiled-languages-java>`__
          -  `.NET Core <#compiled-languages-dotnetcore>`__
-      
+
       -  `IAM Credentials <#iam-credentials>`__
       -  `Lambda Environment
          Variables <#lambda-environment-variables>`__
@@ -874,7 +874,7 @@ images created by `@mhart <https://github.com/mhart>`__.
 Examples
 --------
 
-You can find sample code and SAM templates in this
+You can find sample code and SAM templates in the
 `examples <https://github.com/awslabs/serverless-application-model/tree/master/examples>`__
 folder within the `serverless-application-model <https://github.com/awslabs/serverless-application-model>`__ repository.
 


### PR DESCRIPTION
*Issue #, if available:* #430 

*Description of changes:* As per [this comment](https://github.com/awslabs/aws-sam-cli/pull/383#issuecomment-387538494) on the PR #383 that triggered this issue, the right place for samples is under `examples` directory of [serverless-application-model](https://github.com/awslabs/serverless-application-model). Updated README file to reflect this and while at it fixed a typo and a link to a username.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
