### PR TITLE
feat(LocalLambdaService): Error handling for local lambda

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -6,30 +6,13 @@ import base64
 
 from flask import Flask, request
 
-from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser
+from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser, CaseInsensitiveDict
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.local.events.api_event import ContextIdentity, RequestContext, ApiGatewayLambdaEvent
 from .service_error_responses import ServiceErrorResponses
 from .path_converter import PathConverter
 
 LOG = logging.getLogger(__name__)
-
-
-class CaseInsensitiveDict(dict):
-    """
-    Implement a simple case insensitive dictionary for storing headers. To preserve the original
-    case of the given Header (e.g. X-FooBar-Fizz) this only touches the get and contains magic
-    methods rather than implementing a __setitem__ where we normalize the case of the headers.
-    """
-
-    def __getitem__(self, key):
-        matches = [v for k, v in self.items() if k.lower() == key.lower()]
-        if not matches:
-            raise KeyError(key)
-        return matches[0]
-
-    def __contains__(self, key):
-        return key.lower() in [k.lower() for k in self.keys()]
 
 
 class Route(object):

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -156,7 +156,7 @@ class LocalApigwService(BaseLocalService):
                       "statusCode in the response object). Response received: %s", lambda_response)
             return ServiceErrorResponses.lambda_failure_response()
 
-        return self._service_response(body, headers, status_code)
+        return self.service_response(body, headers, status_code)
 
     def _get_current_route(self, flask_request):
         """

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -158,7 +158,7 @@ class LocalApigwService(BaseLocalService):
         except FunctionNotFound:
             return ServiceErrorResponses.lambda_not_found_response()
 
-        lambda_response, lambda_logs = LambdaOutputParser.get_lambda_output(stdout_stream)
+        lambda_response, lambda_logs, _ = LambdaOutputParser.get_lambda_output(stdout_stream)
 
         if self.stderr and lambda_logs:
             # Write the logs to stderr if available.

--- a/samcli/local/lambda_service/lambda_error_responses.py
+++ b/samcli/local/lambda_service/lambda_error_responses.py
@@ -2,8 +2,6 @@
 
 import json
 
-from flask import Response
-
 from samcli.local.services.base_local_service import BaseLocalService
 
 
@@ -43,34 +41,34 @@ class LambdaErrorResponses(object):
         -------
 
         """
-        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Function not found: arn:aws:lambda:us-west-2:012345678901:function:{}".format(function_name)),
+        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Function not found: arn:aws:lambda:us-west-2:012345678901:function:{}".format(function_name)),
             {'x-amzn-errortype': LambdaErrorResponses.ResourceNotFoundException[0], 'Content-Type': 'application/json'},
             LambdaErrorResponses.ResourceNotFoundException[1])
 
     @staticmethod
     def invalid_request_content(message):
-        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.USER_ERROR, message),
+        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR, message),
             {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'},
             400
         )
 
     @staticmethod
     def unsupported_media_type(content_type):
-        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Unsupported content type: {}".format(content_type)),
+        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Unsupported content type: {}".format(content_type)),
             {'x-amzn-errortype': 'UnsupportedMediaType', 'Content-Type': 'application/json'},
             415
         )
 
     @staticmethod
     def generic_service_exception(*args):
-        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.SERVICE_ERROR, "ServiceException"),
+        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.SERVICE_ERROR, "ServiceException"),
             {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'},
             500
         )
 
     @staticmethod
     def not_implemented_locally(message):
-        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, message),
+        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, message),
             {'x-amzn-errortype': 'NotImplemented', 'Content-Type': 'application/json'},
             501
         )
@@ -78,7 +76,7 @@ class LambdaErrorResponses(object):
     @staticmethod
     def generic_path_not_found(*args):
         return BaseLocalService._service_response(
-            LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, "PathNotFoundException"),
+            LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, "PathNotFoundException"),
             {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
             404
         )
@@ -86,12 +84,12 @@ class LambdaErrorResponses(object):
     @staticmethod
     def generic_method_not_allowed(*args):
         return BaseLocalService._service_response(
-            LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR,
+            LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR,
                                                                "MethodNotAllowedException"),
             {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
             405
         )
 
     @staticmethod
-    def construct_error_response_body(error_type, error_message):
+    def _construct_error_response_body(error_type, error_message):
         return json.dumps({"Type": error_type, "Message": error_message})

--- a/samcli/local/lambda_service/lambda_error_responses.py
+++ b/samcli/local/lambda_service/lambda_error_responses.py
@@ -1,4 +1,4 @@
-""" Common Lambda Error Response"""
+"""Common Lambda Error Responses"""
 
 import json
 
@@ -28,68 +28,174 @@ class LambdaErrorResponses(object):
     CONTENT_TYPE = 'application/json'
     CONTENT_TYPE_HEADER_KEY = 'Content-Type'
 
-
     @staticmethod
     def resource_not_found(function_name):
         """
+        Creates a Lambda Service ResourceNotFound Response
 
         Parameters
         ----------
-        function_name
+        function_name str
+            Name of the function that was requested to invoke
 
         Returns
         -------
-
+        Flask.Response
+            A response object representing the ResourceNotFound Error
         """
-        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Function not found: arn:aws:lambda:us-west-2:012345678901:function:{}".format(function_name)),
+        return BaseLocalService.service_response(
+            LambdaErrorResponses._construct_error_response_body(
+                LambdaErrorResponses.USER_ERROR,
+                "Function not found: arn:aws:lambda:us-west-2:012345678901:function:{}".format(function_name)
+            ),
             {'x-amzn-errortype': LambdaErrorResponses.ResourceNotFoundException[0], 'Content-Type': 'application/json'},
             LambdaErrorResponses.ResourceNotFoundException[1])
 
     @staticmethod
     def invalid_request_content(message):
-        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR, message),
+        """
+        Creates a Lambda Service InvalidRequestContent Response
+
+        Parameters
+        ----------
+        message str
+            Message to be added to the body of the response
+
+        Returns
+        -------
+        Flask.Response
+            A response object representing the InvalidRequestContent Error
+        """
+        return BaseLocalService.service_response(
+            LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR, message),
             {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'},
             400
         )
 
     @staticmethod
     def unsupported_media_type(content_type):
-        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Unsupported content type: {}".format(content_type)),
+        """
+        Creates a Lambda Service UnsupportedMediaType Response
+
+        Parameters
+        ----------
+        content_type str
+            Content Type of the request that was made
+
+        Returns
+        -------
+        Flask.Response
+            A response object representing the UnsupportedMediaType Error
+        """
+        return BaseLocalService.service_response(
+            LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.USER_ERROR,
+                                                                "Unsupported content type: {}".format(content_type)),
             {'x-amzn-errortype': 'UnsupportedMediaType', 'Content-Type': 'application/json'},
             415
         )
 
     @staticmethod
     def generic_service_exception(*args):
