### PR TITLE
Remove docs about re-using Docker container

### DIFF
--- a/docs/running_and_debugging_serverless_applications_locally.rst
+++ b/docs/running_and_debugging_serverless_applications_locally.rst
@@ -20,6 +20,8 @@ Running API Gateway Locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 start-api: Creates a local HTTP server hosting all of your Lambda functions. When accessed by using a browser or the CLI, this operation launches a Docker container locally to invoke your function. It reads the CodeUri property of the AWS::Serverless::Function resource to find the path in your file system containing the Lambda function code. This path can be the project's root directory for interpreted languages like Node.js or Python, a build directory that stores your compiled artifacts, or for Java, a .jar file.
 
+If you use an interpreted language, local changes are made available without rebuilding. This approach means you can reinvoke your Lambda function with no need to restart the CLI.
+
 invoke: Invokes a local Lambda function once and terminates after invocation completes.
 
 .. code::

--- a/docs/running_and_debugging_serverless_applications_locally.rst
+++ b/docs/running_and_debugging_serverless_applications_locally.rst
@@ -20,8 +20,6 @@ Running API Gateway Locally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 start-api: Creates a local HTTP server hosting all of your Lambda functions. When accessed by using a browser or the CLI, this operation launches a Docker container locally to invoke your function. It reads the CodeUri property of the AWS::Serverless::Function resource to find the path in your file system containing the Lambda function code. This path can be the project's root directory for interpreted languages like Node.js or Python, a build directory that stores your compiled artifacts, or for Java, a .jar file.
 
-If you use an interpreted language, local changes are made available within the same Docker container. This approach means you can reinvoke your Lambda function with no need for redeployment.
-
 invoke: Invokes a local Lambda function once and terminates after invocation completes.
 
 .. code::


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Docker container is stopped after every request when running locally however the docs indicate it will be re-used when running an interpreted language.

This PR removes the paragraph for clarity. Feel free to close if I've missed an option that makes this work!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
