### PR TITLE
Fixed spacing typo

### DIFF
--- a/samcli/commands/local/lib/local_lambda_service.py
+++ b/samcli/commands/local/lib/local_lambda_service.py
@@ -53,6 +53,6 @@ class LocalLambdaService(object):
         service.create()
 
         LOG.info("Starting the Local Lambda Service. You can now invoke your Lambda Functions defined in your template"
-                 "through the endpoint.")
+                 " through the endpoint.")
 
         service.run()


### PR DESCRIPTION
*Description of changes:*
When running 'sam local start-lambda' it logged "templatethrough" rather than "template through"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