-        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.SERVICE_ERROR, "ServiceException"),
+        """
+        Creates a Lambda Service Generic ServiceException Response
+
+        Parameters
+        ----------
+        args list
+            List of arguments Flask passes to the method
+
+        Returns
+        -------
+        Flask.Response
+            A response object representing the GenericServiceException Error
+        """
+        return BaseLocalService.service_response(
+            LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.SERVICE_ERROR, "ServiceException"),
             {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'},
             500
         )
 
     @staticmethod
     def not_implemented_locally(message):
-        return BaseLocalService._service_response(LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, message),
+        """
+        Creates a Lambda Service NotImplementedLocally Response
+
+        Parameters
+        ----------
+        message str
+            Message to be added to the body of the response
+
+        Returns
+        -------
+        Flask.Response
+            A response object representing the NotImplementedLocally Error
+        """
+        return BaseLocalService.service_response(
+            LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, message),
             {'x-amzn-errortype': 'NotImplemented', 'Content-Type': 'application/json'},
             501
         )
 
     @staticmethod
     def generic_path_not_found(*args):
-        return BaseLocalService._service_response(
-            LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, "PathNotFoundException"),
+        """
+        Creates a Lambda Service Generic PathNotFound Response
+
+        Parameters
+        ----------
+        args list
+            List of arguments Flask passes to the method
+
+        Returns
+        -------
+        Flask.Response
+            A response object representing the GenericPathNotFound Error
+        """
+        return BaseLocalService.service_response(
+            LambdaErrorResponses._construct_error_response_body(
+                LambdaErrorResponses.LOCAL_SERVICE_ERROR, "PathNotFoundException"),
             {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
             404
         )
 
     @staticmethod
     def generic_method_not_allowed(*args):
-        return BaseLocalService._service_response(
+        """
+        Creates a Lambda Service Generic MethodNotAllowed Response
+
+        Parameters
+        ----------
+        args list
+            List of arguments Flask passes to the method
+
+        Returns
+        -------
+        Flask.Response
+            A response object representing the GenericMethodNotAllowed Error
+        """
+        return BaseLocalService.service_response(
             LambdaErrorResponses._construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR,
-                                                               "MethodNotAllowedException"),
+                                                                "MethodNotAllowedException"),
             {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
             405
         )
 
     @staticmethod
     def _construct_error_response_body(error_type, error_message):
+        """
+        Constructs a string to be used in the body of the Response that conforms
+        to the structure of the Lambda Service Responses
+
+        Parameters
+        ----------
+        error_type str
+            The type of error
+        error_message str
+            Message of the error that occured
+
+        Returns
+        -------
+        str
+            str representing the response body
+        """
         return json.dumps({"Type": error_type, "Message": error_message})

--- a/samcli/local/lambda_service/lambda_error_responses.py
+++ b/samcli/local/lambda_service/lambda_error_responses.py
@@ -4,6 +4,8 @@ import json
 
 from flask import Response
 
+from samcli.local.services.base_local_service import BaseLocalService
+
 
 class LambdaErrorResponses(object):
 
@@ -19,6 +21,16 @@ class LambdaErrorResponses(object):
     # The request body could not be parsed as JSON.
     InvalidRequestContentException = ('InvalidRequestContent', 400)
 
+    # Error Types
+    USER_ERROR = "User"
+    SERVICE_ERROR = "Service"
+    LOCAL_SERVICE_ERROR = "LocalService"
+
+    # Header Information
+    CONTENT_TYPE = 'application/json'
+    CONTENT_TYPE_HEADER_KEY = 'Content-Type'
+
+
     @staticmethod
     def resource_not_found(function_name):
         """
@@ -31,59 +43,55 @@ class LambdaErrorResponses(object):
         -------
 
         """
-        return LambdaErrorResponses._service_response(json.dumps(
-            {"Message": "Function not found: arn:aws:lambda:us-west-2:012345678901:function:{}".format(function_name),
-             "Type": "User"}),
+        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Function not found: arn:aws:lambda:us-west-2:012345678901:function:{}".format(function_name)),
             {'x-amzn-errortype': LambdaErrorResponses.ResourceNotFoundException[0], 'Content-Type': 'application/json'},
             LambdaErrorResponses.ResourceNotFoundException[1])
 
     @staticmethod
     def invalid_request_content(message):
-        return LambdaErrorResponses._service_response(json.dumps(
-            {"Type": "User",
-             "message": message}),
+        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.USER_ERROR, message),
             {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'},
             400
         )
 
     @staticmethod
     def unsupported_media_type(content_type):
-        return LambdaErrorResponses._service_response(json.dumps(
-            {"Type": "User",
-             "message": "Unsupported content type: {}".format(content_type)}),
+        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.USER_ERROR, "Unsupported content type: {}".format(content_type)),
             {'x-amzn-errortype': 'UnsupportedMediaType', 'Content-Type': 'application/json'},
             415
         )
 
     @staticmethod
-    def generic_service_exception():
-        return LambdaErrorResponses._service_response(json.dumps(
-            {"Type": "Service",
-             "message": "ServiceException"}),
+    def generic_service_exception(*args):
+        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.SERVICE_ERROR, "ServiceException"),
             {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'},
             500
         )
 
     @staticmethod
     def not_implemented_locally(message):
-        return LambdaErrorResponses._service_response(json.dumps(
-            {"Type": "LocalService",
-             "message": message}),
+        return BaseLocalService._service_response(LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, message),
             {'x-amzn-errortype': 'NotImplemented', 'Content-Type': 'application/json'},
             501
         )
 
     @staticmethod
