### PR TITLE
Fix(installation): Bump Boto3 requirement

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -222,6 +222,18 @@ homebrew and try again:
 
 Once installed then repeat the `Installation process <#windows-linux-macos-with-pip>`_
 
+DistributionNotFound with botocore/boto3
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If after installing/upgrading SAM CLI or AWS CLI, you receive an error something similar to:
+
+::
+
+   pkg_resources.DistributionNotFound: The 'botocore<1.11.0,>=1.10.62' distribution was not found and is required by boto3
+
+then you will need to upgrade the other CLI. For example, you already had SAM CLI installed and upgraded AWS CLI. You
+received the message above and would need to upgrade SAM CLI.
+
 Learn More
 ==========
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ six~=1.11.0
 click~=6.7
 enum34~=1.1.6
 Flask~=1.0.2
-boto3~=1.5
+boto3~=1.8
 PyYAML~=3.12
 cookiecutter~=1.6.0
 aws-sam-translator==1.6.0


### PR DESCRIPTION
If you were to upgrade AWS CLI to a version greater than 1.14.46,
then SAM CLI would fail execution of commands due to a botocore
version conflict. This was due to the newer versions of the AWS
CLI bumping boto3 (which in turn bumps botocore). Boto3 has a min
and max version of botocore defined. Since AWS CLI and SAM CLI
had different Boto3 versions, their installations  overrode the
required version for each other causing commands to fail with
DistributionNotFound.

*Issue #, if available:*
#629

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
