### PR TITLE
fix setup PATH on macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,7 +215,7 @@ General Issues
 .. code:: bash
 
     # Find your path Python User Base path (where Python --user will install packages/scripts)
-    USER_BASE_PATH="$(python -m site --user-base)"
+    USER_BASE_PATH="$(python -m site --user-base)/bin"
 
     # Add this path to your $PATH
     export PATH=$USER_BASE_PATH:$PATH


### PR DESCRIPTION
*Description of changes:*

The sample of extending PATH var was missing the `/bin` part.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
