### PR TITLE
fix: Tell Flask we are running the service in main

### DIFF
--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -2,6 +2,7 @@
 import io
 import json
 import logging
+import os
 import base64
 
 from flask import Flask, request, Response
@@ -146,6 +147,11 @@ class Service(object):
         multi_threaded = not self.lambda_runner.is_debugging()
 
         LOG.debug("Local API Server starting up. Multi-threading = %s", multi_threaded)
+
+        # This environ signifies we are running a main function for Flask. This is true, since we are using it within
+        # our cli and not on a production server.
+        os.environ['WERKZEUG_RUN_MAIN'] = 'true'
+
         self._app.run(threaded=multi_threaded, host=self.host, port=self.port)
 
     def _request_handler(self, **kwargs):

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -384,6 +384,15 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEquals(response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded")
         self.assertEquals(response_data.get("body"), "key=value")
 
+    def test_request_to_an_endpoint_with_two_different_handlers(self):
+        response = requests.get(self.url + "/echoeventbody")
+
+        self.assertEquals(response.status_code, 200)
+
+        response_data = response.json()
+
+        self.assertEquals(response_data.get("handler"), 'echo_event_handler_2')
+
     def test_request_with_query_params(self):
         """
         Query params given should be put into the Event to Lambda

--- a/tests/integration/testdata/start_api/main.py
+++ b/tests/integration/testdata/start_api/main.py
@@ -13,6 +13,13 @@ def echo_event_handler(event, context):
     return {"statusCode": 200, "body": json.dumps(event)}
 
 
+def echo_event_handler_2(event, context):
+
+    event['handler'] = 'echo_event_handler_2'
+
+    return {"statusCode": 200, "body": json.dumps(event)}
+
+
 def content_type_setter_handler(event, context):
 
     return {"statusCode": 200, "body": "hello", "headers": {"Content-Type": "text/plain"}}

--- a/tests/integration/testdata/start_api/template.yaml
+++ b/tests/integration/testdata/start_api/template.yaml
@@ -59,6 +59,19 @@ Resources:
             Method: POST
             Path: /echoeventbody
 
+  EchoEventFunction2:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.echo_event_handler_2
+      Runtime: python3.6
+      CodeUri: .
+      Events:
+        EchoEventBodyPath:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /echoeventbody
+
   ContentTypeSetterFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
Flask thinks we are running in a production environment and displays
warning banners beause of it. We set an environment variable before
starting the service to tell Flask we are running within a 'main'
function.

This commit also adds a tests for having two Lambda functions defined under
a given path but have different methods associated with them.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
