### PR TITLE
fix: Allow Proxy Paths to have arbitrary names

### DIFF
--- a/samcli/local/apigw/path_converter.py
+++ b/samcli/local/apigw/path_converter.py
@@ -4,16 +4,31 @@ Converter class that handles the conversion of paths from Api Gateway to Flask a
 
 import re
 
-FLASK_PATH_PARAMS = "/<path:proxy>"
-APIGW_PATH_PARAMS_ESCAPED = r"/{proxy\+}"
-APIGW_PATH_PARAMS = "/{proxy+}"
+# The regex captures any path information before the {proxy+}. This is to support paths that have other params in
+# them. Example: /id/{id}/user/{proxy+}. Otherwise the regex will match the first { with the last +} giving incorrect
+# results.
+APIGW_PATH_PARAMS_ESCAPED = r"(.*/){(.*)\+}"
+
+# The regex replaces what was captured with APIGW_PATH_PARAMS_ESCAPED to construct the full path with the {proxy+}
+# replaces. The first group is anything before {proxy+}, while the second group is the name given to the proxy.
+# Example: /id/{id}/user/{resource+}; g<1> = '/id/{id}/user/'; g<2> = 'resource'
+FLASK_PATH_PARAMS = r"\g<1><path:\g<2>>"
+
+# The regex will replace the first group from FLASK_PATH_PARAMS_REGEX into the proxy name part of the APIGW path.
+# Example: /<path:resource>; g<1> = 'resource'; output = /{resource+}
+APIGW_PATH_PARAMS = r"/{\g<1>+}"
+
+# The regex will capture the name of the path for the APIGW Proxy path.
+# Example: /<path:resource> is equivalent to the APIGW path /{resource+}
+FLASK_PATH_PARAMS_REGEX = r"/<path:(.*)>"
+
 LEFT_BRACKET = "{"
 RIGHT_BRACKET = "}"
 LEFT_ANGLE_BRACKET = "<"
 RIGHT_ANGLE_BRACKET = ">"
 
 APIGW_TO_FLASK_REGEX = re.compile(APIGW_PATH_PARAMS_ESCAPED)
-FLASK_TO_APIGW_REGEX = re.compile(FLASK_PATH_PARAMS)
+FLASK_TO_APIGW_REGEX = re.compile(FLASK_PATH_PARAMS_REGEX)
 
 
 class PathConverter(object):

--- a/samcli/local/apigw/path_converter.py
+++ b/samcli/local/apigw/path_converter.py
@@ -5,30 +5,30 @@ Converter class that handles the conversion of paths from Api Gateway to Flask a
 import re
 
 # The regex captures any path information before the {proxy+}. This is to support paths that have other params in
-# them. Example: /id/{id}/user/{proxy+}. Otherwise the regex will match the first { with the last +} giving incorrect
-# results.
-APIGW_PATH_PARAMS_ESCAPED = r"(.*/){(.*)\+}"
+# them. Otherwise the regex will match the first { with the last +} giving incorrect results.
+# Example: /id/{id}/user/{proxy+}. g<1> = '/id/{id}/user/' g<2> = 'proxy'
+PROXY_PATH_PARAMS_ESCAPED = r"(.*/){(.*)\+}"
 
-# The regex replaces what was captured with APIGW_PATH_PARAMS_ESCAPED to construct the full path with the {proxy+}
+# The regex replaces what was captured with PROXY_PATH_PARAMS_ESCAPED to construct the full path with the {proxy+}
 # replaces. The first group is anything before {proxy+}, while the second group is the name given to the proxy.
 # Example: /id/{id}/user/{resource+}; g<1> = '/id/{id}/user/'; g<2> = 'resource'
-FLASK_PATH_PARAMS = r"\g<1><path:\g<2>>"
+FLASK_CAPTURE_ALL_PATH = r"\g<1><path:\g<2>>"
 
-# The regex will replace the first group from FLASK_PATH_PARAMS_REGEX into the proxy name part of the APIGW path.
+# The regex will replace the first group from FLASK_CAPTURE_ALL_PATH_REGEX into the proxy name part of the APIGW path.
 # Example: /<path:resource>; g<1> = 'resource'; output = /{resource+}
