### PR TITLE
Change `jest` to `mocha` in README

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/README.md
@@ -109,7 +109,7 @@ aws cloudformation describe-stacks \
 
 ## Testing
 
-We use `jest` for testing our code and it is already added in `package.json` under `scripts`, so that we can simply run the following command to run our tests:
+We use `mocha` for testing our code and it is already added in `package.json` under `scripts`, so that we can simply run the following command to run our tests:
 
 ```bash
 cd hello_world


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Afterf `sam init`, the README says `We use `jest` for testing our code...`, however, sam uses Mocha instead of Jest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
