### PR TITLE
fix: Do not add DefinitionUri when DefinitionBody Property is given

### DIFF
--- a/samcli/commands/validate/lib/sam_template_validator.py
+++ b/samcli/commands/validate/lib/sam_template_validator.py
@@ -81,8 +81,8 @@ class SamTemplateValidator(object):
                 SamTemplateValidator._update_to_s3_uri("CodeUri", resource_dict)
 
             if resource_type == "AWS::Serverless::Api":
-
-                SamTemplateValidator._update_to_s3_uri("DefinitionUri", resource_dict)
+                if "DefinitionBody" not in resource_dict:
+                    SamTemplateValidator._update_to_s3_uri("DefinitionUri", resource_dict)
 
     @staticmethod
     def is_s3_uri(uri):

--- a/tests/functional/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/functional/commands/validate/lib/test_sam_template_validator.py
@@ -104,6 +104,28 @@ class TestValidate(TestCase):
         # Should not throw an exception
         validator.is_valid()
 
+    def test_valid_template_with_DefinitionBody_for_api(self):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "ServerlessApi": {
+                    "Type": "AWS::Serverless::Api",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {"swagger": "2.0"}
+                        }
+                    }
+                }
+            }
+
+        managed_policy_mock = Mock()
+        managed_policy_mock.load.return_value = {"PolicyName": "FakePolicy"}
+
+        validator = SamTemplateValidator(template, managed_policy_mock)
+
+        # Should not throw an exception
+        validator.is_valid()
 
     def test_valid_template_with_s3_object_passed(self):
         template = {

--- a/tests/unit/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/unit/commands/validate/lib/test_sam_template_validator.py
@@ -171,6 +171,33 @@ class TestSamTemplateValidator(TestCase):
         self.assertEquals(tempalte_resources.get("ServerlessFunction").get("Properties").get("CodeUri"),
                           "s3://bucket/value")
 
+    def test_DefinitionUri_does_not_get_added_to_template_when_DefinitionBody_given(self):
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Resources": {
+                "ServerlessApi": {
+                    "Type": "AWS::Serverless::Api",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "DefinitionBody": {
+                            "swagger": {}
+                        }
+                    }
+                }
+            }
+        }
+
+        managed_policy_mock = Mock()
+
+        validator = SamTemplateValidator(template, managed_policy_mock)
+
+        validator._replace_local_codeuri()
+
+        tempalte_resources = validator.sam_template.get("Resources")
+        self.assertNotIn("DefinitionUri", tempalte_resources.get("ServerlessApi").get("Properties"))
+        self.assertIn("DefinitionBody", tempalte_resources.get("ServerlessApi").get("Properties"))
+
     def test_replace_local_codeuri_with_no_resources(self):
 
         template = {


### PR DESCRIPTION
*Issue #, if available:*
#417 

*Description of changes:*

For the `sam validate` command, only add the DefinitionUri before running the SAM Translator to an `AWS::Serverless::Api` Resource if the DefintionBody is not given.

*Tested locally*
* ran `pytest -vv tests/functional/commands/validate/lib/test_sam_template_validator.py`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