-APIGW_PATH_PARAMS = r"/{\g<1>+}"
+PROXY_PATH_PARAMS = r"/{\g<1>+}"
 
 # The regex will capture the name of the path for the APIGW Proxy path.
 # Example: /<path:resource> is equivalent to the APIGW path /{resource+}
-FLASK_PATH_PARAMS_REGEX = r"/<path:(.*)>"
+FLASK_CAPTURE_ALL_PATH_REGEX = r"/<path:(.*)>"
 
 LEFT_BRACKET = "{"
 RIGHT_BRACKET = "}"
 LEFT_ANGLE_BRACKET = "<"
 RIGHT_ANGLE_BRACKET = ">"
 
-APIGW_TO_FLASK_REGEX = re.compile(APIGW_PATH_PARAMS_ESCAPED)
-FLASK_TO_APIGW_REGEX = re.compile(FLASK_PATH_PARAMS_REGEX)
+APIGW_TO_FLASK_REGEX = re.compile(PROXY_PATH_PARAMS_ESCAPED)
+FLASK_TO_APIGW_REGEX = re.compile(FLASK_CAPTURE_ALL_PATH_REGEX)
 
 
 class PathConverter(object):
@@ -46,7 +46,7 @@ class PathConverter(object):
         :param str path: Path to convert to Flask defined path
         :return str: Path representing a Flask path
         """
-        proxy_sub_path = APIGW_TO_FLASK_REGEX.sub(FLASK_PATH_PARAMS, path)
+        proxy_sub_path = APIGW_TO_FLASK_REGEX.sub(FLASK_CAPTURE_ALL_PATH, path)
 
         # Replace the '{' and '}' with '<' and '>' respectively
         return proxy_sub_path.replace(LEFT_BRACKET, LEFT_ANGLE_BRACKET).replace(RIGHT_BRACKET, RIGHT_ANGLE_BRACKET)
@@ -64,7 +64,7 @@ class PathConverter(object):
         :param str path: Path to convert to Api Gateway defined path
         :return str: Path representing an Api Gateway path
         """
-        proxy_sub_path = FLASK_TO_APIGW_REGEX.sub(APIGW_PATH_PARAMS, path)
+        proxy_sub_path = FLASK_TO_APIGW_REGEX.sub(PROXY_PATH_PARAMS, path)
 
         # Replace the '<' and '>' with '{' and '}' respectively
         return proxy_sub_path.replace(LEFT_ANGLE_BRACKET, LEFT_BRACKET).replace(RIGHT_ANGLE_BRACKET, RIGHT_BRACKET)

--- a/tests/functional/local/apigw/test_service.py
+++ b/tests/functional/local/apigw/test_service.py
@@ -142,7 +142,8 @@ class TestService_EventSerialization(TestCase):
         list_of_routes = [Route(['POST', 'GET'], cls.function_name, '/something'),
                           Route(['GET'], cls.function_name, '/'),
                           Route(['GET', 'PUT'], cls.function_name, '/something/{event}'),
-                          Route(['GET'], cls.function_name, '/proxypath/{proxy+}')
+                          Route(['GET'], cls.function_name, '/proxypath/{proxy+}'),
+                          Route(['GET'], cls.function_name, '/resourceproxypath/{resource+}')
                           ]
 
         cls.service, cls.port, cls.url, cls.scheme = make_service(list_of_routes, cls.mock_function_provider, cls.cwd)
@@ -273,6 +274,26 @@ class TestService_EventSerialization(TestCase):
                                          resourcePath="/proxypath/{proxy+}",
                                          resolvedResourcePath=path,
                                          pathParameters={"proxy": "thisisproxypath/thatshouldbecaught"},
+                                         body=None,
+                                         queryParams=None,
+                                         headers=None)
+
+        response = requests.get(self.url + path)
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.headers.get('Content-Type'), "application/json")
+
+    def test_calling_proxy_path_that_has_name_resource(self):
+        path = '/resourceproxypath/resourcepath/thatshouldbecaught'
+        expected = make_service_response(self.port,
+                                         scheme=self.scheme,
+                                         method="GET",
+                                         resourcePath="/resourceproxypath/{resource+}",
+                                         resolvedResourcePath=path,
+                                         pathParameters={"resource": "resourcepath/thatshouldbecaught"},
                                          body=None,
                                          queryParams=None,
                                          headers=None)

