### PR TITLE
update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,7 +18,32 @@ environment variable to contact the docker daemon.
 -  **Windows**: `Docker
    For Windows (create an account & follow through to download from the Docker Store) <https://www.docker.com/docker-windows>`__
 -  **Linux**: Check your distro’s package manager (e.g. yum install docker)
+      *** for Centos 7.5 System requirements are::
+         yum install gcc zip py-pip py-setuptools ca-certificates groff  python-dev g++ make docker epel-release python-pip python-devel\
+                     python-tools
+          **run post install of above**
+          pip install --upgrade pip
+          pip install --upgrade setuptools
+          pip install --upgrade aws-sam-cli
+        *** if you want to use the lambda-local option(without running it as root) you will need to add your user to the docker group ***
+         usermod -a -G Docker yourUserName
+      ***Docker if you would like to run SAM-CLI in a docker container (lambda-local will probably act weird)***
+         DOCKERFILE:
+         FROM alpine:latest
 
+         # Versions: https://pypi.python.org/pypi/awscli#downloads
+         #ENV AWS_CLI_VERSION 1.14.16
+   
+         RUN apk --no-cache update
+         RUN apk --no-cache add python py-pip py-setuptools ca-certificates groff less python-dev g++ make
+         RUN pip install --upgrade pip
+         RUN pip --no-cache-dir install  --upgrade awscli 
+         RUN pip --no-cache-dir install --upgrade  aws-sam-cli 
+
+         RUN rm -rf /var/cache/apk/*
+
+         WORKDIR /awscli
+         ***end DOCKERFILE***
 **Note for macOS and Windows users**: SAM CLI requires that the project directory
 (or any parent directory) is listed in `Docker file sharing options <https://docs.docker.com/docker-for-mac/osxfs/>`__.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,23 +27,7 @@ environment variable to contact the docker daemon.
           pip install --upgrade aws-sam-cli
         *** if you want to use the lambda-local option(without running it as root) you will need to add your user to the docker group ***
          usermod -a -G Docker yourUserName
-      ***Docker if you would like to run SAM-CLI in a docker container (lambda-local will probably act weird)***
-         DOCKERFILE:
-         FROM alpine:latest
-
-         # Versions: https://pypi.python.org/pypi/awscli#downloads
-         #ENV AWS_CLI_VERSION 1.14.16
-   
-         RUN apk --no-cache update
-         RUN apk --no-cache add python py-pip py-setuptools ca-certificates groff less python-dev g++ make
-         RUN pip install --upgrade pip
-         RUN pip --no-cache-dir install  --upgrade awscli 
-         RUN pip --no-cache-dir install --upgrade  aws-sam-cli 
-
-         RUN rm -rf /var/cache/apk/*
-
-         WORKDIR /awscli
-         ***end DOCKERFILE***
+     
 **Note for macOS and Windows users**: SAM CLI requires that the project directory
 (or any parent directory) is listed in `Docker file sharing options <https://docs.docker.com/docker-for-mac/osxfs/>`__.
 


### PR DESCRIPTION
this change offers info on the minimum system requirements for a redhat like system to get sam-cli up and running
this would be very similar for debian based system, but I haven't tested. If you feel it will be valuable I can do so.
the dockerfile is because "lets put everything in docker" I havent tried the lambda-local option in it. I know people run docker in docker but I would expect memory or file space issues
however if you want to have docker environment for plenty of other sam-cli related tasks this can be useful and it runs on  alpine so its small and fast.
I would probably guess not having this info on the main install page is good, I would think linking to it might be better, but you can tell me what is best.

*Issue #, if available:*

*Description of changes:*

added info for installation requirements for linux, specifically centos 7.5, and added alpine linux dockerfile
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
