### PR TITLE
Remove an extra word in the sam packaging command

### DIFF
--- a/docs/deploying_serverless_applications.rst
+++ b/docs/deploying_serverless_applications.rst
@@ -22,7 +22,7 @@ Next, open a command prompt and type the following:
 .. code:: bash
 
     sam package \
-        --template-file file path/template.yaml \
+        --template-file path/template.yaml \
         --output-template-file packaged.yaml \
         --s3-bucket s3-bucket-name
 


### PR DESCRIPTION
*Description of changes:*
It looks like the packaging command does not require the `file` word between --template-file and the file name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.