--- a/tests/unit/local/apigw/test_path_converter.py
+++ b/tests/unit/local/apigw/test_path_converter.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from parameterized import parameterized
+
 from samcli.local.apigw.path_converter import PathConverter
 
 
@@ -19,12 +21,16 @@ class TestPathConverter_toFlask(TestCase):
 
         self.assertEquals(flask_path, "/<path:proxy>")
 
-    def test_proxy_path_with_different_name(self):
-        path = "/{resource+}"
-
+    @parameterized.expand([("/{resource+}", "/<path:resource>"),
+                           ("/a/{id}/b/{resource+}", "/a/<id>/b/<path:resource>"),
+                           ("/a/b/{proxy}/{resource+}", "/a/b/<proxy>/<path:resource>"),
+                           ("/{id}/{something+}", "/<id>/<path:something>"),
+                           ("/{a}/{b}/{c}/{d+}", "/<a>/<b>/<c>/<path:d>")
+                           ])
+    def test_proxy_path_with_different_name(self, path, expected_result):
         flask_path = PathConverter.convert_path_to_flask(path)
 
-        self.assertEquals(flask_path, "/<path:resource>")
+        self.assertEquals(flask_path, expected_result)
 
     def test_proxy_with_path_param(self):
         path = "/id/{id}/user/{proxy+}"
@@ -64,12 +70,16 @@ class TestPathConverter_toApiGateway(TestCase):
 
         self.assertEquals(flask_path, "/{proxy+}")
 
-    def test_proxy_path_with_different_name(self):
-        path = "/<path:resource>"
-
+    @parameterized.expand([("/<path:resource>", "/{resource+}"),
+                           ("/a/<id>/b/<path:resource>", "/a/{id}/b/{resource+}"),
+                           ("/a/b/<proxy>/<path:resource>", "/a/b/{proxy}/{resource+}"),
+                           ("/<id>/<path:something>", "/{id}/{something+}"),
+                           ("/<a>/<b>/<c>/<path:d>", "/{a}/{b}/{c}/{d+}")
+                           ])
+    def test_proxy_path_with_different_name(self, path, expected_result):
         flask_path = PathConverter.convert_path_to_api_gateway(path)
 
-        self.assertEquals(flask_path, "/{resource+}")
+        self.assertEquals(flask_path, expected_result)
 
     def test_proxy_with_path_param(self):
         path = "/id/<id>/user/<path:proxy>"

--- a/tests/unit/local/apigw/test_path_converter.py
+++ b/tests/unit/local/apigw/test_path_converter.py
@@ -19,6 +19,13 @@ class TestPathConverter_toFlask(TestCase):
 
         self.assertEquals(flask_path, "/<path:proxy>")
 
+    def test_proxy_path_with_different_name(self):
+        path = "/{resource+}"
+
+        flask_path = PathConverter.convert_path_to_flask(path)
+
+        self.assertEquals(flask_path, "/<path:resource>")
+
     def test_proxy_with_path_param(self):
         path = "/id/{id}/user/{proxy+}"
 
@@ -56,6 +63,13 @@ class TestPathConverter_toApiGateway(TestCase):
         flask_path = PathConverter.convert_path_to_api_gateway(path)
 
         self.assertEquals(flask_path, "/{proxy+}")
+
+    def test_proxy_path_with_different_name(self):
+        path = "/<path:resource>"
+
+        flask_path = PathConverter.convert_path_to_api_gateway(path)
+
+        self.assertEquals(flask_path, "/{resource+}")
 
     def test_proxy_with_path_param(self):
         path = "/id/<id>/user/<path:proxy>"


### PR DESCRIPTION
*Issue #, if available:*
Addressed the bug from #457 where SAM CLI only accepted proxy paths with '{proxy+}'. This PR will allow 'proxy' to be any arbitrary name.

I ran the functional tests locally in both Py2 and Py3 (all passed in both).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
