### PR TITLE
docs: Adding a note directing Windows users to use pipenv

### DIFF
--- a/DEVELOPMENT_GUIDE.rst
+++ b/DEVELOPMENT_GUIDE.rst
@@ -7,6 +7,8 @@ This document will make your life easier by helping you setup a development envi
 or anything that will help you be more productive. If you found something is missing or inaccurate, update this guide
 and send a Pull Request.
 
+**Note**: ``pyenv`` currently only supports macOS and Linux. If you are a Windows users, consider using `pipenv`_.
+
 Environment Setup
 -----------------
 
@@ -105,3 +107,4 @@ best practices that we have learnt over time.
 .. _pyenv: https://github.com/pyenv/pyenv
 .. _tox: http://tox.readthedocs.io/en/latest/
 .. _numpy docstring: https://numpydoc.readthedocs.io/en/latest/format.html
+.. _pipenv: https://docs.pipenv.org/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since pyenv doesn't support Windows, I added a note directing Windows users to use pipenv instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
