### PR TITLE
[minor] Fix @mhart link in readme (was a markdown link)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1012,7 +1012,7 @@ A special thank you
 
 SAM CLI uses the open source
 `docker-lambda <https://github.com/lambci/docker-lambda>`__ Docker
-images created by [@mhart](https://github.com/mhart).
+images created by `@mhart <https://github.com/mhart>`__.
 
 
 .. raw:: html


### PR DESCRIPTION
*Description of changes:*

Link at the bottom of the readme wasn't rendering ok

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