-    def _service_response(body, headers, status_code):
-        """
-        Constructs a Flask Response from the body, headers, and status_code.
+    def generic_path_not_found(*args):
+        return BaseLocalService._service_response(
+            LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR, "PathNotFoundException"),
+            {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
+            404
+        )
 
-        :param str body: Response body as a string
-        :param dict headers: headers for the response
-        :param int status_code: status_code for response
-        :return: Flask Response
-        """
-        response = Response(body)
-        response.headers = headers
-        response.status_code = status_code
-        return response
+    @staticmethod
+    def generic_method_not_allowed(*args):
+        return BaseLocalService._service_response(
+            LambdaErrorResponses.construct_error_response_body(LambdaErrorResponses.LOCAL_SERVICE_ERROR,
+                                                               "MethodNotAllowedException"),
+            {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
+            405
+        )
+
+    @staticmethod
+    def construct_error_response_body(error_type, error_message):
+        return json.dumps({"Type": error_type, "Message": error_message})

--- a/samcli/local/lambda_service/lambda_error_responses.py
+++ b/samcli/local/lambda_service/lambda_error_responses.py
@@ -1,0 +1,89 @@
+""" Common Lambda Error Response"""
+
+import json
+
+from flask import Response
+
+
+class LambdaErrorResponses(object):
+
+    # The content type of the Invoke request body is not JSON.
+    UnsupportedMediaTypeException = ('UnsupportedMediaType', 415)
+
+    # The AWS Lambda service encountered an internal error.
+    ServiceException = ('Service', 500)
+
+    # The resource (for example, a Lambda function or access policy statement) specified in the request does not exist.
+    ResourceNotFoundException = ('ResourceNotFound', 404)
+
+    # The request body could not be parsed as JSON.
+    InvalidRequestContentException = ('InvalidRequestContent', 400)
+
+    @staticmethod
+    def resource_not_found(function_name):
+        """
+
+        Parameters
+        ----------
+        function_name
+
+        Returns
+        -------
+
+        """
+        return LambdaErrorResponses._service_response(json.dumps(
+            {"Message": "Function not found: arn:aws:lambda:us-west-2:012345678901:function:{}".format(function_name),
+             "Type": "User"}),
+            {'x-amzn-errortype': LambdaErrorResponses.ResourceNotFoundException[0], 'Content-Type': 'application/json'},
+            LambdaErrorResponses.ResourceNotFoundException[1])
+
+    @staticmethod
+    def invalid_request_content(message):
+        return LambdaErrorResponses._service_response(json.dumps(
+            {"Type": "User",
+             "message": message}),
+            {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'},
+            400
+        )
+
+    @staticmethod
+    def unsupported_media_type(content_type):
+        return LambdaErrorResponses._service_response(json.dumps(
+            {"Type": "User",
+             "message": "Unsupported content type: {}".format(content_type)}),
+            {'x-amzn-errortype': 'UnsupportedMediaType', 'Content-Type': 'application/json'},
+            415
+        )
+
+    @staticmethod
+    def generic_service_exception():
+        return LambdaErrorResponses._service_response(json.dumps(
+            {"Type": "Service",
+             "message": "ServiceException"}),
+            {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'},
+            500
+        )
+
+    @staticmethod
+    def not_implemented_locally(message):
+        return LambdaErrorResponses._service_response(json.dumps(
+            {"Type": "LocalService",
+             "message": message}),
+            {'x-amzn-errortype': 'NotImplemented', 'Content-Type': 'application/json'},
+            501
+        )
+
+    @staticmethod
+    def _service_response(body, headers, status_code):
+        """
+        Constructs a Flask Response from the body, headers, and status_code.
+
+        :param str body: Response body as a string
+        :param dict headers: headers for the response
+        :param int status_code: status_code for response
+        :return: Flask Response
+        """
+        response = Response(body)
+        response.headers = headers
+        response.status_code = status_code
+        return response

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -58,15 +58,20 @@ class LocalLambdaInvokeService(BaseLocalService):
         """
         Validates the incoming request
 
-        Returns
-        -------
-        flask.Response
-            A Response is returned in the following cases:
+        The following are invalid
             1. The Request data is not json serializable
             2. Query Parameters are sent to the endpoint
             3. The Request Content-Type is not application/json
+            4. 'X-Amz-Log-Type' header is not 'None'
+            5. 'X-Amz-Invocation-Type' header is not 'RequestResponse'
 
-            Otherwise this function does not return anything
+        Returns
+        -------
+        flask.Response
+            If the request is not valid a flask Response is returned
+
+        None:
+            If the request passes all validation
         """
         flask_request = request
         request_data = flask_request.get_data()
@@ -127,7 +132,6 @@ class LocalLambdaInvokeService(BaseLocalService):
         Returns
         -------
         A Flask Response response object as if it was returned from Lambda
-
         """
         flask_request = request
 
@@ -154,8 +158,8 @@ class LocalLambdaInvokeService(BaseLocalService):
             self.stderr.write(lambda_logs)
 
         if is_lambda_user_error_response:
-            return self._service_response(lambda_response,
-                                          {'Content-Type': 'application/json', 'x-amz-function-error': 'Unhandled'},
-                                          200)
+            return self.service_response(lambda_response,
+                                         {'Content-Type': 'application/json', 'x-amz-function-error': 'Unhandled'},
+                                         200)
 
-        return self._service_response(lambda_response, {'Content-Type': 'application/json'}, 200)
+        return self.service_response(lambda_response, {'Content-Type': 'application/json'}, 200)

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -1,5 +1,6 @@
 """Local Lambda Service that only invokes a function"""
 
+import json
 import logging
 import io
 
@@ -8,6 +9,7 @@ from flask import Flask, request
 
 from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser
 from samcli.local.lambdafn.exceptions import FunctionNotFound
+from .lambda_error_responses import LambdaErrorResponses
 
 LOG = logging.getLogger(__name__)
 
@@ -46,14 +48,65 @@ class LocalLambdaInvokeService(BaseLocalService):
                                methods=['POST'],
                                provide_automatic_options=False)
 
+        # setup request validation before Flask calls the view_func
+        self._app.before_request = self.validate_request
+
         self._construct_error_handling()
+
+    def validate_request(self):
+        """
+        Validates the incoming request
+
+        Returns
+        -------
+        flask.Response
+            A Response is returned in the following cases:
+            1. The Request data is not json serializable
+            2. Query Parameters are sent to the endpoint
+            3. The Request Content-Type is not application/json
+
+            Otherwise this function does not return anything
+        """
+        flask_request = request
+        request_data = flask_request.get_data()
+
+        if not request_data:
+            request_data = b'{}'
+
+        request_data = request_data.decode('utf-8')
+
+        try:
+            json.loads(request_data)
+        except ValueError as json_error:
+            LOG.debug("Request body was not json.")
+            return LambdaErrorResponses.invalid_request_content(
+                "Could not parse request body into json: {}".format(str(json_error)))
+
+        if flask_request.args:
+            LOG.debug("Query parameters are in the request but not supported")
+            return LambdaErrorResponses.invalid_request_content("Query Parameters are not supported")
+
+        if flask_request.content_type.lower() != "application/json":
+            LOG.debug("%s media type is not supported. Must be application/json", flask_request.content_type)
+            return LambdaErrorResponses.unsupported_media_type(flask_request.content_type)
+
+        log_type = flask_request.headers.get('X-Amz-Log-Type', 'None')
+        if log_type != 'None':
+            LOG.info("log-type: %s is not supported. Ignoring X-Amz-Log-Type header", log_type)
+
+        invocation_type = flask_request.headers.get('X-Amz-Invocation-Type', 'RequestResponse')
+        if invocation_type != 'RequestResponse':
+            LOG.warning("invocation_type: %s is not supported. RequestResponse is only supported.", invocation_type)
+            return LambdaErrorResponses.not_implemented_locally(
+                "invocation_type: {} is not supported. RequestResponse is only supported.".format(invocation_type))
 
     def _construct_error_handling(self):
         """
         Updates the Flask app with Error Handlers for different Error Codes
 
         """
-        pass
+        self._app.register_error_handler(500, LambdaErrorResponses.generic_service_exception())
+        self._app.register_error_handler(404, LambdaErrorResponses.resource_not_found(""))
 
     def _invoke_request_handler(self, function_name):
         """
@@ -71,17 +124,29 @@ class LocalLambdaInvokeService(BaseLocalService):
 
         """
         flask_request = request
-        request_data = flask_request.get_data().decode('utf-8')
+
+        request_data = flask_request.get_data()
+
+        if not request_data:
+            request_data = b'{}'
+
+        request_data = request_data.decode('utf-8')
 
         stdout_stream = io.BytesIO()
 
         try:
             self.lambda_runner.invoke(function_name, request_data, stdout=stdout_stream, stderr=self.stderr)
         except FunctionNotFound:
-            # TODO Change this
-            raise Exception('Change this later')
+            LOG.debug('%s was not found to invoke.', function_name)
+            return LambdaErrorResponses.resource_not_found(function_name)
 
-        lambda_response, lambda_logs = LambdaOutputParser.get_lambda_output(stdout_stream)
+        lambda_response, lambda_logs, is_lambda_user_error_response = \
+            LambdaOutputParser.get_lambda_output(stdout_stream)
+
+        if is_lambda_user_error_response:
+            return self._service_response(lambda_response,
+                                          {'Content-Type': 'application/json', 'x-amz-function-error': 'Unhandled'},
+                                          200)
 
         if self.stderr and lambda_logs:
             # Write the logs to stderr if available.

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -81,7 +81,7 @@ class BaseLocalService(object):
         self._app.run(threaded=multi_threaded, host=self.host, port=self.port)
 
     @staticmethod
-    def _service_response(body, headers, status_code):
+    def service_response(body, headers, status_code):
         """
         Constructs a Flask Response from the body, headers, and status_code.
 

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -138,6 +138,8 @@ class LambdaOutputParser(object):
             # Last line is Lambda response. Make sure to strip() so we get rid of extra whitespaces & newlines around
             lambda_response = stdout_data[last_line_position:].strip()
 
+        lambda_response = lambda_response.decode('utf-8')
+
         is_lambda_user_error_response = LambdaOutputParser.is_lambda_error_response(lambda_response)
 
         return lambda_response, lambda_logs, is_lambda_user_error_response
@@ -155,6 +157,6 @@ class LambdaOutputParser(object):
                     'stackTrace' in lambda_response_dict:
                 is_lambda_user_error_response = True
         except ValueError:
-            # If you cant serialize the output into a dict, then do nothing
+            # If you can't serialize the output into a dict, then do nothing
             pass
         return is_lambda_user_error_response

--- a/tests/functional/function_code.py
+++ b/tests/functional/function_code.py
@@ -47,6 +47,13 @@ exports.handler = function(event, context) {
 };
 """
 
+THROW_ERROR_LAMBDA = """
+exports.handler = function(event, context, callback) {
+    var error = new Error("something is wrong");
+    callback(error);
+};
+"""
+
 API_GATEWAY_ECHO_EVENT = """
 exports.handler = function(event, context, callback){
 

--- a/tests/functional/local/lambda_service/test_local_lambda_invoke.py
+++ b/tests/functional/local/lambda_service/test_local_lambda_invoke.py
@@ -9,7 +9,7 @@ import os
 import requests
 
 from samcli.local.lambda_service.local_lambda_invoke_service import LocalLambdaInvokeService
-from tests.functional.function_code import nodejs_lambda, HELLO_FROM_LAMBDA, ECHO_CODE
+from tests.functional.function_code import nodejs_lambda, HELLO_FROM_LAMBDA, ECHO_CODE, THROW_ERROR_LAMBDA
 from samcli.commands.local.lib import provider
 from samcli.local.lambdafn.runtime import LambdaRuntime
 from samcli.commands.local.lib.local_lambda import LocalLambdaRunner
@@ -22,23 +22,37 @@ class TestLocalLambdaService(TestCase):
     @classmethod
     def mocked_function_provider(cls, function_name):
         if function_name == "HelloWorld":
-            return cls.function
+            return cls.hello_world_function
+        if function_name == "ThrowError":
+            return cls.throw_error_function
         else:
             raise FunctionNotFound("Could not find Function")
 
     @classmethod
     def setUpClass(cls):
+        cls.code_abs_path_for_throw_error = nodejs_lambda(THROW_ERROR_LAMBDA)
+
+        # Let's convert this absolute path to relative path. Let the parent be the CWD, and codeuri be the folder
+        cls.cwd_for_throw_error = os.path.dirname(cls.code_abs_path_for_throw_error)
+        cls.code_uri_for_throw_error = os.path.relpath(cls.code_abs_path_for_throw_error, cls.cwd_for_throw_error)  # Get relative path with respect to CWD
+
         cls.code_abs_path = nodejs_lambda(HELLO_FROM_LAMBDA)
 
         # Let's convert this absolute path to relative path. Let the parent be the CWD, and codeuri be the folder
         cls.cwd = os.path.dirname(cls.code_abs_path)
         cls.code_uri = os.path.relpath(cls.code_abs_path, cls.cwd)  # Get relative path with respect to CWD
 
-        cls.function_name = "HelloWorld"
+        cls.hello_world_function_name = "HelloWorld"
 
-        cls.function = provider.Function(name=cls.function_name, runtime="nodejs4.3", memory=256, timeout=5,
-                                         handler="index.handler", codeuri=cls.code_uri, environment=None,
-                                         rolearn=None)
+        cls.hello_world_function = provider.Function(name=cls.hello_world_function_name, runtime="nodejs4.3",
+                                                     memory=256, timeout=5, handler="index.handler",
+                                                     codeuri=cls.code_uri, environment=None, rolearn=None)
+
+        cls.throw_error_function_name = "ThrowError"
+
+        cls.throw_error_function = provider.Function(name=cls.throw_error_function_name, runtime="nodejs4.3",
+                                                     memory=256, timeout=5, handler="index.handler",
+                                                     codeuri=cls.code_uri_for_throw_error, environment=None, rolearn=None)
 
         cls.mock_function_provider = Mock()
         cls.mock_function_provider.get.side_effect = cls.mocked_function_provider
@@ -53,6 +67,7 @@ class TestLocalLambdaService(TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.code_abs_path)
+        shutil.rmtree(cls.code_abs_path_for_throw_error)
 
     def setUp(self):
         # Print full diff when comparing large dictionaries
@@ -80,6 +95,19 @@ class TestLocalLambdaService(TestCase):
         self.assertEquals(actual_data, expected_data)
         self.assertEquals(acutal_error_type_header, 'ResourceNotFound')
         self.assertEquals(response.status_code, 404)
+
+    def test_request_a_function_that_throws_an_error(self):
+        expected_data = {'errorMessage': 'something is wrong', 'errorType': 'Error','stackTrace': ['exports.handler (/var/task/index.js:3:17)']}
+
+        response = requests.post(self.url + '/2015-03-31/functions/ThrowError/invocations')
+
+        actual_data = response.json()
+        acutal_error_type_header = response.headers.get('x-amz-function-error')
+
+        self.assertEquals(actual_data, expected_data)
+        self.assertEquals(acutal_error_type_header, 'Unhandled')
+        self.assertEquals(response.status_code, 200)
+
 
 class TestLocalEchoLambdaService(TestCase):
     @classmethod
@@ -123,6 +151,160 @@ class TestLocalEchoLambdaService(TestCase):
 
         self.assertEquals(actual, expected)
         self.assertEquals(response.status_code, 200)
+
+    def test_function_executed_when_no_data_provided(self):
+        expected = {}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations')
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 200)
+
+
+class TestLocalLambdaService_NotSupportedRequests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.code_abs_path = nodejs_lambda(ECHO_CODE)
+
+        # Let's convert this absolute path to relative path. Let the parent be the CWD, and codeuri be the folder
+        cls.cwd = os.path.dirname(cls.code_abs_path)
+        cls.code_uri = os.path.relpath(cls.code_abs_path, cls.cwd)  # Get relative path with respect to CWD
+
+        cls.function_name = "HelloWorld"
+
+        cls.function = provider.Function(name=cls.function_name, runtime="nodejs4.3", memory=256, timeout=5,
+                                         handler="index.handler", codeuri=cls.code_uri, environment=None,
+                                         rolearn=None)
+
+        cls.mock_function_provider = Mock()
+        cls.mock_function_provider.get.return_value = cls.function
+
+        cls.service, cls.port, cls.url, cls.scheme = make_service(cls.mock_function_provider, cls.cwd)
+        cls.service.create()
+        # import pdb; pdb.set_trace()
+        t = threading.Thread(name='thread', target=cls.service.run, args=())
+        t.setDaemon(True)
+        t.start()
+        time.sleep(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.code_abs_path)
+
+    def setUp(self):
+        # Print full diff when comparing large dictionaries
+        self.maxDiff = None
+
+    def test_query_string_parameters_in_request(self):
+        expected = {"Type": "User",
+             "Message": "Query Parameters are not supported"}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations', json={"key1": "value1"}, params={"key": "value"})
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 400)
+        self.assertEquals(response.headers.get('x-amzn-errortype'), 'InvalidRequestContentException')
+        self.assertEquals(response.headers.get('Content-Type'),'application/json')
+
+    def test_payload_is_not_json_serializable(self):
+        expected = {"Type": "User",
+                    "Message": "Could not parse request body into json: Expecting value: line 1 column 1 (char 0)"}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations', data='notat:asdfasdf')
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 400)
+        self.assertEquals(response.headers.get('x-amzn-errortype'), 'InvalidRequestContentException')
+        self.assertEquals(response.headers.get('Content-Type'), 'application/json')
+
+    def test_log_type_tail_in_request(self):
+        expected = {"Type": "LocalService", "Message": "log-type: Tail is not supported. None is only supported."}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations', headers={'X-Amz-Log-Type': 'Tail'})
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 501)
+        self.assertEquals(response.headers.get('Content-Type'), 'application/json')
+        self.assertEquals(response.headers.get('x-amzn-errortype'), 'NotImplemented')
+
+    def test_log_type_tail_in_request_with_lowercase_header(self):
+        expected = {"Type": "LocalService", "Message": "log-type: Tail is not supported. None is only supported."}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations', headers={'x-amz-log-type': 'Tail'})
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 501)
+        self.assertEquals(response.headers.get('Content-Type'), 'application/json')
+        self.assertEquals(response.headers.get('x-amzn-errortype'), 'NotImplemented')
+
+    def test_invocation_type_event_in_request(self):
+        expected = {"Type": "LocalService", "Message": "invocation-type: Event is not supported. RequestResponse is only supported."}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations',
+                                 headers={'X-Amz-Invocation-Type': 'Event'})
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 501)
+        self.assertEquals(response.headers.get('Content-Type'), 'application/json')
+        self.assertEquals(response.headers.get('x-amzn-errortype'), 'NotImplemented')
+
+    def test_invocation_type_dry_run_in_request(self):
+        expected = {"Type": "LocalService", "Message": "invocation-type: DryRun is not supported. RequestResponse is only supported."}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations',
+                                 headers={'X-Amz-Invocation-Type': 'DryRun'})
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 501)
+        self.assertEquals(response.headers.get('Content-Type'), 'application/json')
+        self.assertEquals(response.headers.get('x-amzn-errortype'), 'NotImplemented')
+
+    def test_media_type_is_not_application_json(self):
+        expected = {"Type": "User",
+                    "Message": 'Unsupported content type: image/gif'}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations', headers={'Content-Type':'image/gif'})
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 415)
+        self.assertEquals(response.headers.get('x-amzn-errortype'), 'UnsupportedMediaType')
+        self.assertEquals(response.headers.get('Content-Type'), 'application/json')
+
+    def test_generic_404_error_when_request_to_nonexisting_endpoint(self):
+        expected_data = {'Type': 'LocalService', 'Message': 'PathNotFoundException'}
+
+        response = requests.post(self.url + '/some/random/path/that/does/not/exist')
+
+        actual_data = response.json()
+
+        self.assertEquals(actual_data, expected_data)
+        self.assertEquals(response.status_code, 404)
+
+    def test_generic_405_error_when_request_path_with_invalid_method(self):
+        expected_data = {'Type': 'LocalService', 'Message': 'MethodNotAllowedException'}
+
+        response = requests.get(self.url + '/2015-03-31/functions/HelloWorld/invocations')
+
+        actual_data = response.json()
+
+        self.assertEquals(actual_data, expected_data)
+        self.assertEquals(response.status_code, 405)
 
 
 def make_service(function_provider, cwd):

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -5,7 +5,7 @@ import base64
 
 from parameterized import parameterized, param
 
