### PR TITLE
adds anchor & alias support for yaml parser

### DIFF
--- a/samcli/yamlhelper.py
+++ b/samcli/yamlhelper.py
@@ -46,6 +46,17 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     return {cfntag: value}
 
 
+def _resolve_aliases(dict_to_resolve):
+    """
+    Resolves all anchors in a yaml template
+    :param dict_to_resolve
+    :return:
+    """
+    yaml.SafeDumper.ignore_aliases = lambda *args: True
+    return yaml.safe_load(
+        yaml.safe_dump(dict_to_resolve, default_flow_style=False))
+
+
 def yaml_dump(dict_to_dump):
     """
     Dumps the dictionary as a YAML document
@@ -64,4 +75,4 @@ def yaml_parse(yamlstr):
         return json.loads(yamlstr)
     except ValueError:
         yaml.SafeLoader.add_multi_constructor("!", intrinsics_multi_constructor)
-        return yaml.safe_load(yamlstr)
+        return _resolve_aliases(yaml.safe_load(yamlstr))

--- a/tests/unit/test_yamlhelper.py
+++ b/tests/unit/test_yamlhelper.py
@@ -46,6 +46,29 @@ class TestYaml(TestCase):
         }
     }
 
+    yaml_with_aliases = """
+    Resource:
+        Foobar: &Foobar
+            Qux: Quux
+            Overridable: unknown
+        Baz:
+            <<: *Foobar
+            Overridable: True
+    """
+
+    parsed_yaml_with_aliases = {
+        "Resource": {
+            "Foobar": {
+                "Qux": "Quux",
+                "Overridable": "unknown"
+            },
+            "Baz": {
+                "Qux": "Quux",
+                "Overridable": True
+            }
+        }
+    }
+
     def test_yaml_with_tags(self):
         output = yaml_parse(self.yaml_with_tags)
         self.assertEquals(self.parsed_yaml_dict, output)
@@ -73,6 +96,10 @@ class TestYaml(TestCase):
 
         actual_output = yaml_parse(input)
         self.assertEquals(actual_output, output)
+
+    def test_yaml_aliases_resolution(self):
+        output = yaml_parse(self.yaml_with_aliases)
+        self.assertEquals(self.parsed_yaml_with_aliases, output)
 
     def test_parse_json_with_tabs(self):
         template = '{\n\t"foo": "bar"\n}'


### PR DESCRIPTION
*Issue #, if available:*

No issue number specifically, but this has been mentioned before in several cases and a feature I wanted natively in CloudFormation but we aren't going to get anytime soon. (ex: https://github.com/awslabs/serverless-application-model/issues/228)

*Description of changes:*

This simply enhances the yaml parser in exactly the same way I propose the aws-cli does (https://github.com/aws/aws-cli/pull/3462). Mostly just making sure we maintain consistency across the platform.

Important to note, this is doing _nothing_ that nearly all other yaml libs can't do. Take the below template for example and plug it in to http://yaml-online-parser.appspot.com and you'll get perfectly valid json outputs with no additional logic. Of course, you would still need `aws cloudformation package` to populate the `CodeUri` but that is a different process.

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Transform: 'AWS::Serverless-2016-10-31'
Description: A starter AWS Lambda function.

Metadata:
  Templates:
    Resources:
      Properties: &Props
        Handler: lambda_function.lambda_handler
        Runtime: python3.6
        CodeUri: .
        Description: A starter AWS Lambda function.
        MemorySize: 128
        Timeout: 3

Resources:
  helloworldpython3:
    Type: 'AWS::Serverless::Function'
    Properties:
      <<: *Props

  helloworldnode:
    Type: 'AWS::Serverless::Function'
    Properties:
      <<: *Props
      Runtime: nodejs8.10
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
