### PR TITLE
Properly test results with generated Nodejs8.10 runtime unit tests.

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/tests/unit/test_handler.js
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello_world/tests/unit/test_handler.js
@@ -29,17 +29,17 @@ describe('Tests Handler', function () {
 {% else %}
 describe('Tests index', function () {
     it('verifies successful response', async () => {
-        const result = await app.lambdaHandler(event, context, (err, result) => {
-            expect(result).to.be.an('object');
-            expect(result.statusCode).to.equal(200);
-            expect(result.body).to.be.an('string');
+        const result = await app.lambdaHandler(event, context)
 
-            let response = JSON.parse(result.body);
+        expect(result).to.be.an('object');
+        expect(result.statusCode).to.equal(200);
+        expect(result.body).to.be.an('string');
 
-            expect(response).to.be.an('object');
-            expect(response.message).to.be.equal("hello world");
-            expect(response.location).to.be.an("string");
-        });
+        let response = JSON.parse(result.body);
+
+        expect(response).to.be.an('object');
+        expect(response.message).to.be.equal("hello world");
+        expect(response.location).to.be.an("string");
     });
 });
 {% endif %}


### PR DESCRIPTION
Nodejs8.10 lambda doesn't take in a callback so tests pass no
matter what. Should be testing results captured from await call.

*Issue #, if available:*

*Description of changes:*
Nodejs 8.10 runtime unit tests are passing but not properly testing anything since the lamdba uses async/await instead of callbacks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
