### PR TITLE
Fix stringifying λ environment variables when using Python2

### DIFF
--- a/samcli/local/lambdafn/env_vars.py
+++ b/samcli/local/lambdafn/env_vars.py
@@ -193,6 +193,7 @@ class EnvironmentVariables(object):
             result = "false"
 
         # value is a scalar type like int, str which can be stringified
+        # do not stringify unicode in Py2, Py3 str supports unicode
         elif sys.version_info.major > 2:
             result = str(value)
         elif not isinstance(value, unicode):  # noqa: F821 pylint: disable=undefined-variable

--- a/samcli/local/lambdafn/env_vars.py
+++ b/samcli/local/lambdafn/env_vars.py
@@ -195,7 +195,7 @@ class EnvironmentVariables(object):
         # value is a scalar type like int, str which can be stringified
         elif sys.version_info.major > 2:
             result = str(value)
-        elif not isinstance(value, unicode):
+        elif not isinstance(value, unicode):  # noqa: F821 pylint: disable=undefined-variable
             result = str(value)
         else:
             result = value

--- a/samcli/local/lambdafn/env_vars.py
+++ b/samcli/local/lambdafn/env_vars.py
@@ -2,6 +2,8 @@
 Supplies the environment variables necessary to set up Local Lambda runtime
 """
 
+import sys
+
 
 class EnvironmentVariables(object):
     """
@@ -191,7 +193,11 @@ class EnvironmentVariables(object):
             result = "false"
 
         # value is a scalar type like int, str which can be stringified
-        else:
+        elif sys.version_info.major > 2:
             result = str(value)
+        elif not isinstance(value, unicode):
+            result = str(value)
+        else:
+            result = value
 
         return result

--- a/tests/unit/local/lambdafn/test_env_vars.py
+++ b/tests/unit/local/lambdafn/test_env_vars.py
@@ -325,7 +325,7 @@ class TestEnvironmentVariables_stringify_value(TestCase):
         (False, "false"),
         (1234, "1234"),
         (3.14, "3.14"),
-        (u"mystring", "mystring"),
+        (u"mystring\xe0", u"mystring\xe0"),
         ("mystring", "mystring"),
     ])
     def test_must_stringify(self, input, expected):

--- a/tests/unit/local/lambdafn/test_env_vars.py
+++ b/tests/unit/local/lambdafn/test_env_vars.py
@@ -325,6 +325,7 @@ class TestEnvironmentVariables_stringify_value(TestCase):
         (False, "false"),
         (1234, "1234"),
         (3.14, "3.14"),
+        (u"mystring", "mystring"),
         ("mystring", "mystring"),
     ])
     def test_must_stringify(self, input, expected):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sam-cli/issues/517

*Description of changes:*
Fix stringifying  λ environment variables that are passed when using Python2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
