### PR TITLE
fix(path): change windows style path to unix

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -6,6 +6,7 @@ import logging
 import docker
 
 from samcli.local.docker.attach_api import attach
+from .utils import to_posix_path
 
 LOG = logging.getLogger(__name__)
 
@@ -103,6 +104,9 @@ class Container(object):
 
         if self._additional_volumes:
             kwargs["volumes"].update(self._additional_volumes)
+
+        # Make sure all mounts are of posix path style.
+        kwargs["volumes"] = {to_posix_path(host_dir): mount for host_dir, mount in kwargs["volumes"].items()}
 
         if self._env_vars:
             kwargs["environment"] = self._env_vars

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -1,0 +1,36 @@
+"""
+Helper methods that aid with changing the mount path to unix style.
+"""
+
+import os
+import posixpath
+import re
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
+
+
+def to_posix_path(code_path):
+    """
+    Change the code_path to be of unix-style if running on windows when supplied with an absolute windows path.
+
+    Parameters
+    ----------
+    code_path : str
+        Directory in the host operating system that should be mounted within the container.
+    Returns
+    -------
+    str
+        Posix equivalent of absolute windows style path.
+    Examples
+    --------
+    >>> to_posix_path('/Users/UserName/sam-app')
+    /Users/UserName/sam-app
+    >>> to_posix_path('C:\\\\Users\\\\UserName\\\\AppData\\\\Local\\\\Temp\\\\mydir')
+    /c/Users/UserName/AppData/Local/Temp/mydir
+    """
+
+    return re.sub("^([A-Za-z])+:",
+                  lambda match: posixpath.sep + match.group().replace(":", "").lower(),
+                  pathlib.PureWindowsPath(code_path).as_posix()) if os.name == "nt" else code_path

--- a/tests/unit/local/docker/test_utils.py
+++ b/tests/unit/local/docker/test_utils.py
@@ -1,0 +1,28 @@
+"""
+Unit test for Utils
+"""
+
+import os
+from unittest import TestCase
+
+from mock import patch
+
+from samcli.local.docker.utils import to_posix_path
+
+
+class TestUtils(TestCase):
+
+    def setUp(self):
+        self.ntpath = "C:\\Users\\UserName\\AppData\\Local\\Temp\\temp1337"
+        self.posixpath = "/c/Users/UserName/AppData/Local/Temp/temp1337"
+        self.current_working_dir = os.getcwd()
+
+    @patch("samcli.local.docker.utils.os")
+    def test_convert_posix_path_if_windows_style_path(self, mock_os):
+        mock_os.name = "nt"
+        self.assertEquals(self.posixpath, to_posix_path(self.ntpath))
+
+    @patch("samcli.local.docker.utils.os")
+    def test_do_not_convert_posix_path(self, mock_os):
+        mock_os.name = "posix"
+        self.assertEquals(self.current_working_dir, to_posix_path(self.current_working_dir))


### PR DESCRIPTION
- On supplying path for docker in windows environments, change path to unix style.
- This allows sam-cli to work with docker toolkit.

*Issue #, if available:*

- https://github.com/awslabs/aws-sam-cli/issues/461

*Description of changes:*

- change windows style paths to unix style paths, to allow operability of the sam cli under windows 8.
- Did testing on windows environment with docker toolbox and docker for windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