-from samcli.local.apigw.local_apigw_service import LocalApigwService, Route, CaseInsensitiveDict
+from samcli.local.apigw.local_apigw_service import LocalApigwService, Route
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 
 
@@ -29,7 +29,7 @@ class TestApiGatewayService(TestCase):
     def test_request_must_invoke_lambda(self):
         make_response_mock = Mock()
 
-        self.service._service_response = make_response_mock
+        self.service.service_response = make_response_mock
         self.service._get_current_route = Mock()
         self.service._construct_event = Mock()
 
@@ -39,7 +39,7 @@ class TestApiGatewayService(TestCase):
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
-        self.service._service_response = service_response_mock
+        self.service.service_response = service_response_mock
 
         result = self.service._request_handler()
 
@@ -54,7 +54,7 @@ class TestApiGatewayService(TestCase):
 
         make_response_mock = Mock()
 
-        self.service._service_response = make_response_mock
+        self.service.service_response = make_response_mock
         self.service._get_current_route = Mock()
         self.service._construct_event = Mock()
 
@@ -68,7 +68,7 @@ class TestApiGatewayService(TestCase):
         lambda_output_parser_mock.get_lambda_output.return_value = lambda_response, lambda_logs, is_customer_error
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
-        self.service._service_response = service_response_mock
+        self.service.service_response = service_response_mock
 
         result = self.service._request_handler()
 
