### PR TITLE
Add dotnetcore 2.1 support for init command

### DIFF
--- a/samcli/local/init/__init__.py
+++ b/samcli/local/init/__init__.py
@@ -22,6 +22,7 @@ RUNTIME_TEMPLATE_MAPPING = {
     "nodejs4.3": os.path.join(_templates, "cookiecutter-aws-sam-hello-nodejs"),
     "nodejs": os.path.join(_templates, "cookiecutter-aws-sam-hello-nodejs"),
     "dotnetcore2.0": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
+    "dotnetcore2.1": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
     "dotnetcore1.0": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
     "dotnetcore": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
     "dotnet": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/cookiecutter.json
@@ -1,3 +1,4 @@
 {
-    "project_name": "Name of the project"
+    "project_name": "Name of the project",
+    "runtime": "dotnetcore2.1"
 }

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/README.md
@@ -36,7 +36,7 @@ sam local start-api
 ```yaml
 ...
 Events:
-    {{cookiecutter.project_name}}:
+    HelloWorldFunction:
         Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
         Properties:
             Path: /hello
@@ -52,10 +52,10 @@ AWS Lambda C# runtime requires a flat folder with all dependencies including the
 
 ```yaml
 ...
-    FirstFunction:
+    HelloWorldFunction:
         Type: AWS::Serverless::Function
         Properties:
-            CodeUri: src/HelloWorld/bin/Debug/netcoreapp2.0/publish            
+            CodeUri: artifacts/HelloWorld.zip            
             ...
 ```
 

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
+    {%- elif cookiecutter.runtime == 'dotnetcore2.1' or cookiecutter.runtime == 'dotnet' %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
     {%- endif %}
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    {%- else %}
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    {%- endif %}
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
@@ -17,3 +21,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -8,8 +8,13 @@
   "profile": "default",
   "region": "us-east-2",
   "configuration": "Release",
+  {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
   "framework": "netcoreapp2.0",
   "function-runtime": "dotnetcore2.0",
+  {%- else %}
+  "function-runtime": "dotnetcore2.1",
+  "framework": "netcoreapp2.1",
+  {%- endif %}
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "HelloWorld::HelloWorld.Function::FunctionHandler"

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/aws-lambda-tools-defaults.json
@@ -10,8 +10,8 @@
   "configuration": "Release",
   {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
   "framework": "netcoreapp2.0",
-  "function-runtime": "dotnetcore2.0",
-  {%- else %}
+  "function-runtime": "{{ cookiecutter.runtime }}",
+  {%- elif cookiecutter.runtime == 'dotnetcore2.1' or cookiecutter.runtime == 'dotnet' %}
   "function-runtime": "dotnetcore2.1",
   "framework": "netcoreapp2.1",
   {%- endif %}

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -14,7 +14,7 @@ Resources:
     HelloWorldFunction:
         Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
         Properties:
-            CodeUri: src/HelloWorld/bin/Debug/netcoreapp2.0/publish
+            CodeUri: ./artifacts/HelloWorld.zip
             Handler: HelloWorld::HelloWorld.Function::FunctionHandler
             {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
             Runtime: {{ cookiecutter.runtime }}

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,11 @@ Resources:
         Properties:
             CodeUri: src/HelloWorld/bin/Debug/netcoreapp2.0/publish
             Handler: HelloWorld::HelloWorld.Function::FunctionHandler
+            {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
             Runtime: dotnetcore2.0
+            {%- else %}
+            Runtime: dotnetcore2.1
+            {%- endif %}
             Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
                 Variables:
                     PARAM1: VALUE

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -17,8 +17,8 @@ Resources:
             CodeUri: src/HelloWorld/bin/Debug/netcoreapp2.0/publish
             Handler: HelloWorld::HelloWorld.Function::FunctionHandler
             {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-            Runtime: dotnetcore2.0
-            {%- else %}
+            Runtime: {{ cookiecutter.runtime }}
+            {%- elif cookiecutter.runtime == 'dotnetcore2.1' or cookiecutter.runtime == 'dotnet' %}
             Runtime: dotnetcore2.1
             {%- endif %}
             Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    {%- else %}
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    {%- endif %}
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,3 +23,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
+    {%- elif cookiecutter.runtime == 'dotnetcore2.1' or cookiecutter.runtime == 'dotnet' %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
     {%- endif %}
   </PropertyGroup>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-sam-cli/issues/609

*Description of changes:*

* Adds support for dotnetcore 2.1 
* Defaults to dotnetcore 2.1 when `dotnet` is selected
* Addresses a regression noted in https://github.com/awslabs/aws-sam-cli/issues/673


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
