### PR TITLE
remove json header check and update tests

### DIFF
--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -92,10 +92,6 @@ class LocalLambdaInvokeService(BaseLocalService):
             LOG.debug("Query parameters are in the request but not supported")
             return LambdaErrorResponses.invalid_request_content("Query Parameters are not supported")
 
-        if flask_request.content_type and flask_request.content_type.lower() != "application/json":
-            LOG.debug("%s media type is not supported. Must be application/json", flask_request.content_type)
-            return LambdaErrorResponses.unsupported_media_type(flask_request.content_type)
-
         request_headers = CaseInsensitiveDict(flask_request.headers)
 
         log_type = request_headers.get('X-Amz-Log-Type', 'None')

--- a/tests/functional/local/lambda_service/test_local_lambda_invoke.py
+++ b/tests/functional/local/lambda_service/test_local_lambda_invoke.py
@@ -152,6 +152,16 @@ class TestLocalEchoLambdaService(TestCase):
         self.assertEquals(actual, expected)
         self.assertEquals(response.status_code, 200)
 
+    def test_binary_octet_stream_format(self):
+        expected = {"key1": "value1"}
+
+        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations', json={"key1": "value1"}, headers={"Content-Type":"binary/octet-stream"})
+
+        actual = response.json()
+
+        self.assertEquals(actual, expected)
+        self.assertEquals(response.status_code, 200)
+
     def test_function_executed_when_no_data_provided(self):
         expected = {}
 
@@ -272,19 +282,6 @@ class TestLocalLambdaService_NotSupportedRequests(TestCase):
         self.assertEquals(response.status_code, 501)
         self.assertEquals(response.headers.get('Content-Type'), 'application/json')
         self.assertEquals(response.headers.get('x-amzn-errortype'), 'NotImplemented')
-
-    def test_media_type_is_not_application_json(self):
-        expected = {"Type": "User",
-                    "Message": 'Unsupported content type: image/gif'}
-
-        response = requests.post(self.url + '/2015-03-31/functions/HelloWorld/invocations', headers={'Content-Type':'image/gif'})
-
-        actual = response.json()
-
-        self.assertEquals(actual, expected)
-        self.assertEquals(response.status_code, 415)
-        self.assertEquals(response.headers.get('x-amzn-errortype'), 'UnsupportedMediaType')
-        self.assertEquals(response.headers.get('Content-Type'), 'application/json')
 
     def test_generic_404_error_when_request_to_nonexisting_endpoint(self):
         expected_data = {'Type': 'LocalService', 'Message': 'PathNotFoundException'}

--- a/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
+++ b/tests/unit/local/lambda_service/test_local_lambda_invoke_service.py
@@ -207,23 +207,6 @@ class TestValidateRequestHandling(TestCase):
 
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaErrorResponses')
     @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')
-    def test_request_with_content_type_not_application_json(self, flask_request, lambda_error_responses_mock):
-        flask_request.get_data.return_value = None
-        flask_request.headers = {}
-        flask_request.content_type = 'image/gif'
-        flask_request.args = {}
-
-        lambda_error_responses_mock.unsupported_media_type.return_value = "UnsupportedMediaType"
-
-        response = LocalLambdaInvokeService.validate_request()
-
-        self.assertEquals(response, "UnsupportedMediaType")
-
-        lambda_error_responses_mock.unsupported_media_type.assert_called_once_with(
-            "image/gif")
-
-    @patch('samcli.local.lambda_service.local_lambda_invoke_service.LambdaErrorResponses')
-    @patch('samcli.local.lambda_service.local_lambda_invoke_service.request')
     def test_request_log_type_not_None(self, flask_request, lambda_error_responses_mock):
         flask_request.get_data.return_value = None
         flask_request.headers = {'X-Amz-Log-Type': 'Tail'}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sam-cli/issues/591#issuecomment-409287350

*Description of changes:*
- removed the check for header `application/json`
- removed related tests
- added one test with header `binary/octet-stream`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
