### PR TITLE
"Amazon Kinesis" disambiguation #34

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Main features
 -  Develop and test your Lambda functions locally with ``sam local`` and
    Docker
 -  Invoke functions from known event sources such as Amazon S3, Amazon
-   DynamoDB, Amazon Kinesis, etc.
+   DynamoDB, Amazon Streams, etc.
 -  Start local API Gateway from a SAM template, and quickly iterate over
    your functions with hot-reloading
 -  Validate SAM templates
@@ -324,7 +324,7 @@ To make local development and testing of Lambda functions easier, you
 can generate mock/sample event payloads for the following services:
 
 -  S3
--  Kinesis
+-  Kinesis Streams
 -  DynamoDB
 -  Cloudwatch Scheduled Event
 -  API Gateway

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Main features
 -  Develop and test your Lambda functions locally with ``sam local`` and
    Docker
 -  Invoke functions from known event sources such as Amazon S3, Amazon
-   DynamoDB, Amazon Streams, etc.
+   DynamoDB, Amazon Kinesis Streams, etc.
 -  Start local API Gateway from a SAM template, and quickly iterate over
    your functions with hot-reloading
 -  Validate SAM templates


### PR DESCRIPTION
*Issue #, if available:* 34

*Description of changes:* Change "Kinesis" to "Kinesis Streams" in the README


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
