### PR TITLE
chore: Version bump and update setup.py to include Python3.6

### DIFF
--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ setup(
     license=read('LICENSE'),
     packages=find_packages(exclude=('tests', 'docs')),
     keywords="AWS SAM CLI",
-    # Support Python2.7 and higher, but not 3.x
-    python_requires='~=2.7',
+    # Support Python 2.7 and 3.6 or greater
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     entry_points={
         'console_scripts': [
             '{}=samcli.cli.main:cli'.format(cmd_name)
@@ -66,6 +66,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet',
         'Topic :: Software Development :: Build Tools',
         'Topic :: Utilities',


### PR DESCRIPTION
This is in preparation for a new release (0.4.0). The release will include support for Python3.6 which is the reason there are some additional changes to the setup.py


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
