### PR TITLE
Remove broken examples link from Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -871,14 +871,6 @@ SAM CLI uses the open source
 `docker-lambda <https://github.com/lambci/docker-lambda>`__ Docker
 images created by [@mhart](https://github.com/mhart).
 
-Examples
---------
-
-You can find sample functions code and a SAM template used in this
-README under the
-`samples <https://github.com/awslabs/aws-sam-local/tree/master/samples>`__
-folder within this repo.
-
 .. raw:: html
 
    <!-- Links -->


### PR DESCRIPTION
Closes #430 

The examples were removed in #383, so this will remove the broken link in the Readme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
