### PR TITLE
chore: Update Flask version to 1.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 six~=1.11.0
 click~=6.7
 enum34~=1.1.6
-Flask~=0.12.2
+Flask~=1.0.2
 boto3~=1.5
 PyYAML~=3.12
 cookiecutter~=1.6.0

--- a/tests/functional/local/apigw/test_service.py
+++ b/tests/functional/local/apigw/test_service.py
@@ -94,6 +94,7 @@ class TestService_ContentType(TestCase):
         t = threading.Thread(name='thread', target=cls.service.run, args=())
         t.setDaemon(True)
         t.start()
+        time.sleep(1)
 
     @classmethod
     def tearDownClass(cls):
@@ -148,6 +149,7 @@ class TestService_EventSerialization(TestCase):
         t = threading.Thread(name='thread', target=cls.service.run, args=())
         t.setDaemon(True)
         t.start()
+        time.sleep(1)
 
     @classmethod
     def tearDownClass(cls):
@@ -316,6 +318,7 @@ class TestService_ProxyAtBasePath(TestCase):
         t = threading.Thread(name='thread', target=cls.service.run, args=())
         t.setDaemon(True)
         t.start()
+        time.sleep(1)
 
     @classmethod
     def tearDownClass(cls):
@@ -377,6 +380,7 @@ class TestService_Binary(TestCase):
         t = threading.Thread(name='thread', target=cls.service.run, args=())
         t.setDaemon(True)
         t.start()
+        time.sleep(1)
 
     @classmethod
     def tearDownClass(cls):
@@ -451,6 +455,7 @@ class TestService_PostingBinary(TestCase):
         t = threading.Thread(name='thread', target=cls.service.run, args=())
         t.setDaemon(True)
         t.start()
+        time.sleep(1)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Functional tests for the local APIGW we intermittently failing due to
connection issues. This is due to the variable time periods the local
APIGW needs to get setup. Adding a sleep statement to the setup methods,
allows time for the setup to finish. Pervisouly, this was only in one tests
setup method.

*Issue #, if available:*
Upgrade need in order to fix #400 (this does not fix that issue, that will come in a later PR)

*Description of changes:*

See commit details above

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
