### PR TITLE
Make sam validate respect --profile

### DIFF
--- a/DEVELOPMENT_GUIDE.rst
+++ b/DEVELOPMENT_GUIDE.rst
@@ -26,7 +26,7 @@ versions before sending a Pull Request. `pyenv`_ is a great tool to easily setup
 2. Activate Virtualenv
 ~~~~~~~~~~~~~~~~~~~~~~
 Virtualenv allows you to install required libraries outside of the Python installation. A good practice is to setup
-a different virtualenv for each project. `pyenv`_ comes with a handy plugin that can create virtualenv.
+a different virtualenv for each project. `pyenv`_ comes with a handy `plugin`_ that can create virtualenv.
 
 #. Create new virtualenv if it does not exist: ``pyenv virtualenv 2.7.14 samcli27`` and ``pyenv virtualenv 3.6.4 samcli36``
 #. ``pyenv activate samcli27`` for Python2.7 or ``pyenv activate samcli36`` for Python3.6
@@ -105,3 +105,4 @@ best practices that we have learnt over time.
 .. _pyenv: https://github.com/pyenv/pyenv
 .. _tox: http://tox.readthedocs.io/en/latest/
 .. _numpy docstring: https://numpydoc.readthedocs.io/en/latest/format.html
+.. _plugin: https://github.com/pyenv/pyenv-virtualenv

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -18,17 +18,20 @@ from .lib.sam_template_validator import SamTemplateValidator
 
 @click.command("validate",
                short_help="Validate an AWS SAM template.")
+@click.option("--profile",
+              help="Specify which AWS credentials profile to use.",
+              required=False)
 @template_option
 @cli_framework_options
 @pass_context
-def cli(ctx, template):
+def cli(ctx, template, profile=None):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(ctx, template)  # pragma: no cover
+    do_cli(ctx, template, profile)  # pragma: no cover
 
 
-def do_cli(ctx, template):
+def do_cli(ctx, template, profile=None):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -38,7 +38,14 @@ def do_cli(ctx, template, profile=None):
 
     sam_template = _read_sam_file(template)
 
-    iam_client = boto3.client('iam')
+    # If a profile is passed, instantiate the boto3 client from the session.
+    if profile:
+        # Throws a botocore.exceptions.ProfileNotFound for unknown profiles.
+        session = boto3.Session(profile_name=profile)
+        iam_client = session.client('iam')
+    else:
+        iam_client = boto3.client('iam')
+
     validator = SamTemplateValidator(sam_template, ManagedPolicyLoader(iam_client))
 
     try:

--- a/tests/unit/commands/validate/test_cli.py
+++ b/tests/unit/commands/validate/test_cli.py
@@ -35,13 +35,13 @@ class TestValidateCli(TestCase):
     @patch('samcli.commands.validate.validate.SamTemplateValidator')
     @patch('samcli.commands.validate.validate.click')
     @patch('samcli.commands.validate.validate._read_sam_file')
-    def test_template_fails_validation(self, read_sam_file_patch, click_patch, template_valiadator):
+    def test_template_fails_validation(self, read_sam_file_patch, click_patch, template_validator):
         template_path = 'path_to_template'
         read_sam_file_patch.return_value = {"a": "b"}
 
         is_valid_mock = Mock()
         is_valid_mock.is_valid.side_effect = InvalidSamDocumentException
-        template_valiadator.return_value = is_valid_mock
+        template_validator.return_value = is_valid_mock
 
         with self.assertRaises(InvalidSamTemplateException):
             do_cli(ctx=None,
@@ -50,13 +50,29 @@ class TestValidateCli(TestCase):
     @patch('samcli.commands.validate.validate.SamTemplateValidator')
     @patch('samcli.commands.validate.validate.click')
     @patch('samcli.commands.validate.validate._read_sam_file')
-    def test_template_passes_validation(self, read_sam_file_patch, click_patch, template_valiadator):
+    def test_template_passes_validation(self, read_sam_file_patch, click_patch, template_validator):
         template_path = 'path_to_template'
         read_sam_file_patch.return_value = {"a": "b"}
 
         is_valid_mock = Mock()
         is_valid_mock.is_valid.return_value = True
-        template_valiadator.return_value = is_valid_mock
+        template_validator.return_value = is_valid_mock
 
         do_cli(ctx=None,
                template=template_path)
+
+    @patch('samcli.commands.validate.validate.SamTemplateValidator')
+    @patch('samcli.commands.validate.validate.click')
+    @patch('samcli.commands.validate.validate._read_sam_file')
+    def test_profile_is_passed(self, read_sam_file_patch, click_patch, template_validator):
+        template_path = 'path_to_template'
+        profile = 'development'
+        read_sam_file_patch.return_value = {"a": "b"}
+
+        is_valid_mock = Mock()
+        is_valid_mock.is_valid.return_value = True
+        template_validator.return_value = is_valid_mock
+
+        do_cli(ctx=None,
+               template=template_path,
+               profile=profile)


### PR DESCRIPTION
*Issue #396*

*Description of changes:*
`sam validate` did not know about the --profile parameter. Now it does, and all is well.

I've added only the minimal required unit test code to get it to pass. Any guidance on how to ensure the profile param is actually passed into Boto would be appreciated - keep in mind this is my first foray into Python development.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
