### PR TITLE
Fix download a swagger file from given S3 location

### DIFF
--- a/samcli/commands/local/lib/swagger/reader.py
+++ b/samcli/commands/local/lib/swagger/reader.py
@@ -213,7 +213,7 @@ class SamSwaggerReader(object):
 
         with tempfile.TemporaryFile() as fp:
             try:
-                s3.download_file(
+                s3.download_fileobj(
                     bucket, key, fp,
                     ExtraArgs=extra_args)
 

--- a/tests/unit/commands/local/lib/swagger/test_reader.py
+++ b/tests/unit/commands/local/lib/swagger/test_reader.py
@@ -260,7 +260,7 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         self.assertEquals(actual, expected)
 
         s3_mock.download_fileobj.assert_called_with(self.bucket, self.key, fp_mock,
-                                                 ExtraArgs={"VersionId": self.version})
+                                                    ExtraArgs={"VersionId": self.version})
 
         fp_mock.seek.assert_called_with(0)  # make sure we seek the file before reading
         fp_mock.read.assert_called_with()
@@ -286,7 +286,7 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         self.assertEquals(actual, expected)
 
         s3_mock.download_fileobj.assert_called_with(self.bucket, self.key, fp_mock,
-                                                 ExtraArgs={})
+                                                    ExtraArgs={})
 
     @patch('samcli.commands.local.lib.swagger.reader.boto3')
     @patch('samcli.commands.local.lib.swagger.reader.tempfile')
@@ -298,7 +298,7 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         fp_mock = Mock()
         tempfilemock.TemporaryFile.return_value.__enter__.return_value = fp_mock  # mocking context manager
         s3_mock.download_fileobj.side_effect = botocore.exceptions.ClientError({"Error": {}},
-                                                                            "download_file")
+                                                                               "download_file")
 
         with self.assertRaises(botocore.exceptions.ClientError):
             SamSwaggerReader._download_from_s3(self.bucket, self.key)

--- a/tests/unit/commands/local/lib/swagger/test_reader.py
+++ b/tests/unit/commands/local/lib/swagger/test_reader.py
@@ -269,7 +269,7 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         with self.assertRaises(Exception) as cm:
             SamSwaggerReader._download_from_s3(self.bucket, self.key)
         self.assertEqual(cm.exception.__class__,
-                             botocore.exceptions.ClientError or botocore.exceptions.NoCredentialsError)
+                         botocore.exceptions.ClientError or botocore.exceptions.NoCredentialsError)
 
     @patch('samcli.commands.local.lib.swagger.reader.boto3')
     @patch('samcli.commands.local.lib.swagger.reader.tempfile')

--- a/tests/unit/commands/local/lib/swagger/test_reader.py
+++ b/tests/unit/commands/local/lib/swagger/test_reader.py
@@ -266,7 +266,8 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         fp_mock.read.assert_called_with()
 
     def test_must_fail_on_download_from_s3(self):
-        with self.assertRaises(botocore.exceptions.ClientError):
+        with self.assertRaises(botocore.exceptions.ClientError) or self.assertRaises(
+                botocore.exceptions.NoCredentialsError):
             SamSwaggerReader._download_from_s3(self.bucket, self.key)
 
     @patch('samcli.commands.local.lib.swagger.reader.boto3')

--- a/tests/unit/commands/local/lib/swagger/test_reader.py
+++ b/tests/unit/commands/local/lib/swagger/test_reader.py
@@ -268,8 +268,8 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
     def test_must_fail_on_download_from_s3(self):
         with self.assertRaises(Exception) as cm:
             SamSwaggerReader._download_from_s3(self.bucket, self.key)
-        self.assertEqual(cm.exception.__class__,
-                         botocore.exceptions.ClientError or botocore.exceptions.NoCredentialsError)
+        self.assertIn(cm.exception.__class__,
+                      (botocore.exceptions.NoCredentialsError, botocore.exceptions.ClientError))
 
     @patch('samcli.commands.local.lib.swagger.reader.boto3')
     @patch('samcli.commands.local.lib.swagger.reader.tempfile')

--- a/tests/unit/commands/local/lib/swagger/test_reader.py
+++ b/tests/unit/commands/local/lib/swagger/test_reader.py
@@ -266,9 +266,10 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         fp_mock.read.assert_called_with()
 
     def test_must_fail_on_download_from_s3(self):
-        with self.assertRaises(botocore.exceptions.ClientError) or self.assertRaises(
-                botocore.exceptions.NoCredentialsError):
+        with self.assertRaises(Exception) as cm:
             SamSwaggerReader._download_from_s3(self.bucket, self.key)
+        self.assertEqual(cm.exception.__class__,
+                             botocore.exceptions.ClientError or botocore.exceptions.NoCredentialsError)
 
     @patch('samcli.commands.local.lib.swagger.reader.boto3')
     @patch('samcli.commands.local.lib.swagger.reader.tempfile')

--- a/tests/unit/commands/local/lib/swagger/test_reader.py
+++ b/tests/unit/commands/local/lib/swagger/test_reader.py
@@ -259,11 +259,15 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         actual = SamSwaggerReader._download_from_s3(self.bucket, self.key, self.version)
         self.assertEquals(actual, expected)
 
-        s3_mock.download_file.assert_called_with(self.bucket, self.key, fp_mock,
+        s3_mock.download_fileobj.assert_called_with(self.bucket, self.key, fp_mock,
                                                  ExtraArgs={"VersionId": self.version})
 
         fp_mock.seek.assert_called_with(0)  # make sure we seek the file before reading
         fp_mock.read.assert_called_with()
+
+    def test_must_fail_on_download_from_s3(self):
+        with self.assertRaises(botocore.exceptions.ClientError):
+            SamSwaggerReader._download_from_s3(self.bucket, self.key)
 
     @patch('samcli.commands.local.lib.swagger.reader.boto3')
     @patch('samcli.commands.local.lib.swagger.reader.tempfile')
@@ -281,7 +285,7 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
         actual = SamSwaggerReader._download_from_s3(self.bucket, self.key)
         self.assertEquals(actual, expected)
 
-        s3_mock.download_file.assert_called_with(self.bucket, self.key, fp_mock,
+        s3_mock.download_fileobj.assert_called_with(self.bucket, self.key, fp_mock,
                                                  ExtraArgs={})
 
     @patch('samcli.commands.local.lib.swagger.reader.boto3')
@@ -293,7 +297,7 @@ class TestSamSwaggerReaderDownloadFromS3(TestCase):
 
         fp_mock = Mock()
         tempfilemock.TemporaryFile.return_value.__enter__.return_value = fp_mock  # mocking context manager
-        s3_mock.download_file.side_effect = botocore.exceptions.ClientError({"Error": {}},
+        s3_mock.download_fileobj.side_effect = botocore.exceptions.ClientError({"Error": {}},
                                                                             "download_file")
 
         with self.assertRaises(botocore.exceptions.ClientError):


### PR DESCRIPTION
Signed-off-by: Marcel Casado <mcasado@tendrilinc.com>

*Issue #, if available:*
https://github.com/awslabs/aws-sam-cli/issues/438

*Description of changes:*
Uploading swagger files from s3 is broken since we use boto3 method that expected a string and not a file object. Changed to use the right boto3 method that takes the file object. Modified test and added unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
