### PR TITLE
Fix readme: removed cloudtrail, added SNS to match

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -320,8 +320,8 @@ can generate mock/sample event payloads for the following services:
 -  Kinesis
 -  DynamoDB
 -  Cloudwatch Scheduled Event
--  Cloudtrail
 -  API Gateway
+-  SNS
 
 **Syntax**
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Typo in readme:
Removed Cloudtrail entry and added SNS. Cloudtrail doesn't seem to be a valid sample event?

<img width="400" alt="commands" src="https://user-images.githubusercontent.com/15994365/43044054-699f3e18-8de2-11e8-87b6-bedf9213392f.png">

SAM CLI, version 0.5.0
<img width="327" alt="version" src="https://user-images.githubusercontent.com/15994365/43044074-bcd2d4be-8de2-11e8-8c10-774473eb1f74.png">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
