### PR TITLE
fix: Options requests not invoking Local Lambda

### DIFF
--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -95,7 +95,8 @@ class Service(object):
             self._app.add_url_rule(path,
                                    endpoint=path,
                                    view_func=self._request_handler,
-                                   methods=api_gateway_route.methods)
+                                   methods=api_gateway_route.methods,
+                                   provide_automatic_options=False)
 
         self._construct_error_handling()
 

--- a/tests/functional/local/apigw/test_service.py
+++ b/tests/functional/local/apigw/test_service.py
@@ -506,6 +506,64 @@ class TestService_PostingBinary(TestCase):
         self.assertEquals(response.status_code, 502)
         self.assertEquals(response.headers.get('Content-Type'), "application/json")
 
+class TestService_FlaskDefaultOptionsDisabled(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.code_abs_path = nodejs_lambda(API_GATEWAY_ECHO_EVENT)
+
+        # Let's convert this absolute path to relative path. Let the parent be the CWD, and codeuri be the folder
+        cls.cwd = os.path.dirname(cls.code_abs_path)
+        cls.code_uri = os.path.relpath(cls.code_abs_path, cls.cwd)  # Get relative path with respect to CWD
+
+        cls.function_name = "name"
+
+        cls.function = provider.Function(name=cls.function_name, runtime="nodejs4.3", memory=256, timeout=5,
+                                         handler="index.handler", codeuri=cls.code_uri, environment=None,
+                                         rolearn=None)
+
+        cls.base64_response_function = provider.Function(name=cls.function_name, runtime="nodejs4.3", memory=256, timeout=5,
+                                                         handler="index.handler", codeuri=cls.code_uri, environment=None,
+                                                         rolearn=None)
+
+        cls.mock_function_provider = Mock()
+        cls.mock_function_provider.get.return_value = cls.function
+
+        list_of_routes = [Route(['GET'], cls.function_name, '/something'),
+                          Route(['OPTIONS'], cls.function_name, '/something')
+                          ]
+
+        cls.service, cls.port, cls.url, cls.scheme = make_service(list_of_routes, cls.mock_function_provider, cls.cwd)
+        cls.service.create()
+        t = threading.Thread(name='thread', target=cls.service.run, args=())
+        t.setDaemon(True)
+        t.start()
+        time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.code_abs_path)
+
+    def setUp(self):
+        # Print full diff when comparing large dictionaries
+        self.maxDiff = None
+
+    def test_flask_default_options_is_disabled(self):
+        expected = make_service_response(self.port,
+                                         scheme=self.scheme,
+                                         method="OPTIONS",
+                                         resourcePath="/something",
+                                         resolvedResourcePath="/something",
+                                         pathParameters=None,
+                                         body=None,
+                                         queryParams=None,
+                                         headers={"Content-Length": "0"})
+
+        response = requests.options(self.url + '/something')
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 200)
 
 def make_service(list_of_routes, function_provider, cwd):
     port = random_port()

--- a/tests/unit/local/apigw/test_service.py
+++ b/tests/unit/local/apigw/test_service.py
@@ -147,7 +147,8 @@ class TestApiGatewayService(TestCase):
         app_mock.add_url_rule.assert_called_once_with('/',
                                                       endpoint='/',
                                                       view_func=self.service._request_handler,
-                                                      methods=['GET'])
+                                                      methods=['GET'],
+                                                      provide_automatic_options=False)
 
     def test_initalize_creates_default_values(self):
         self.assertEquals(self.service.port, 3000)


### PR DESCRIPTION
Flask will automagically add a OPTIONS to a route if OPTIONS is not provided
in the list of HTTP Verbs on a url rule. Since we add a new url rule for each
path + HTTP Verb, Flask was adding OPTIONS to every path. This causes some
paths to not execute the Local Lambda code when calling a path with an OPTIONS
verb. We turn off this behavior by turning off the feature through provide_automatic_options.

*Issue #, if available:* 
#400

*Description of changes:*
See above commit message


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
