### PR TITLE
Fix readme typo in `sam -version`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,7 @@ Install with PyEnv
     $ pip install --user aws-sam-cli
 
     # Verify your installation worked
-    $ sam –version
+    $ sam -–version
 
 Troubleshooting
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
*Description of changes:*
`sam -version` -> "Error: no such option: -v"
`sam --version` -> "SAM CLI, version 0.3.0"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.