### PR TITLE
Fix casing in NodeJS test initializtion

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/tests/unit/test_handler.js
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/tests/unit/test_handler.js
@@ -8,7 +8,7 @@ var event, context;
 {% if cookiecutter.runtime == 'nodejs6.10' or cookiecutter.runtime == 'nodejs4.3' %}
 describe('Tests Handler', function () {
     it('verifies successful response', function (done) {
-        app.lambda_handler(event, context, function (err, result) {
+        app.lambdaHandler(event, context, function (err, result) {
             try {
                 expect(result).to.be.an('object');
                 expect(result.statusCode).to.equal(200);
@@ -29,7 +29,7 @@ describe('Tests Handler', function () {
 {% else %}
 describe('Tests index', function () {
     it('verifies successful response', async () => {
-        const result = await app.lambda_handler(event, context, (err, result) => {
+        const result = await app.lambdaHandler(event, context, (err, result) => {
             expect(result).to.be.an('object');
             expect(result.statusCode).to.equal(200);
             expect(result.body).to.be.an('string');


### PR DESCRIPTION
On init of NodeJs project, tests were immediately failing because it should have been calling to app.lambdaHandler.

*Issue #, if available:*

*Description of changes:*
Default function for lambdaHandler was changed but this change was not made in the test initialization.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
