### PR TITLE
fix: On Linux where the created temp dir has insufficient permissions

### DIFF
--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -9,6 +9,7 @@ import tempfile
 import signal
 import logging
 import threading
+import stat
 from contextlib import contextmanager
 
 from samcli.local.docker.lambda_container import LambdaContainer
@@ -187,6 +188,7 @@ def _unzip_file(filepath):
     """
 
     temp_dir = tempfile.mkdtemp()
+    os.chmod(temp_dir, 0755)
 
     LOG.info("Decompressing %s", filepath)
 


### PR DESCRIPTION
(#462)

*Issue #462 *

*Description of changes: Fix for Linux where the created temp dir has insufficient permissions. When CodeUri from the template points to an archive. After extraction Docker can't read from the direcroty - 0700, works with 0755.*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