@@ -83,7 +83,7 @@ class TestApiGatewayService(TestCase):
     def test_request_handler_returns_make_response(self):
         make_response_mock = Mock()
 
-        self.service._service_response = make_response_mock
+        self.service.service_response = make_response_mock
         self.service._get_current_route = Mock()
         self.service._construct_event = Mock()
 
@@ -93,7 +93,7 @@ class TestApiGatewayService(TestCase):
 
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
-        self.service._service_response = service_response_mock
+        self.service.service_response = service_response_mock
 
         result = self.service._request_handler()
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -64,8 +64,8 @@ class TestApiGatewayService(TestCase):
 
         lambda_logs = "logs"
         lambda_response = "response"
-        lambda_output_parser_mock.get_lambda_output.return_value = lambda_response, lambda_logs
-
+        is_customer_error = False
+        lambda_output_parser_mock.get_lambda_output.return_value = lambda_response, lambda_logs, is_customer_error
         service_response_mock = Mock()
         service_response_mock.return_value = make_response_mock
         self.service._service_response = service_response_mock

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -468,36 +468,3 @@ class TestService_should_base64_encode(TestCase):
     ])
     def test_should_base64_encode_returns_false(self, test_case_name, binary_types, mimetype):
         self.assertFalse(LocalApigwService._should_base64_encode(binary_types, mimetype))
