### PR TITLE
Add default index file for static directory

### DIFF
--- a/samcli/local/apigw/service.py
+++ b/samcli/local/apigw/service.py
@@ -87,6 +87,8 @@ class Service(object):
                           static_folder=self.static_dir  # Serve static files from this directory
                           )
 
+        self._app.add_url_rule('/', 'index', self.index)
+
         for api_gateway_route in self.routing_list:
             path = PathConverter.convert_path_to_flask(api_gateway_route.path)
             for route_key in self._generate_route_keys(api_gateway_route.methods,
@@ -445,3 +447,14 @@ class Service(object):
 
         """
         return request_mimetype in binary_types or "*/*" in binary_types
+
+    def index(self):
+        """
+        Default Index file
+
+        Returns
+        -------
+            index.html
+
+        """
+        return self._app.send_static_file('index.html')

--- a/tests/unit/local/apigw/test_service.py
+++ b/tests/unit/local/apigw/test_service.py
@@ -144,11 +144,13 @@ class TestApiGatewayService(TestCase):
 
         self.service.create()
 
-        app_mock.add_url_rule.assert_called_once_with('/',
-                                                      endpoint='/',
-                                                      view_func=self.service._request_handler,
-                                                      methods=['GET'],
-                                                      provide_automatic_options=False)
+        app_mock.add_url_rule.assert_any_call('/', 'index', self.service.index)
+
+        app_mock.add_url_rule.assert_any_call('/',
+                                              endpoint='/',
+                                              view_func=self.service._request_handler,
+                                              methods=['GET'],
+                                              provide_automatic_options=False)
 
     def test_initalize_creates_default_values(self):
         self.assertEquals(self.service.port, 3000)


### PR DESCRIPTION
*Issue #437 

Default page index.html for static directory.  localhost:3000 -> serves index.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
