### PR TITLE
feat(debugging): Support debugging Golang functions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -504,21 +504,21 @@ When debugging, you must compile your function in debug mode:
 You must compile `delve` to run in the container and provide its local path
 via the `--debugger-path` argument. Build delve locally as follows:
 
-`GOARCH=amd64 GOOS=linux go build -o <output path>/dlv github.com/derekparker/delve/cmd/dlv`
+`GOARCH=amd64 GOOS=linux go build -o <delve folder path>/dlv github.com/derekparker/delve/cmd/dlv`
 
 NOTE: The output path needs to end in `/dlv`. The docker container will expect the dlv binary to be in the <output path>
 and will cause mounting issue otherwise.
 
 Then invoke `sam` similar to the following:
 
-`sam local start-api -d 5986 --debugger-path <output path>`
+`sam local start-api -d 5986 --debugger-path <delve folder path>`
 
 NOTE: The `--debugger-path` is the path to the directory that contains the `dlv` binary compiled from the above.
 
 The following is an example launch configuration for Visual Studio Code to
 attach to a debug session.
 
-.. code:: bash
+.. code:: json
 
   {
     "version": "0.2.0",

--- a/README.rst
+++ b/README.rst
@@ -497,14 +497,23 @@ Java, and Python. We require `delve <https://github.com/derekparker/delve>`__
 as the debugger, and wrap your function with it at runtime. The debugger
 is run in headless mode, listening on the debug port.
 
+When debugging, you must compile you function in debug mode:
+
+`GOARCH=amd64 GOOS=linux go build -gcflags='-N -l' -o <output path> <path to code directory>
+
 You must compile `delve` to run in the container and provide its local path
 via the `--debugger-path` argument. Build delve locally as follows:
 
-`GOARCH=amd64 GOOS=linux go build -o <output path> github.com/derekparker/delve/cmd/dlv`
+`GOARCH=amd64 GOOS=linux go build -o <output path>/dlv github.com/derekparker/delve/cmd/dlv`
+
+NOTE: The output path needs to end in `/dlv`. The docker container will expect the dlv binary to be in the <output path>
+and will cause mounting issue otherwise.
 
 Then invoke `sam` similar to the following:
 
 `sam local start-api -d 5986 --debugger-path <output path>`
+
+NOTE: The `--debugger-path` is the path to the directory that contains the `dlv` binary compiled from the above.
 
 The following is an example launch configuration for Visual Studio Code to
 attach to a debug session.

--- a/README.rst
+++ b/README.rst
@@ -506,7 +506,7 @@ via the `--debugger-path` argument. Build delve locally as follows:
 
 `GOARCH=amd64 GOOS=linux go build -o <delve folder path>/dlv github.com/derekparker/delve/cmd/dlv`
 
-NOTE: The output path needs to end in `/dlv`. The docker container will expect the dlv binary to be in the <output path>
+NOTE: The output path needs to end in `/dlv`. The docker container will expect the dlv binary to be in the <delve folder path>
 and will cause mounting issue otherwise.
 
 Then invoke `sam` similar to the following:

--- a/README.rst
+++ b/README.rst
@@ -489,6 +489,47 @@ port to your host machine.
    issue <https://github.com/Microsoft/vscode-python/issues/71>`__ for
    updates.
 
+Debugging Golang functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Golang function debugging is slightly different when compared to Node.JS,
+Java, and Python. We require `delve <https://github.com/derekparker/delve>`__
+as the debugger, and wrap your function with it at runtime. The debugger
+is run in headless mode, listening on the debug port.
+
+You must compile `delve` to run in the container and provide its local path
+via the `--debugger-path` argument. Build delve locally as follows:
+
+`GOARCH=amd64 GOOS=linux go build -o <output path> github.com/derekparker/delve/cmd/dlv`
+
+Then invoke `sam` similar to the following:
+
+`sam local start-api -d 5986 --debugger-path <output path>`
+
+The following is an example launch configuration for Visual Studio Code to
+attach to a debug session.
+
+.. code:: bash
+
+  {
+    "version": "0.2.0",
+    "configurations": [
+    {
+        "name": "Connect to Lambda container",
+        "type": "go",
+        "request": "launch",
+        "mode": "remote",
+        "remotePath": "",
+        "port": <debug port>,
+        "host": "127.0.0.1",
+        "program": "${workspaceRoot}",
+        "env": {},
+        "args": [],
+      },
+    ]
+  }
+
+
 Passing Additional Runtime Debug Arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -497,7 +497,7 @@ Java, and Python. We require `delve <https://github.com/derekparker/delve>`__
 as the debugger, and wrap your function with it at runtime. The debugger
 is run in headless mode, listening on the debug port.
 
-When debugging, you must compile you function in debug mode:
+When debugging, you must compile your function in debug mode:
 
 `GOARCH=amd64 GOOS=linux go build -gcflags='-N -l' -o <output path> <path to code directory>
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ aws-sam-translator==1.6.0
 docker>=3.3.0
 dateparser~=0.7
 python-dateutil~=2.6
+pathlib2~=2.3.2; python_version<"3.4"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ pylint==1.7.2
 pytest==3.0.7
 py==1.4.33
 mock==2.0.0
-requests>=2.19.0
+requests==2.19.0
 parameterized==0.6.1
 pathlib2==2.3.2; python_version<"3.4"
 futures==3.2.0; python_version<"3.2.3"

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -330,13 +330,13 @@ class InvokeContext(object):
                 debugger = Path(debugger_path).resolve(strict=True)
             except OSError as error:
                 if error.errno == errno.ENOENT:
-                    raise DebugContextException("'debugger_path' could not be found.")
+                    raise DebugContextException("'{}' could not be found.".format(debugger_path))
                 else:
                     raise error
 
             # We turn off pylint here due to https://github.com/PyCQA/pylint/issues/1660
             if not debugger.is_dir():  # pylint: disable=no-member
-                raise DebugContextException("'debugger_path' should be a directory with the debugger in it.")
+                raise DebugContextException("'{}' should be a directory with the debugger in it.".format(debugger_path))
             debugger_path = str(debugger)
 
         return DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -38,13 +38,12 @@ class InvokeContext(object):
                  template_file,
                  function_identifier=None,
                  env_vars_file=None,
-                 debug_port=None,
-                 debug_args=None,
                  docker_volume_basedir=None,
                  docker_network=None,
                  log_file=None,
                  skip_pull_image=None,
-                 aws_profile=None):
+                 aws_profile=None,
+                 debug_context=None):
         """
         Initialize the context
 
@@ -63,13 +62,12 @@ class InvokeContext(object):
         self._template_file = template_file
         self._function_identifier = function_identifier
         self._env_vars_file = env_vars_file
-        self._debug_port = debug_port
-        self._debug_args = debug_args
         self._docker_volume_basedir = docker_volume_basedir
         self._docker_network = docker_network
         self._log_file = log_file
         self._skip_pull_image = skip_pull_image
         self._aws_profile = aws_profile
+        self._debug_context = debug_context
 
         self._template_dict = None
         self._function_provider = None
@@ -146,8 +144,7 @@ class InvokeContext(object):
                                  function_provider=self._function_provider,
                                  cwd=self.get_cwd(),
                                  env_vars_values=self._env_vars_value,
-                                 debug_port=self._debug_port,
-                                 debug_args=self._debug_args,
+                                 debug_context=self._debug_context,
                                  aws_profile=self._aws_profile)
 
     @property

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -108,6 +108,9 @@ def invoke_common_options(f):
                           "port on localhost.",
                      envvar="SAM_DEBUG_PORT"),
 
+        click.option('--debugger-path',
+                     help="Host path to a debugger that will be mounted into the Lambda container."),
+
         click.option('--debug-args',
                      help="Additional arguments to be passed to the debugger.",
                      envvar="DEBUGGER_ARGS"),

--- a/samcli/commands/local/cli_common/user_exceptions.py
+++ b/samcli/commands/local/cli_common/user_exceptions.py
@@ -24,3 +24,10 @@ class SamTemplateNotFoundException(UserException):
     The SAM Template provided could not be found
     """
     pass
+
+
+class DebugContextException(UserException):
+    """
+    Something went wrong when creating the DebugContext
+    """
+    pass

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -57,7 +57,7 @@ def do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debu
     LOG.debug("local invoke command is called")
 
     event_data = _get_event(event)
-    debug_context = _get_debug_context(debug_port, debug_args, debugger_path)
+    debug_context = DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)
     # Pass all inputs to setup necessary context to invoke function locally.
     # Handler exception raised by the processor for invalid args and print errors
     try:
@@ -100,16 +100,3 @@ def _get_event(event_file_name):
     # accidentally closing a standard stream
     with click.open_file(event_file_name, 'r') as fp:
         return fp.read()
-
-
-def _get_debug_context(debug_port, debug_args, debugger_path):
-    """
-    Returns a debug context from debug options; Separated out for unit testing.
-    :param int debug_port: Container debug port
-    :param string debug_args: Extra debug arguments for process
-    :param string debugger_path: Path to debugger on host
-    :return DebugContext:
-    """
-    if not debug_port or debug_args or debugger_path:
-        return None
-    return DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -9,6 +9,7 @@ from samcli.cli.main import pass_context, common_options as cli_framework_option
 from samcli.commands.local.cli_common.options import invoke_common_options
 from samcli.commands.exceptions import UserException
 from samcli.commands.local.cli_common.invoke_context import InvokeContext
+from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 
@@ -38,17 +39,17 @@ $ echo '{"message": "Hey, are you there?" }' | sam local invoke "HelloWorldFunct
 @cli_framework_options
 @click.argument('function_identifier', required=False)
 @pass_context
-def cli(ctx, function_identifier, template, event, env_vars, debug_port, debug_args, docker_volume_basedir,
-        docker_network, log_file, skip_pull_image, profile):
+def cli(ctx, function_identifier, template, event, env_vars, debug_port, debug_args, debugger_path,
+        docker_volume_basedir, docker_network, log_file, skip_pull_image, profile):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debug_args, docker_volume_basedir,
-           docker_network, log_file, skip_pull_image, profile)  # pragma: no cover
+    do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debug_args, debugger_path,
+           docker_volume_basedir, docker_network, log_file, skip_pull_image, profile)  # pragma: no cover
 
 
-def do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debug_args, docker_volume_basedir,
-           docker_network, log_file, skip_pull_image, profile):
+def do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debug_args,  # pylint: disable=R0914
+           debugger_path, docker_volume_basedir, docker_network, log_file, skip_pull_image, profile):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
@@ -56,7 +57,7 @@ def do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debu
     LOG.debug("local invoke command is called")
 
     event_data = _get_event(event)
-
+    debug_context = _get_debug_context(debug_port, debug_args, debugger_path)
     # Pass all inputs to setup necessary context to invoke function locally.
     # Handler exception raised by the processor for invalid args and print errors
     try:
@@ -64,13 +65,12 @@ def do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debu
         with InvokeContext(template_file=template,
                            function_identifier=function_identifier,
                            env_vars_file=env_vars,
-                           debug_port=debug_port,
-                           debug_args=debug_args,
                            docker_volume_basedir=docker_volume_basedir,
                            docker_network=docker_network,
                            log_file=log_file,
                            skip_pull_image=skip_pull_image,
-                           aws_profile=profile) as context:
+                           aws_profile=profile,
+                           debug_context=debug_context) as context:
 
             # Invoke the function
             context.local_lambda_runner.invoke(context.function_name,
@@ -100,3 +100,16 @@ def _get_event(event_file_name):
     # accidentally closing a standard stream
     with click.open_file(event_file_name, 'r') as fp:
         return fp.read()
+
+
+def _get_debug_context(debug_port, debug_args, debugger_path):
+    """
+    Returns a debug context from debug options; Separated out for unit testing.
+    :param int debug_port: Container debug port
+    :param string debug_args: Extra debug arguments for process
+    :param string debugger_path: Path to debugger on host
+    :return DebugContext:
+    """
+    if not debug_port or debug_args or debugger_path:
+        return None
+    return DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -9,7 +9,6 @@ from samcli.cli.main import pass_context, common_options as cli_framework_option
 from samcli.commands.local.cli_common.options import invoke_common_options
 from samcli.commands.exceptions import UserException
 from samcli.commands.local.cli_common.invoke_context import InvokeContext
-from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 
@@ -57,7 +56,7 @@ def do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debu
     LOG.debug("local invoke command is called")
 
     event_data = _get_event(event)
-    debug_context = DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)
+
     # Pass all inputs to setup necessary context to invoke function locally.
     # Handler exception raised by the processor for invalid args and print errors
     try:
@@ -70,7 +69,9 @@ def do_cli(ctx, function_identifier, template, event, env_vars, debug_port, debu
                            log_file=log_file,
                            skip_pull_image=skip_pull_image,
                            aws_profile=profile,
-                           debug_context=debug_context) as context:
+                           debug_port=debug_port,
+                           debug_args=debug_args,
+                           debugger_path=debugger_path) as context:
 
             # Invoke the function
             context.local_lambda_runner.invoke(context.function_name,

--- a/samcli/commands/local/lib/debug_context.py
+++ b/samcli/commands/local/lib/debug_context.py
@@ -1,0 +1,21 @@
+"""
+Information and debug options for a specific runtime.
+"""
+
+
+class DebugContext(object):
+
+    def __init__(self,
+                 debug_port=None,
+                 debugger_path=None,
+                 debug_args=None):
+
+        self.debug_port = debug_port
+        self.debugger_path = debugger_path
+        self.debug_args = debug_args
+
+    def __bool__(self):
+        return bool(self.debug_port)
+
+    def __nonzero__(self):
+        return self.__bool__()

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -25,10 +25,8 @@ class LocalLambdaRunner(object):
                  function_provider,
                  cwd,
                  env_vars_values=None,
-                 debug_port=None,
-                 debug_args=None,
-                 aws_profile=None
-                 ):
+                 aws_profile=None,
+                 debug_context=None):
         """
         Initializes the class
 
@@ -46,9 +44,8 @@ class LocalLambdaRunner(object):
         self.provider = function_provider
         self.cwd = cwd
         self.env_vars_values = env_vars_values or {}
-        self.debug_port = debug_port
-        self.debug_args = debug_args
         self.aws_profile = aws_profile
+        self.debug_context = debug_context
 
     def invoke(self, function_name, event, stdout=None, stderr=None):
         """
@@ -76,8 +73,7 @@ class LocalLambdaRunner(object):
         config = self._get_invoke_config(function)
 
         # Invoke the function
-        self.local_runtime.invoke(config, event, debug_port=self.debug_port, debug_args=self.debug_args,
-                                  stdout=stdout, stderr=stderr)
+        self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
 
     def is_debugging(self):
         """
@@ -89,7 +85,7 @@ class LocalLambdaRunner(object):
             True, if we are debugging the invoke ie. the Docker container will break into the debugger and wait for
             attach
         """
-        return bool(self.debug_port)
+        return bool(self.debug_context)
 
     def _get_invoke_config(self, function):
         """

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -8,7 +8,6 @@ import click
 from samcli.cli.main import pass_context, common_options as cli_framework_options
 from samcli.commands.local.cli_common.options import invoke_common_options, service_common_options
 from samcli.commands.local.cli_common.invoke_context import InvokeContext
-from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.commands.local.lib.exceptions import NoApisDefined
 from samcli.commands.exceptions import UserException
 from samcli.commands.local.lib.local_api_service import LocalApiService
@@ -63,8 +62,6 @@ def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_ar
 
     LOG.debug("local start-api command is called")
 
-    debug_context = DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)
-
     # Pass all inputs to setup necessary context to invoke function locally.
     # Handler exception raised by the processor for invalid args and print errors
 
@@ -77,7 +74,9 @@ def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_ar
                            log_file=log_file,
                            skip_pull_image=skip_pull_image,
                            aws_profile=profile,
-                           debug_context=debug_context) as invoke_context:
+                           debug_port=debug_port,
+                           debug_args=debug_args,
+                           debugger_path=debugger_path) as invoke_context:
 
             service = LocalApiService(lambda_invoke_context=invoke_context,
                                       port=port,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -8,6 +8,7 @@ import click
 from samcli.cli.main import pass_context, common_options as cli_framework_options
 from samcli.commands.local.cli_common.options import invoke_common_options, service_common_options
 from samcli.commands.local.cli_common.invoke_context import InvokeContext
+from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.commands.local.cli_common.user_exceptions import UserException
 from samcli.commands.local.lib.local_lambda_service import LocalLambdaService
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
@@ -58,22 +59,24 @@ def cli(ctx,
         host, port,
 
         # Common Options for Lambda Invoke
-        template, env_vars, debug_port, debug_args, docker_volume_basedir,
+        template, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
         docker_network, log_file, skip_pull_image, profile
         ):
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(ctx, host, port, template, env_vars, debug_port, debug_args, docker_volume_basedir,
+    do_cli(ctx, host, port, template, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
            docker_network, log_file, skip_pull_image, profile)  # pragma: no cover
 
 
 def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylint: disable=R0914
-           docker_volume_basedir, docker_network, log_file, skip_pull_image, profile):
+           debugger_path, docker_volume_basedir, docker_network, log_file, skip_pull_image, profile):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
 
     LOG.debug("local start_lambda command is called")
+
+    debug_context = DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)
 
     # Pass all inputs to setup necessary context to invoke function locally.
     # Handler exception raised by the processor for invalid args and print errors
@@ -82,8 +85,7 @@ def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylin
         with InvokeContext(template_file=template,
                            function_identifier=None,  # Don't scope to one particular function
                            env_vars_file=env_vars,
-                           debug_port=debug_port,
-                           debug_args=debug_args,
+                           debug_context=debug_context,
                            docker_volume_basedir=docker_volume_basedir,
                            docker_network=docker_network,
                            log_file=log_file,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -8,7 +8,6 @@ import click
 from samcli.cli.main import pass_context, common_options as cli_framework_options
 from samcli.commands.local.cli_common.options import invoke_common_options, service_common_options
 from samcli.commands.local.cli_common.invoke_context import InvokeContext
-from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.commands.local.cli_common.user_exceptions import UserException
 from samcli.commands.local.lib.local_lambda_service import LocalLambdaService
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
@@ -76,8 +75,6 @@ def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylin
 
     LOG.debug("local start_lambda command is called")
 
-    debug_context = DebugContext(debug_port=debug_port, debug_args=debug_args, debugger_path=debugger_path)
-
     # Pass all inputs to setup necessary context to invoke function locally.
     # Handler exception raised by the processor for invalid args and print errors
 
@@ -85,12 +82,14 @@ def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylin
         with InvokeContext(template_file=template,
                            function_identifier=None,  # Don't scope to one particular function
                            env_vars_file=env_vars,
-                           debug_context=debug_context,
                            docker_volume_basedir=docker_volume_basedir,
                            docker_network=docker_network,
                            log_file=log_file,
                            skip_pull_image=skip_pull_image,
-                           aws_profile=profile) as invoke_context:
+                           aws_profile=profile,
+                           debug_port=debug_port,
+                           debug_args=debug_args,
+                           debugger_path=debugger_path) as invoke_context:
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context,
                                          port=port,

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -33,7 +33,9 @@ class Container(object):
                  exposed_ports=None,
                  entrypoint=None,
                  env_vars=None,
-                 docker_client=None):
+                 docker_client=None,
+                 container_opts=None,
+                 additional_volumes=None):
         """
         Initializes the class with given configuration. This does not automatically create or run the container.
 
@@ -57,6 +59,8 @@ class Container(object):
         self._env_vars = env_vars
         self._memory_limit_mb = memory_limit_mb
         self._network_id = None
+        self._container_opts = container_opts
+        self._additional_volumes = additional_volumes
 
         # Use the given Docker client or create new one
         self.docker_client = docker_client or docker.from_env()
@@ -94,6 +98,12 @@ class Container(object):
             "tty": False
         }
 
+        if self._container_opts:
+            kwargs.update(self._container_opts)
+
+        if self._additional_volumes:
+            kwargs["volumes"].update(self._additional_volumes)
+
         if self._env_vars:
             kwargs["environment"] = self._env_vars
 
@@ -120,7 +130,6 @@ class Container(object):
         """
         Removes a container that was created earlier.
         """
-
         if not self.is_created():
             LOG.debug("Container was not created. Skipping deletion")
             return

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -38,7 +38,13 @@ class LambdaContainer(Container):
 
     _IMAGE_REPO_NAME = "lambci/lambda"
     _WORKING_DIR = "/var/task"
-    _DEFAULT_CONTAINER_DEBUG_PATH = "/tmp/lambci_debug_files/dlv"
+
+    # The Volume Mount path for debug files in docker
+    _DEBUGGER_VOLUME_MOUNT_PATH = "/tmp/lambci_debug_files"
+    _DEFAULT_CONTAINER_DBG_GO_PATH = _DEBUGGER_VOLUME_MOUNT_PATH + "/dlv"
+
+    # This is the dictionary that represents where the debugger_path arg is mounted in docker to as readonly.
+    _DEBUGGER_VOLUME_MOUNT = {"bind": _DEBUGGER_VOLUME_MOUNT_PATH, "mode": "ro"}
 
     def __init__(self,
                  runtime,
@@ -131,10 +137,7 @@ class LambdaContainer(Container):
             return None
 
         return {
-            debug_options.debugger_path: {
-                "bind": "/tmp/lambci_debug_files",
-                "mode": "ro"
-            }
+            debug_options.debugger_path: LambdaContainer._DEBUGGER_VOLUME_MOUNT
         }
 
     @staticmethod
@@ -195,7 +198,7 @@ class LambdaContainer(Container):
                 + [
                     "-debug=true",
                     "-delvePort=" + str(debug_port),
-                    "-delvePath=" + LambdaContainer._DEFAULT_CONTAINER_DEBUG_PATH,
+                    "-delvePath=" + LambdaContainer._DEFAULT_CONTAINER_DBG_GO_PATH,
                   ]
 
         elif runtime == Runtime.nodejs.value:

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -37,8 +37,7 @@ class LambdaRuntime(object):
     def invoke(self,
                function_config,
                event,
-               debug_port=None,
-               debug_args=None,
+               debug_context=None,
                stdout=None,
                stderr=None):
         """
@@ -53,8 +52,7 @@ class LambdaRuntime(object):
 
         :param FunctionConfig function_config: Configuration of the function to invoke
         :param event: String input event passed to Lambda function
-        :param integer debug_port: Optional, port to attach debugger to
-        :param string debug_args: Optional, additional args to pass to debugger
+        :param DebugContext debug_context: Debugging context for the function (includes port, args, and path)
         :param io.IOBase stdout: Optional. IO Stream to that receives stdout text from container.
         :param io.IOBase stderr: Optional. IO Stream that receives stderr text from container
         :raises Keyboard
@@ -68,14 +66,12 @@ class LambdaRuntime(object):
         env_vars = environ.resolve()
 
         with self._get_code_dir(function_config.code_abs_path) as code_dir:
-
             container = LambdaContainer(function_config.runtime,
                                         function_config.handler,
                                         code_dir,
                                         memory_mb=function_config.memory,
                                         env_vars=env_vars,
-                                        debug_port=debug_port,
-                                        debug_args=debug_args)
+                                        debug_options=debug_context)
 
             try:
 
@@ -90,7 +86,7 @@ class LambdaRuntime(object):
                 timer = self._configure_interrupt(function_config.name,
                                                   function_config.timeout,
                                                   container,
-                                                  bool(debug_port))
+                                                  bool(debug_context))
 
                 # NOTE: BLOCKING METHOD
                 # Block the thread waiting to fetch logs from the container. This method will return after container

--- a/tests/functional/commands/local/lib/test_local_api_service.py
+++ b/tests/functional/commands/local/lib/test_local_api_service.py
@@ -66,7 +66,7 @@ class TestFunctionalLocalLambda(TestCase):
         manager = ContainerManager()
         local_runtime = LambdaRuntime(manager)
         lambda_runner = LocalLambdaRunner(local_runtime, self.mock_function_provider, self.cwd, env_vars_values=None,
-                                          debug_args=None, debug_port=None, aws_profile=None)
+                                          debug_context=None, aws_profile=None)
         self.lambda_invoke_context_mock.local_lambda_runner = lambda_runner
         self.lambda_invoke_context_mock.get_cwd.return_value = self.cwd
 
@@ -74,8 +74,8 @@ class TestFunctionalLocalLambda(TestCase):
         shutil.rmtree(self.code_abs_path)
 
     @patch("samcli.commands.local.lib.local_api_service.SamApiProvider")
-    def test_must_start_service_and_serve_endpoints(self, SamApiProviderMock):
-        SamApiProviderMock.return_value = self.api_provider_mock
+    def test_must_start_service_and_serve_endpoints(self, sam_api_provider_mock):
+        sam_api_provider_mock.return_value = self.api_provider_mock
 
         local_service = LocalApiService(self.lambda_invoke_context_mock,
                                         self.port,
@@ -94,8 +94,8 @@ class TestFunctionalLocalLambda(TestCase):
         self.assertEquals(response.status_code, 403)  # "HTTP GET /post" must not exist
 
     @patch("samcli.commands.local.lib.local_api_service.SamApiProvider")
-    def test_must_serve_static_files(self, SamApiProviderMock):
-        SamApiProviderMock.return_value = self.api_provider_mock
+    def test_must_serve_static_files(self, sam_api_provider_mock):
+        sam_api_provider_mock.return_value = self.api_provider_mock
 
         local_service = LocalApiService(self.lambda_invoke_context_mock,
                                         self.port,

--- a/tests/functional/commands/local/lib/test_local_lambda.py
+++ b/tests/functional/commands/local/lib/test_local_lambda.py
@@ -67,7 +67,7 @@ class TestFunctionalLocalLambda(TestCase):
         manager = ContainerManager()
         local_runtime = LambdaRuntime(manager)
         runner = LocalLambdaRunner(local_runtime, self.mock_function_provider, self.cwd, self.env_var_overrides,
-                                   debug_args=None, debug_port=None, aws_profile=None)
+                                   debug_context=None, aws_profile=None)
 
         # Append the real AWS credentials to the expected values.
         creds = runner.get_aws_creds()

--- a/tests/functional/local/docker/test_lambda_container.py
+++ b/tests/functional/local/docker/test_lambda_container.py
@@ -11,6 +11,7 @@ import six
 from contextlib import contextmanager
 from unittest import TestCase
 
+from samcli.commands.local.lib.debug_context import DebugContext
 from tests.functional.function_code import nodejs_lambda
 from samcli.local.docker.lambda_container import LambdaContainer
 from samcli.local.docker.manager import ContainerManager
@@ -47,6 +48,9 @@ class TestLambdaContainer(TestCase):
         self.expected_docker_image = self.IMAGE_NAME
         self.handler = "index.handler"
         self.debug_port = _rand_port()
+        self.debug_context = DebugContext(debug_port=self.debug_port,
+                                          debugger_path=None,
+                                          debug_args=None)
         self.code_dir = nodejs_lambda(self.HELLO_WORLD_CODE)
         self.network_prefix = "sam_cli_test_network"
 
@@ -79,7 +83,7 @@ class TestLambdaContainer(TestCase):
 
     def test_debug_port_is_created_on_host(self):
 
-        container = LambdaContainer(self.runtime, self.handler, self.code_dir, debug_port=self.debug_port)
+        container = LambdaContainer(self.runtime, self.handler, self.code_dir, debug_options=self.debug_context)
 
         with self._create(container):
 

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -32,13 +32,12 @@ class TestInvokeContext__enter__(TestCase):
         invoke_context = InvokeContext(template_file=template_file,
                                        function_identifier="id",
                                        env_vars_file=env_vars_file,
-                                       debug_port=123,
-                                       debug_args="args",
                                        docker_volume_basedir="volumedir",
                                        docker_network="network",
                                        log_file=log_file,
                                        skip_pull_image=True,
-                                       aws_profile="profile")
+                                       aws_profile="profile",
+                                       debug_context=None)
 
         template_dict = "template_dict"
         invoke_context._get_template_data = Mock()
@@ -105,13 +104,12 @@ class TestInvokeContextAsContextManager(TestCase):
         with InvokeContext(template_file="template_file",
                            function_identifier="id",
                            env_vars_file="env_vars_file",
-                           debug_port=123,
-                           debug_args="args",
                            docker_volume_basedir="volumedir",
                            docker_network="network",
                            log_file="log_file",
                            skip_pull_image=True,
-                           aws_profile="profile") as context:
+                           aws_profile="profile",
+                           debug_context=None) as context:
             self.assertEquals(context_obj, context)
 
         EnterMock.assert_called_with()
@@ -152,8 +150,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
         self.context = InvokeContext(template_file="template_file",
                                      function_identifier="id",
                                      env_vars_file="env_vars_file",
-                                     debug_port=123,
-                                     debug_args="args",
+                                     debug_context=None,
                                      docker_volume_basedir="volumedir",
                                      docker_network="network",
                                      log_file="log_file",
@@ -187,9 +184,8 @@ class TestInvokeContext_local_lambda_runner(TestCase):
         LocalLambdaMock.assert_called_with(local_runtime=runtime_mock,
                                            function_provider=ANY,
                                            cwd=cwd,
+                                           debug_context=None,
                                            env_vars_values=ANY,
-                                           debug_port=123,
-                                           debug_args="args",
                                            aws_profile="profile")
 
 

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 from mock import patch, Mock
 from parameterized import parameterized, param
 
-from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.exceptions import UserException
@@ -31,14 +30,13 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.invoke.cli.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
-    @patch("samcli.commands.local.invoke.cli._get_debug_context")
-    def test_cli_must_setup_context_and_invoke(self, get_debug_context_mock, get_event_mock, InvokeContextMock):
+    @patch("samcli.commands.local.invoke.cli.DebugContext")
+    def test_cli_must_setup_context_and_invoke(self, debug_context, get_event_mock, InvokeContextMock):
         event_data = "data"
         get_event_mock.return_value = event_data
 
-        debug_context_data = DebugContext(debug_port=self.debug_port, debug_args=self.debug_args,
-                                          debugger_path=self.debugger_path)
-        get_debug_context_mock.return_value = debug_context_data
+        debug_context_mock = Mock()
+        debug_context.return_value = debug_context_mock
 
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
@@ -61,7 +59,7 @@ class TestCli(TestCase):
         InvokeContextMock.assert_called_with(template_file=self.template,
                                              function_identifier=self.function_id,
                                              env_vars_file=self.env_vars,
-                                             debug_context=debug_context_data,
+                                             debug_context=debug_context_mock,
                                              docker_volume_basedir=self.docker_volume_basedir,
                                              docker_network=self.docker_network,
                                              log_file=self.log_file,

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from mock import patch, Mock
 from parameterized import parameterized, param
 
+from samcli.commands.local.lib.debug_context import DebugContext
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.exceptions import UserException
@@ -21,6 +22,7 @@ class TestCli(TestCase):
         self.env_vars = "env-vars"
         self.debug_port = 123
         self.debug_args = "args"
+        self.debugger_path = "/test/path"
         self.docker_volume_basedir = "basedir"
         self.docker_network = "network"
         self.log_file = "logfile"
@@ -29,9 +31,14 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.invoke.cli.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
-    def test_cli_must_setup_context_and_invoke(self, get_event_mock, InvokeContextMock):
+    @patch("samcli.commands.local.invoke.cli._get_debug_context")
+    def test_cli_must_setup_context_and_invoke(self, get_debug_context_mock, get_event_mock, InvokeContextMock):
         event_data = "data"
         get_event_mock.return_value = event_data
+
+        debug_context_data = DebugContext(debug_port=self.debug_port, debug_args=self.debug_args,
+                                          debugger_path=self.debugger_path)
+        get_debug_context_mock.return_value = debug_context_data
 
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
@@ -44,6 +51,7 @@ class TestCli(TestCase):
                    env_vars=self.env_vars,
                    debug_port=self.debug_port,
                    debug_args=self.debug_args,
+                   debugger_path=self.debugger_path,
                    docker_volume_basedir=self.docker_volume_basedir,
                    docker_network=self.docker_network,
                    log_file=self.log_file,
@@ -53,8 +61,7 @@ class TestCli(TestCase):
         InvokeContextMock.assert_called_with(template_file=self.template,
                                              function_identifier=self.function_id,
                                              env_vars_file=self.env_vars,
-                                             debug_port=self.debug_port,
-                                             debug_args=self.debug_args,
+                                             debug_context=debug_context_data,
                                              docker_volume_basedir=self.docker_volume_basedir,
                                              docker_network=self.docker_network,
                                              log_file=self.log_file,
@@ -88,6 +95,7 @@ class TestCli(TestCase):
                        env_vars=self.env_vars,
                        debug_port=self.debug_port,
                        debug_args=self.debug_args,
+                       debugger_path=self.debugger_path,
                        docker_volume_basedir=self.docker_volume_basedir,
                        docker_network=self.docker_network,
                        log_file=self.log_file,
@@ -114,6 +122,7 @@ class TestCli(TestCase):
                        env_vars=self.env_vars,
                        debug_port=self.debug_port,
                        debug_args=self.debug_args,
+                       debugger_path=self.debugger_path,
                        docker_volume_basedir=self.docker_volume_basedir,
                        docker_network=self.docker_network,
                        log_file=self.log_file,

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -30,13 +30,9 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.invoke.cli.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
-    @patch("samcli.commands.local.invoke.cli.DebugContext")
-    def test_cli_must_setup_context_and_invoke(self, debug_context, get_event_mock, InvokeContextMock):
+    def test_cli_must_setup_context_and_invoke(self, get_event_mock, InvokeContextMock):
         event_data = "data"
         get_event_mock.return_value = event_data
-
-        debug_context_mock = Mock()
-        debug_context.return_value = debug_context_mock
 
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
@@ -59,12 +55,14 @@ class TestCli(TestCase):
         InvokeContextMock.assert_called_with(template_file=self.template,
                                              function_identifier=self.function_id,
                                              env_vars_file=self.env_vars,
-                                             debug_context=debug_context_mock,
                                              docker_volume_basedir=self.docker_volume_basedir,
                                              docker_network=self.docker_network,
                                              log_file=self.log_file,
                                              skip_pull_image=self.skip_pull_image,
-                                             aws_profile=self.profile)
+                                             aws_profile=self.profile,
+                                             debug_port=self.debug_port,
+                                             debug_args=self.debug_args,
+                                             debugger_path=self.debugger_path)
 
         context_mock.local_lambda_runner.invoke.assert_called_with(context_mock.function_name,
                                                                    event=event_data,

--- a/tests/unit/commands/local/lib/test_debug_context.py
+++ b/tests/unit/commands/local/lib/test_debug_context.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from samcli.commands.local.lib.debug_context import DebugContext
+
+
+class TestDebugContext(TestCase):
+
+    def test_init(self):
+        context = DebugContext('port', 'debuggerpath', 'debug_args')
+
+        self.assertEquals(context.debug_port, 'port')
+        self.assertEquals(context.debugger_path, 'debuggerpath')
+        self.assertEquals(context.debug_args, 'debug_args')
+
+    @parameterized.expand([
+        ('1000', 'debuggerpath', 'debug_args'),
+        ('1000', None, None),
+        ('1000', None, 'debug_args'),
+        ('1000', 'debuggerpath', None),
+        (1000, 'debuggerpath', 'debug_args'),
+        (1000, None, None),
+        (1000, None, 'debug_args'),
+        (1000, 'debuggerpath', None)
+    ])
+    def test_bool_truthy(self, port, debug_path, debug_ars):
+        debug_context = DebugContext(port, debug_path, debug_ars)
+
+        self.assertTrue(debug_context.__bool__())
+
+    @parameterized.expand([
+        (None, 'debuggerpath', 'debug_args'),
+        (None, None, None),
+        (None, None, 'debug_args'),
+        (None, 'debuggerpath', None),
+    ])
+    def test_bool_falsy(self, port, debug_path, debug_ars):
+        debug_context = DebugContext(port, debug_path, debug_ars)
+
+        self.assertFalse(debug_context.__bool__())
+
+    @parameterized.expand([
+        ('1000', 'debuggerpath', 'debug_args'),
+        ('1000', None, None),
+        ('1000', None, 'debug_args'),
+        ('1000', 'debuggerpath', None),
+        (1000, 'debuggerpath', 'debug_args'),
+        (1000, None, None),
+        (1000, None, 'debug_args'),
+        (1000, 'debuggerpath', None)
+    ])
+    def test_nonzero_thruthy(self, port, debug_path, debug_ars):
+        debug_context = DebugContext(port, debug_path, debug_ars)
+
+        self.assertTrue(debug_context.__nonzero__())
+
+    @parameterized.expand([
+        (None, 'debuggerpath', 'debug_args'),
+        (None, None, None),
+        (None, None, 'debug_args'),
+        (None, 'debuggerpath', None)
+    ])
+    def test_nonzero_falsy(self, port, debug_path, debug_ars):
+        debug_context = DebugContext(port, debug_path, debug_ars)
+
+        self.assertFalse(debug_context.__nonzero__())

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -24,17 +24,15 @@ class TestLocalLambda_get_aws_creds(TestCase):
         self.function_provider_mock = Mock()
         self.cwd = "cwd"
         self.env_vars_values = {}
-        self.debug_port = 123
-        self.debug_args = "abc"
+        self.debug_context = None
         self.aws_profile = "myprofile"
 
         self.local_lambda = LocalLambdaRunner(self.runtime_mock,
                                               self.function_provider_mock,
                                               self.cwd,
-                                              self.env_vars_values,
-                                              self.debug_port,
-                                              self.debug_args,
-                                              self.aws_profile)
+                                              env_vars_values=self.env_vars_values,
+                                              debug_context=self.debug_context,
+                                              aws_profile=self.aws_profile)
 
     @patch("samcli.commands.local.lib.local_lambda.boto3")
     def test_must_get_from_boto_session(self, boto3_mock):
@@ -187,8 +185,7 @@ class TestLocalLambda_get_code_path(TestCase):
         self.function_provider_mock = Mock()
         self.cwd = "/my/current/working/directory"
         self.env_vars_values = {}
-        self.debug_port = 123
-        self.debug_args = "abc"
+        self.debug_context = None
         self.aws_profile = "myprofile"
 
         self.relative_codeuri = "./my/path"
@@ -198,10 +195,9 @@ class TestLocalLambda_get_code_path(TestCase):
         self.local_lambda = LocalLambdaRunner(self.runtime_mock,
                                               self.function_provider_mock,
                                               self.cwd,
-                                              self.env_vars_values,
-                                              self.debug_port,
-                                              self.debug_args,
-                                              self.aws_profile)
+                                              env_vars_values=self.env_vars_values,
+                                              aws_profile=self.aws_profile,
+                                              debug_context=self.debug_context)
 
     @parameterized.expand([
         ("."),
@@ -267,8 +263,7 @@ class TestLocalLambda_make_env_vars(TestCase):
         self.runtime_mock = Mock()
         self.function_provider_mock = Mock()
         self.cwd = "/my/current/working/directory"
-        self.debug_port = 123
-        self.debug_args = "abc"
+        self.debug_context = None
         self.aws_profile = "myprofile"
         self.env_vars_values = {}
 
@@ -281,10 +276,9 @@ class TestLocalLambda_make_env_vars(TestCase):
         self.local_lambda = LocalLambdaRunner(self.runtime_mock,
                                               self.function_provider_mock,
                                               self.cwd,
-                                              self.env_vars_values,
-                                              self.debug_port,
-                                              self.debug_args,
-                                              self.aws_profile)
+                                              env_vars_values=self.env_vars_values,
+                                              debug_context=self.debug_context,
+                                              aws_profile=self.aws_profile)
 
         self.aws_creds = {"key": "key"}
         self.local_lambda.get_aws_creds = Mock()
@@ -367,18 +361,16 @@ class TestLocalLambda_get_invoke_config(TestCase):
         self.runtime_mock = Mock()
         self.function_provider_mock = Mock()
         self.cwd = "/my/current/working/directory"
-        self.debug_port = 123
-        self.debug_args = "abc"
         self.aws_profile = "myprofile"
+        self.debug_context = None
         self.env_vars_values = {}
 
         self.local_lambda = LocalLambdaRunner(self.runtime_mock,
                                               self.function_provider_mock,
                                               self.cwd,
-                                              self.env_vars_values,
-                                              self.debug_port,
-                                              self.debug_args,
-                                              self.aws_profile)
+                                              env_vars_values=self.env_vars_values,
+                                              aws_profile=self.aws_profile,
+                                              debug_context=self.debug_context)
 
     @patch('samcli.commands.local.lib.local_lambda.FunctionConfig')
     def test_must_work(self, FunctionConfigMock):
@@ -422,18 +414,16 @@ class TestLocalLambda_invoke(TestCase):
         self.runtime_mock = Mock()
         self.function_provider_mock = Mock()
         self.cwd = "/my/current/working/directory"
-        self.debug_port = 123
-        self.debug_args = "abc"
+        self.debug_context = None
         self.aws_profile = "myprofile"
         self.env_vars_values = {}
 
         self.local_lambda = LocalLambdaRunner(self.runtime_mock,
                                               self.function_provider_mock,
                                               self.cwd,
-                                              self.env_vars_values,
-                                              self.debug_port,
-                                              self.debug_args,
-                                              self.aws_profile)
+                                              env_vars_values=self.env_vars_values,
+                                              aws_profile=self.aws_profile,
+                                              debug_context=self.debug_context)
 
     def test_must_work(self):
         name = "name"
@@ -450,8 +440,7 @@ class TestLocalLambda_invoke(TestCase):
         self.local_lambda.invoke(name, event, stdout, stderr)
 
         self.runtime_mock.invoke.assert_called_with(invoke_config, event,
-                                                    debug_port=self.debug_port,
-                                                    debug_args=self.debug_args,
+                                                    debug_context=None,
                                                     stdout=stdout, stderr=stderr)
 
     def test_must_raise_if_function_not_found(self):
@@ -467,18 +456,16 @@ class TestLocalLambda_is_debugging(TestCase):
         self.runtime_mock = Mock()
         self.function_provider_mock = Mock()
         self.cwd = "/my/current/working/directory"
-        self.debug_port = 123
-        self.debug_args = "abc"
+        self.debug_context = Mock()
         self.aws_profile = "myprofile"
         self.env_vars_values = {}
 
         self.local_lambda = LocalLambdaRunner(self.runtime_mock,
                                               self.function_provider_mock,
                                               self.cwd,
-                                              self.env_vars_values,
-                                              self.debug_port,
-                                              self.debug_args,
-                                              self.aws_profile)
+                                              env_vars_values=self.env_vars_values,
+                                              aws_profile=self.aws_profile,
+                                              debug_context=self.debug_context)
 
     def test_must_be_on(self):
         self.assertTrue(self.local_lambda.is_debugging())
@@ -488,9 +475,8 @@ class TestLocalLambda_is_debugging(TestCase):
         self.local_lambda = LocalLambdaRunner(self.runtime_mock,
                                               self.function_provider_mock,
                                               self.cwd,
-                                              self.env_vars_values,
-                                              debug_port=None,  # No debug port
-                                              debug_args=self.debug_args,
+                                              env_vars_values=self.env_vars_values,
+                                              debug_context=None,
                                               aws_profile=self.aws_profile)
 
         self.assertFalse(self.local_lambda.is_debugging())

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -31,8 +31,7 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.start_api.cli.InvokeContext")
     @patch("samcli.commands.local.start_api.cli.LocalApiService")
-    @patch("samcli.commands.local.start_api.cli.DebugContext")
-    def test_cli_must_setup_context_and_start_service(self, debug_context, local_api_service_mock,
+    def test_cli_must_setup_context_and_start_service(self, local_api_service_mock,
                                                       invoke_context_mock):
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
@@ -41,28 +40,24 @@ class TestCli(TestCase):
         service_mock = Mock()
         local_api_service_mock.return_value = service_mock
 
-        debug_context_mock = Mock()
-        debug_context.return_value = debug_context_mock
-
         self.call_cli()
 
         invoke_context_mock.assert_called_with(template_file=self.template,
                                                function_identifier=None,
                                                env_vars_file=self.env_vars,
-                                               debug_context=debug_context_mock,
                                                docker_volume_basedir=self.docker_volume_basedir,
                                                docker_network=self.docker_network,
                                                log_file=self.log_file,
                                                skip_pull_image=self.skip_pull_image,
-                                               aws_profile=self.profile)
+                                               aws_profile=self.profile,
+                                               debug_port=self.debug_port,
+                                               debug_args=self.debug_args,
+                                               debugger_path=self.debugger_path)
 
         local_api_service_mock.assert_called_with(lambda_invoke_context=context_mock,
                                                   port=self.port,
                                                   host=self.host,
                                                   static_dir=self.static_dir)
-
-        debug_context.assert_called_with(debug_port=self.debug_port, debug_args=self.debug_args,
-                                         debugger_path=self.debugger_path)
 
         service_mock.start.assert_called_with()
 

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -25,8 +25,7 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
     @patch("samcli.commands.local.start_lambda.cli.LocalLambdaService")
-    @patch("samcli.commands.local.start_lambda.cli.DebugContext")
-    def test_cli_must_setup_context_and_start_service(self, debug_context, local_lambda_service_mock,
+    def test_cli_must_setup_context_and_start_service(self, local_lambda_service_mock,
                                                       invoke_context_mock):
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
@@ -35,27 +34,23 @@ class TestCli(TestCase):
         service_mock = Mock()
         local_lambda_service_mock.return_value = service_mock
 
-        debug_context_mock = Mock()
-        debug_context.return_value = debug_context_mock
-
         self.call_cli()
 
         invoke_context_mock.assert_called_with(template_file=self.template,
                                                function_identifier=None,
                                                env_vars_file=self.env_vars,
-                                               debug_context=debug_context_mock,
                                                docker_volume_basedir=self.docker_volume_basedir,
                                                docker_network=self.docker_network,
                                                log_file=self.log_file,
                                                skip_pull_image=self.skip_pull_image,
-                                               aws_profile=self.profile)
+                                               aws_profile=self.profile,
+                                               debug_port=self.debug_port,
+                                               debug_args=self.debug_args,
+                                               debugger_path=self.debugger_path)
 
         local_lambda_service_mock.assert_called_with(lambda_invoke_context=context_mock,
                                                      port=self.port,
                                                      host=self.host)
-
-        debug_context.assert_called_with(debug_port=self.debug_port, debug_args=self.debug_args,
-                                         debugger_path=self.debugger_path)
 
         service_mock.start.assert_called_with()
 

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -13,6 +13,7 @@ class TestCli(TestCase):
         self.env_vars = "env-vars"
         self.debug_port = 123
         self.debug_args = "args"
+        self.debugger_path = "/test/path"
         self.docker_volume_basedir = "basedir"
         self.docker_network = "network"
         self.log_file = "logfile"
@@ -24,7 +25,9 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
     @patch("samcli.commands.local.start_lambda.cli.LocalLambdaService")
-    def test_cli_must_setup_context_and_start_service(self, local_lambda_service_mock, invoke_context_mock):
+    @patch("samcli.commands.local.start_lambda.cli.DebugContext")
+    def test_cli_must_setup_context_and_start_service(self, debug_context, local_lambda_service_mock,
+                                                      invoke_context_mock):
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
         invoke_context_mock.return_value.__enter__.return_value = context_mock
@@ -32,13 +35,15 @@ class TestCli(TestCase):
         service_mock = Mock()
         local_lambda_service_mock.return_value = service_mock
 
+        debug_context_mock = Mock()
+        debug_context.return_value = debug_context_mock
+
         self.call_cli()
 
         invoke_context_mock.assert_called_with(template_file=self.template,
                                                function_identifier=None,
                                                env_vars_file=self.env_vars,
-                                               debug_port=self.debug_port,
-                                               debug_args=self.debug_args,
+                                               debug_context=debug_context_mock,
                                                docker_volume_basedir=self.docker_volume_basedir,
                                                docker_network=self.docker_network,
                                                log_file=self.log_file,
@@ -48,6 +53,9 @@ class TestCli(TestCase):
         local_lambda_service_mock.assert_called_with(lambda_invoke_context=context_mock,
                                                      port=self.port,
                                                      host=self.host)
+
+        debug_context.assert_called_with(debug_port=self.debug_port, debug_args=self.debug_args,
+                                         debugger_path=self.debugger_path)
 
         service_mock.start.assert_called_with()
 
@@ -70,6 +78,7 @@ class TestCli(TestCase):
                          env_vars=self.env_vars,
                          debug_port=self.debug_port,
                          debug_args=self.debug_args,
+                         debugger_path=self.debugger_path,
                          docker_volume_basedir=self.docker_volume_basedir,
                          docker_network=self.docker_network,
                          log_file=self.log_file,

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -58,6 +58,8 @@ class TestContainer_create(TestCase):
         self.exposed_ports = {123: 123}
         self.entrypoint = ["a", "b", "c"]
         self.env_vars = {"key": "value"}
+        self.container_opts = {"container": "opts"}
+        self.additional_volumes = {'/somepath': {"blah": "blah value"}}
 
         self.mock_docker_client = Mock()
         self.mock_docker_client.containers = Mock()
@@ -108,7 +110,8 @@ class TestContainer_create(TestCase):
             self.host_dir: {
                 "bind": self.working_dir,
                 "mode": "ro"
-            }
+            },
+            '/somepath': {"blah": "blah value"}
         }
         expected_memory = "{}m".format(self.memory_mb)
 
@@ -124,7 +127,10 @@ class TestContainer_create(TestCase):
                               exposed_ports=self.exposed_ports,
                               entrypoint=self.entrypoint,
                               env_vars=self.env_vars,
-                              docker_client=self.mock_docker_client)
+                              docker_client=self.mock_docker_client,
+                              container_opts=self.container_opts,
+                              additional_volumes=self.additional_volumes
+                              )
 
         container_id = container.create()
         self.assertEquals(container_id, generated_id)
@@ -138,7 +144,9 @@ class TestContainer_create(TestCase):
                                                                      environment=self.env_vars,
                                                                      ports=self.exposed_ports,
                                                                      entrypoint=self.entrypoint,
-                                                                     mem_limit=expected_memory)
+                                                                     mem_limit=expected_memory,
+                                                                     container='opts'
+                                                                     )
         self.mock_docker_client.networks.get.assert_not_called()
 
     def test_must_connect_to_network_on_create(self):

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -33,13 +33,12 @@ class LambdaRuntime_invoke(TestCase):
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_must_run_container_and_wait_for_logs(self, LambdaContainerMock):
         event = "event"
-        debug_port = 123
-        debug_arg = "abc"
         code_dir = "some code dir"
         stdout = "stdout"
         stderr = "stderr"
         container = Mock()
         timer = Mock()
+        debug_options = Mock()
 
         self.runtime = LambdaRuntime(self.manager_mock)
 
@@ -55,8 +54,7 @@ class LambdaRuntime_invoke(TestCase):
 
         self.runtime.invoke(self.func_config,
                             event,
-                            debug_port=debug_port,
-                            debug_args=debug_arg,
+                            debug_context=debug_options,
                             stdout=stdout,
                             stderr=stderr)
 
@@ -72,7 +70,7 @@ class LambdaRuntime_invoke(TestCase):
         # Make sure the container is created with proper values
         LambdaContainerMock.assert_called_with(self.lang, self.handler, code_dir,
                                                memory_mb=self.DEFAULT_MEMORY, env_vars=self.env_var_value,
-                                               debug_port=debug_port, debug_args=debug_arg)
+                                               debug_options=debug_options)
 
         # Run the container and get results
         self.manager_mock.run.assert_called_with(container)
@@ -86,8 +84,6 @@ class LambdaRuntime_invoke(TestCase):
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_exception_from_run_must_trigger_cleanup(self, LambdaContainerMock):
         event = "event"
-        debug_port = 123
-        debug_arg = "abc"
         code_dir = "some code dir"
         stdout = "stdout"
         stderr = "stderr"
@@ -109,8 +105,7 @@ class LambdaRuntime_invoke(TestCase):
         with self.assertRaises(ValueError):
             self.runtime.invoke(self.func_config,
                                 event,
-                                debug_port=debug_port,
-                                debug_args=debug_arg,
+                                debug_context=None,
                                 stdout=stdout,
                                 stderr=stderr)
 
@@ -128,13 +123,12 @@ class LambdaRuntime_invoke(TestCase):
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_exception_from_wait_for_logs_must_trigger_cleanup(self, LambdaContainerMock):
         event = "event"
-        debug_port = 123
-        debug_arg = "abc"
         code_dir = "some code dir"
         stdout = "stdout"
         stderr = "stderr"
         container = Mock()
         timer = Mock()
+        debug_options = Mock()
 
         self.runtime = LambdaRuntime(self.manager_mock)
 
@@ -151,8 +145,7 @@ class LambdaRuntime_invoke(TestCase):
         with self.assertRaises(ValueError):
             self.runtime.invoke(self.func_config,
                                 event,
-                                debug_port=debug_port,
-                                debug_args=debug_arg,
+                                debug_context=debug_options,
                                 stdout=stdout,
                                 stderr=stderr)
 
@@ -170,8 +163,6 @@ class LambdaRuntime_invoke(TestCase):
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_keyboard_interrupt_must_not_raise(self, LambdaContainerMock):
         event = "event"
-        debug_port = 123
-        debug_arg = "abc"
         code_dir = "some code dir"
         stdout = "stdout"
         stderr = "stderr"
@@ -190,8 +181,6 @@ class LambdaRuntime_invoke(TestCase):
 
         self.runtime.invoke(self.func_config,
                             event,
-                            debug_port=debug_port,
-                            debug_args=debug_arg,
                             stdout=stdout,
                             stderr=stderr)
 


### PR DESCRIPTION
Golang Debugging was initally implemented in #495, but reverted in #526
due to functional and integration tests failures. This commit reverts #526
and adds in the testing gaps. The specific differences are:

* _get_debug_context method was replaces with the __bool__/__nonzero (py2)
* Added additional unit tests for lambda_container to cover added methods
* Updated Functional tests
* Added debug_context support in start-lambda

*Issue #, if available:*
#281

*Description of changes:*

- [x] Run debugger locally with a go function

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