-
-
-class TestService_CaseInsensiveDict(TestCase):
-
-    def setUp(self):
-        self.data = CaseInsensitiveDict({
-            'Content-Type': 'text/html',
-            'Browser': 'APIGW',
-        })
-
-    def test_contains_lower(self):
-        self.assertTrue('content-type' in self.data)
-
-    def test_contains_title(self):
-        self.assertTrue('Content-Type' in self.data)
-
-    def test_contains_upper(self):
-        self.assertTrue('CONTENT-TYPE' in self.data)
-
-    def test_contains_browser_key(self):
-        self.assertTrue('Browser' in self.data)
-
-    def test_contains_not_in(self):
-        self.assertTrue('Dog-Food' not in self.data)
-
-    def test_setitem_found(self):
-        self.data['Browser'] = 'APIGW'
-
-        self.assertTrue(self.data['browser'])
-
-    def test_keyerror(self):
-        with self.assertRaises(KeyError):
-            self.data['does-not-exist']

--- a/tests/unit/local/lambda_service/test_lambda_error_responses.py
+++ b/tests/unit/local/lambda_service/test_lambda_error_responses.py
@@ -28,7 +28,7 @@ class TestLambdaErrorResponses(TestCase):
         self.assertEquals(response, 'InvalidRequestContent')
         service_response_mock.assert_called_once_with(
             '{"Type": "User", "Message": "InvalidRequestContent"}',
-            {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'},
+            {'x-amzn-errortype': 'InvalidRequestContent', 'Content-Type': 'application/json'},
             400)
 
     @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
@@ -52,7 +52,7 @@ class TestLambdaErrorResponses(TestCase):
         self.assertEquals(response, 'GenericServiceException')
         service_response_mock.assert_called_once_with(
             '{"Type": "Service", "Message": "ServiceException"}',
-            {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'},
+            {'x-amzn-errortype': 'Service', 'Content-Type': 'application/json'},
             500)
 
     @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
@@ -76,7 +76,7 @@ class TestLambdaErrorResponses(TestCase):
         self.assertEquals(response, 'GenericPathNotFound')
         service_response_mock.assert_called_once_with(
             '{"Type": "LocalService", "Message": "PathNotFoundException"}',
-            {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
+            {'x-amzn-errortype': 'PathNotFoundLocally', 'Content-Type': 'application/json'},
             404)
 
     @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
@@ -88,5 +88,5 @@ class TestLambdaErrorResponses(TestCase):
         self.assertEquals(response, 'GenericMethodNotAllowed')
         service_response_mock.assert_called_once_with(
             '{"Type": "LocalService", "Message": "MethodNotAllowedException"}',
-            {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
+            {'x-amzn-errortype': 'MethodNotAllowedLocally', 'Content-Type': 'application/json'},
             405)

--- a/tests/unit/local/lambda_service/test_lambda_error_responses.py
+++ b/tests/unit/local/lambda_service/test_lambda_error_responses.py
@@ -3,9 +3,10 @@ from mock import patch
 
 from samcli.local.lambda_service.lambda_error_responses import LambdaErrorResponses
 
+
 class TestLambdaErrorResponses(TestCase):
 
-    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
     def test_resource_not_found(self, service_response_mock):
         service_response_mock.return_value = "ResourceNotFound"
 
@@ -18,7 +19,7 @@ class TestLambdaErrorResponses(TestCase):
             {'x-amzn-errortype': 'ResourceNotFound', 'Content-Type': 'application/json'},
             404)
 
-    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
     def test_invalid_request_content(self, service_response_mock):
         service_response_mock.return_value = "InvalidRequestContent"
 
@@ -26,9 +27,11 @@ class TestLambdaErrorResponses(TestCase):
 
         self.assertEquals(response, 'InvalidRequestContent')
         service_response_mock.assert_called_once_with(
-            '{"Type": "User", "Message": "InvalidRequestContent"}', {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'}, 400)
+            '{"Type": "User", "Message": "InvalidRequestContent"}',
+            {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'},
+            400)
 
-    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
     def test_unsupported_media_type(self, service_response_mock):
         service_response_mock.return_value = "UnsupportedMediaType"
 
@@ -36,9 +39,11 @@ class TestLambdaErrorResponses(TestCase):
 
         self.assertEquals(response, 'UnsupportedMediaType')
         service_response_mock.assert_called_once_with(
-            '{"Type": "User", "Message": "Unsupported content type: UnsupportedMediaType"}', {'x-amzn-errortype': 'UnsupportedMediaType', 'Content-Type': 'application/json'}, 415)
+            '{"Type": "User", "Message": "Unsupported content type: UnsupportedMediaType"}',
+            {'x-amzn-errortype': 'UnsupportedMediaType', 'Content-Type': 'application/json'},
+            415)
 
-    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
     def test_generic_service_exception(self, service_response_mock):
         service_response_mock.return_value = "GenericServiceException"
 
@@ -46,9 +51,11 @@ class TestLambdaErrorResponses(TestCase):
 
         self.assertEquals(response, 'GenericServiceException')
         service_response_mock.assert_called_once_with(
-            '{"Type": "Service", "Message": "ServiceException"}', {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'}, 500)
+            '{"Type": "Service", "Message": "ServiceException"}',
+            {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'},
+            500)
 
-    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
     def test_not_implemented_locally(self, service_response_mock):
         service_response_mock.return_value = "NotImplementedLocally"
 
@@ -56,9 +63,11 @@ class TestLambdaErrorResponses(TestCase):
 
         self.assertEquals(response, 'NotImplementedLocally')
         service_response_mock.assert_called_once_with(
-            '{"Type": "LocalService", "Message": "NotImplementedLocally"}', {'x-amzn-errortype': 'NotImplemented', 'Content-Type': 'application/json'}, 501)
+            '{"Type": "LocalService", "Message": "NotImplementedLocally"}',
+            {'x-amzn-errortype': 'NotImplemented', 'Content-Type': 'application/json'},
+            501)
 
-    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
     def test_generic_path_not_found(self, service_response_mock):
         service_response_mock.return_value = "GenericPathNotFound"
 
@@ -66,9 +75,11 @@ class TestLambdaErrorResponses(TestCase):
 
         self.assertEquals(response, 'GenericPathNotFound')
         service_response_mock.assert_called_once_with(
-            '{"Type": "LocalService", "Message": "PathNotFoundException"}', {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'}, 404)
+            '{"Type": "LocalService", "Message": "PathNotFoundException"}',
+            {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
+            404)
 
-    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    @patch('samcli.local.services.base_local_service.BaseLocalService.service_response')
     def test_generic_method_not_allowed(self, service_response_mock):
         service_response_mock.return_value = "GenericMethodNotAllowed"
 
@@ -76,4 +87,6 @@ class TestLambdaErrorResponses(TestCase):
 
         self.assertEquals(response, 'GenericMethodNotAllowed')
         service_response_mock.assert_called_once_with(
-            '{"Type": "LocalService", "Message": "MethodNotAllowedException"}', {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'}, 405)
+            '{"Type": "LocalService", "Message": "MethodNotAllowedException"}',
+            {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'},
+            405)

--- a/tests/unit/local/lambda_service/test_lambda_error_responses.py
+++ b/tests/unit/local/lambda_service/test_lambda_error_responses.py
@@ -1,0 +1,79 @@
+from unittest import TestCase
+from mock import patch
+
+from samcli.local.lambda_service.lambda_error_responses import LambdaErrorResponses
+
+class TestLambdaErrorResponses(TestCase):
+
+    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    def test_resource_not_found(self, service_response_mock):
+        service_response_mock.return_value = "ResourceNotFound"
+
+        response = LambdaErrorResponses.resource_not_found('HelloFunction')
+
+        self.assertEquals(response, 'ResourceNotFound')
+        service_response_mock.assert_called_once_with(
+            '{"Type": "User", "Message": "Function not found: '
+            'arn:aws:lambda:us-west-2:012345678901:function:HelloFunction"}',
+            {'x-amzn-errortype': 'ResourceNotFound', 'Content-Type': 'application/json'},
+            404)
+
+    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    def test_invalid_request_content(self, service_response_mock):
+        service_response_mock.return_value = "InvalidRequestContent"
+
+        response = LambdaErrorResponses.invalid_request_content('InvalidRequestContent')
+
+        self.assertEquals(response, 'InvalidRequestContent')
+        service_response_mock.assert_called_once_with(
+            '{"Type": "User", "Message": "InvalidRequestContent"}', {'x-amzn-errortype': 'InvalidRequestContentException', 'Content-Type': 'application/json'}, 400)
+
+    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    def test_unsupported_media_type(self, service_response_mock):
+        service_response_mock.return_value = "UnsupportedMediaType"
+
+        response = LambdaErrorResponses.unsupported_media_type('UnsupportedMediaType')
+
+        self.assertEquals(response, 'UnsupportedMediaType')
+        service_response_mock.assert_called_once_with(
+            '{"Type": "User", "Message": "Unsupported content type: UnsupportedMediaType"}', {'x-amzn-errortype': 'UnsupportedMediaType', 'Content-Type': 'application/json'}, 415)
+
+    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    def test_generic_service_exception(self, service_response_mock):
+        service_response_mock.return_value = "GenericServiceException"
+
+        response = LambdaErrorResponses.generic_service_exception('GenericServiceException')
+
+        self.assertEquals(response, 'GenericServiceException')
+        service_response_mock.assert_called_once_with(
+            '{"Type": "Service", "Message": "ServiceException"}', {'x-amzn-errortype': 'ServiceException', 'Content-Type': 'application/json'}, 500)
+
+    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    def test_not_implemented_locally(self, service_response_mock):
+        service_response_mock.return_value = "NotImplementedLocally"
+
+        response = LambdaErrorResponses.not_implemented_locally('NotImplementedLocally')
+
+        self.assertEquals(response, 'NotImplementedLocally')
+        service_response_mock.assert_called_once_with(
+            '{"Type": "LocalService", "Message": "NotImplementedLocally"}', {'x-amzn-errortype': 'NotImplemented', 'Content-Type': 'application/json'}, 501)
+
+    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    def test_generic_path_not_found(self, service_response_mock):
+        service_response_mock.return_value = "GenericPathNotFound"
+
+        response = LambdaErrorResponses.generic_path_not_found('GenericPathNotFound')
+
+        self.assertEquals(response, 'GenericPathNotFound')
+        service_response_mock.assert_called_once_with(
+            '{"Type": "LocalService", "Message": "PathNotFoundException"}', {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'}, 404)
+
+    @patch('samcli.local.services.base_local_service.BaseLocalService._service_response')
+    def test_generic_method_not_allowed(self, service_response_mock):
+        service_response_mock.return_value = "GenericMethodNotAllowed"
+
+        response = LambdaErrorResponses.generic_method_not_allowed('GenericMethodNotAllowed')
+
+        self.assertEquals(response, 'GenericMethodNotAllowed')
+        service_response_mock.assert_called_once_with(
+            '{"Type": "LocalService", "Message": "MethodNotAllowedException"}', {'x-amzn-errortype': 'LocalServiceException', 'Content-Type': 'application/json'}, 405)

--- a/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
+++ b/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from mock import Mock, patch, ANY, call
+import sys
 
 from samcli.local.lambda_service.local_lambda_invoke_service import LocalLambdaInvokeService
 from samcli.local.lambdafn.exceptions import FunctionNotFound
@@ -184,8 +185,12 @@ class TestValidateRequestHandling(TestCase):
 
         self.assertEquals(response, "InvalidRequestContent")
 
-        lambda_error_responses_mock.invalid_request_content.assert_called_once_with(
-            "Could not parse request body into json: Expecting value: line 1 column 1 (char 0)")
+        if sys.version_info.major == 2:
+            expected_called_with = "Could not parse request body into json: No JSON object could be decoded"
+        else:
+            expected_called_with = "Could not parse request body into json: Expecting value: line 1 column 1 (char 0)"
+
+        lambda_error_responses_mock.invalid_request_content.assert_called_once_with(expected_called_with)
 
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaErrorResponses')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')

--- a/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
+++ b/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
@@ -43,7 +43,7 @@ class TestLocalLambdaService(TestCase):
                                                       methods=['POST'],
                                                       provide_automatic_options=False)
 
-    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService._service_response')
+    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService.service_response')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaOutputParser')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')
     def test_invoke_request_handler(self, request_mock, lambda_output_parser_mock, service_response_mock):
@@ -80,7 +80,7 @@ class TestLocalLambdaService(TestCase):
 
         lambda_error_responses_mock.resource_not_found.assert_called_once_with('NotFound')
 
-    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService._service_response')
+    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService.service_response')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaOutputParser')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')
     def test_request_handler_returns_process_stdout_when_making_response(self, request_mock, lambda_output_parser_mock,
@@ -125,10 +125,13 @@ class TestLocalLambdaService(TestCase):
             call(404, lambda_error_response_mock.generic_path_not_found),
             call(405, lambda_error_response_mock.generic_method_not_allowed)])
 
-    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService._service_response')
+    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService.service_response')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaOutputParser')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')
-    def test_invoke_request_handler_with_lambda_that_errors(self, request_mock, lambda_output_parser_mock, service_response_mock):
+    def test_invoke_request_handler_with_lambda_that_errors(self,
+                                                            request_mock,
+                                                            lambda_output_parser_mock,
+                                                            service_response_mock):
         lambda_output_parser_mock.get_lambda_output.return_value = 'hello world', None, True
         service_response_mock.return_value = 'request response'
         request_mock.get_data.return_value = b'{}'
@@ -141,9 +144,12 @@ class TestLocalLambdaService(TestCase):
         self.assertEquals(response, 'request response')
 
         lambda_runner_mock.invoke.assert_called_once_with('HelloWorld', '{}', stdout=ANY, stderr=None)
-        service_response_mock.assert_called_once_with('hello world', {'Content-Type': 'application/json', 'x-amz-function-error': 'Unhandled'}, 200)
+        service_response_mock.assert_called_once_with('hello world',
+                                                      {'Content-Type': 'application/json',
+                                                       'x-amz-function-error': 'Unhandled'},
+                                                      200)
 
-    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService._service_response')
+    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LocalLambdaInvokeService.service_response')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaOutputParser')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')
     def test_invoke_request_handler_with_no_data(self, request_mock, lambda_output_parser_mock, service_response_mock):
@@ -178,7 +184,8 @@ class TestValidateRequestHandling(TestCase):
 
         self.assertEquals(response, "InvalidRequestContent")
 
-        lambda_error_responses_mock.invalid_request_content.assert_called_once_with("Could not parse request body into json: Expecting value: line 1 column 1 (char 0)")
+        lambda_error_responses_mock.invalid_request_content.assert_called_once_with(
+            "Could not parse request body into json: Expecting value: line 1 column 1 (char 0)")
 
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaErrorResponses')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -104,6 +104,7 @@ class TestLambdaOutputParser(TestCase):
         stdout = Mock()
         stdout.getvalue.return_value = stdout_data
 
-        response, logs = LambdaOutputParser.get_lambda_output(stdout)
+        response, logs, is_customer_error = LambdaOutputParser.get_lambda_output(stdout)
         self.assertEquals(logs, expected_logs)
         self.assertEquals(response, expected_response)
+        self.assertFalse(is_customer_error)

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -49,7 +49,7 @@ class TestLocalHostRunner(TestCase):
         status_code = 200
         headers = {"Content-Type": "application/json"}
 
-        actual_response = BaseLocalService._service_response(body, headers, status_code)
+        actual_response = BaseLocalService.service_response(body, headers, status_code)
 
         flask_response_patch.assert_called_once_with("this is the body")
 
@@ -110,14 +110,21 @@ class TestLambdaOutputParser(TestCase):
         self.assertFalse(is_customer_error)
 
     @parameterized.expand([
-        param('{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type"}', True),
-        param('{"error message": "has a message", "stack Trace": "has a stacktrace", "error Type": "has a type"}', False),
-        param('{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type", "hasextrakey": "value"}', False),
-        param("notat:asdfasdf", False),
-        param("errorMessage and stackTrace and errorType are in the string", False)
+        param('{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type"}',
+              True),
+        param('{"error message": "has a message", "stack Trace": "has a stacktrace", "error Type": "has a type"}',
+              False),
+        param('{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type", '
+              '"hasextrakey": "value"}',
+              False),
+        param("notat:asdfasdf",
+              False),
+        param("errorMessage and stackTrace and errorType are in the string",
+              False)
     ])
     def test_is_lambda_error_response(self, input, exected_result):
         self.assertEquals(LambdaOutputParser.is_lambda_error_response(input), exected_result)
+
 
 class CaseInsensiveDict(TestCase):
 
@@ -150,4 +157,3 @@ class CaseInsensiveDict(TestCase):
     def test_keyerror(self):
         with self.assertRaises(KeyError):
             self.data['does-not-exist']
-


### PR DESCRIPTION
Details:
* Handling for when lambda returns an error
* Handled payload could not be parsed as JSON
* Abstracted if the lambda output is an error from the container into LambdaOutputParser
* Added handling for X-Amz-Log-Type
* Added handling for X-Amz-Invocation-Type
* Moved all Request validate to flask.before_request call
* Added handling for Query parameters (not supported)
* Added handling for unsupported_media_type
* Added handling for ServiceError
* Added handling for generic 404 Error handling
* Fix up tests to make them runable

*Description of changes:*
This is to handle the Error cases that can occur in the Local Lambda Service. This is meant to mimic the actually service with some caveats that are specific to local:
* The generic 404 has the same response if the Lambda Function does not exits but with an empty string for the function. This is due to the generic 404 being for any endpoint that does not exist. We handle the functions not found if it follows the endpoint schema we setup. I am considering moving this to, be something along the lines of 'this endpoint does not exist' but haven't landed or changed this yet.
* Any Service error will be a 'generic' 500 error.
* Currently, we only supported X-Amz-Log-Type = 'None' and X-Amz-Invocation-Type = 'RequestResponse'
* The arn of the function given in the ResourceNotFound 404 is hardcoded with an account id and region: us-west-2. The region is passed to the service through a 'context' in the request: `context': {'auth_type': None, 'client_region': u'us-west-2',` but Flask seems to swallow this part of the request and have not found a way to get at this information.

*Work In Progress*
Following items are remaining:
- [x] Add Functional Tests for each Error case handled.
- [x] Add Unit tests
- [x] validate error cases match the Lambda Service (note: some will be different and specific to local only)
- [x] Test the LocalLambdaInvoke by using the AWS CLI to call
- [x] Some general code cleanup

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
