### PR TITLE
Make nodejs8.10 template fully async/await

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/app.js
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/app.js
@@ -27,22 +27,15 @@ exports.lambda_handler = function (event, context, callback) {
         });    
 };
 {% else %}
-exports.lambda_handler = async (event, context, callback) => {
-    try {
-        const ret = await axios(url);
-        response = {
-            'statusCode': 200,
-            'body': JSON.stringify({
-                message: 'hello world',
-                location: ret.data.trim()
-            })
-        }
-    }
-    catch (err) {
-        console.log(err);
-        callback(err, null);
-    }
+exports.lambda_handler = async event => {
+    const ret = await axios(url);
 
-    callback(null, response)
+    return {
+        'statusCode': 200,
+        'body': JSON.stringify({
+            message: 'hello world',
+            location: ret.data.trim()
+        })
+    }
 };
 {% endif %}

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/tests/unit/test_handler.js
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/tests/unit/test_handler.js
@@ -29,17 +29,17 @@ describe('Tests Handler', function () {
 {% else %}
 describe('Tests index', function () {
     it('verifies successful response', async () => {
-        const result = await app.lambda_handler(event, context, (err, result) => {
-            expect(result).to.be.an('object');
-            expect(result.statusCode).to.equal(200);
-            expect(result.body).to.be.an('string');
+        const result = await app.lambda_handler(event);
 
-            let response = JSON.parse(result.body);
+        expect(result).to.be.an('object');
+        expect(result.statusCode).to.equal(200);
+        expect(result.body).to.be.an('string');
 
-            expect(response).to.be.an('object');
-            expect(response.message).to.be.equal("hello world");
-            expect(response.location).to.be.an("string");
-        });
+        let response = JSON.parse(result.body);
+
+        expect(response).to.be.an('object');
+        expect(response.message).to.be.equal("hello world");
+        expect(response.location).to.be.an("string");
     });
 });
 {% endif %}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The current code mixes async/await with callbacks. This is unintuitive
and raises questions about which takes precedence: callback response
values or handler-returned promise resolved values.

The idiomatic way to write such a function is to rely on the return
value from the async handler. This cleans the code up substantially.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
