### PR TITLE
fix: raise error for invalid environment variables file

### DIFF
--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -11,7 +11,7 @@ from samcli.commands.exceptions import UserException
 from samcli.commands.local.cli_common.invoke_context import InvokeContext
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 
 LOG = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ def do_cli(ctx, function_identifier, template, event, no_event, env_vars, debug_
 
     except FunctionNotFound:
         raise UserException("Function {} not found in template".format(function_identifier))
-    except (InvalidSamDocumentException, OverridesNotWellDefined) as ex:
+    except (InvalidSamDocumentException, OverridesNotWellDefinedError) as ex:
         raise UserException(str(ex))
 
 

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -11,6 +11,8 @@ from samcli.commands.exceptions import UserException
 from samcli.commands.local.cli_common.invoke_context import InvokeContext
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+
 
 LOG = logging.getLogger(__name__)
 
@@ -94,7 +96,7 @@ def do_cli(ctx, function_identifier, template, event, no_event, env_vars, debug_
 
     except FunctionNotFound:
         raise UserException("Function {} not found in template".format(function_identifier))
-    except InvalidSamDocumentException as ex:
+    except (InvalidSamDocumentException, OverridesNotWellDefined) as ex:
         raise UserException(str(ex))
 
 

--- a/samcli/commands/local/lib/exceptions.py
+++ b/samcli/commands/local/lib/exceptions.py
@@ -10,7 +10,7 @@ class NoApisDefined(Exception):
     pass
 
 
-class OverridesNotWellDefined(Exception):
+class OverridesNotWellDefinedError(Exception):
     """
     Raised when the overrides file is invalid
     """

--- a/samcli/commands/local/lib/exceptions.py
+++ b/samcli/commands/local/lib/exceptions.py
@@ -8,3 +8,10 @@ class NoApisDefined(Exception):
     Raised when there are no APIs defined in the template
     """
     pass
+
+
+class OverridesNotWellDefined(Exception):
+    """
+    Raised when the overrides file is invalid
+    """
+    pass

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -21,7 +21,7 @@ class LocalLambdaRunner(object):
     """
     PRESENT_DIR = "."
     MAX_DEBUG_TIMEOUT = 36000  # 10 hours in seconds
-
+ 
     def __init__(self,
                  local_runtime,
                  function_provider,
@@ -156,8 +156,12 @@ class LocalLambdaRunner(object):
 
         for env_var_value in self.env_vars_values.values():
             if not isinstance(env_var_value, dict):
-                LOG.debug("Environment variables overrides data is not in a recognized format")
-                raise OverridesNotWellDefinedError("Environment variables overrides data is not in a recognized format")
+                reason = """
+                            Environment variables must be in either CloudFormation parameter file 
+                            format or in {FunctionName: {key:value}} JSON pairs
+                            """
+                LOG.debug(reason)
+                raise OverridesNotWellDefinedError(reason)
 
         if "Parameters" in self.env_vars_values:
             LOG.debug("Environment variables overrides data is in CloudFormation parameter file format")

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -9,6 +9,7 @@ import boto3
 from samcli.local.lambdafn.env_vars import EnvironmentVariables
 from samcli.local.lambdafn.config import FunctionConfig
 from samcli.local.lambdafn.exceptions import FunctionNotFound
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
 
 LOG = logging.getLogger(__name__)
 
@@ -141,6 +142,12 @@ class LocalLambdaRunner(object):
         #
         # Standard format is {FunctionName: {key:value}, FunctionName: {key:value}}
         # CloudFormation parameter file is {"Parameters": {key:value}}
+
+        for fn in self.env_vars_values:
+            if not isinstance(self.env_vars_values.get(fn), dict):
+                LOG.debug("Environment variables overrides data is not in a recognized format")
+                raise OverridesNotWellDefined("Environment variables overrides data is not in a recognized format")
+
         if "Parameters" in self.env_vars_values:
             LOG.debug("Environment variables overrides data is in CloudFormation parameter file format")
             # CloudFormation parameter file format

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -9,7 +9,7 @@ import boto3
 from samcli.local.lambdafn.env_vars import EnvironmentVariables
 from samcli.local.lambdafn.config import FunctionConfig
 from samcli.local.lambdafn.exceptions import FunctionNotFound
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 LOG = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ class LocalLambdaRunner(object):
         for fn in self.env_vars_values:
             if not isinstance(self.env_vars_values.get(fn), dict):
                 LOG.debug("Environment variables overrides data is not in a recognized format")
-                raise OverridesNotWellDefined("Environment variables overrides data is not in a recognized format")
+                raise OverridesNotWellDefinedError("Environment variables overrides data is not in a recognized format")
 
         if "Parameters" in self.env_vars_values:
             LOG.debug("Environment variables overrides data is in CloudFormation parameter file format")

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -154,8 +154,8 @@ class LocalLambdaRunner(object):
         # Standard format is {FunctionName: {key:value}, FunctionName: {key:value}}
         # CloudFormation parameter file is {"Parameters": {key:value}}
 
-        for fn in self.env_vars_values:
-            if not isinstance(self.env_vars_values.get(fn), dict):
+        for env_var_value in self.env_vars_values.values():
+            if not isinstance(env_var_value, dict):
                 LOG.debug("Environment variables overrides data is not in a recognized format")
                 raise OverridesNotWellDefinedError("Environment variables overrides data is not in a recognized format")
 

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -122,12 +122,23 @@ class LocalLambdaRunner(object):
                               env_vars=env_vars)
 
     def _make_env_vars(self, function):
-        """
-        Returns the environment variables configuration for this function
+        """Returns the environment variables configuration for this function
 
-        :param samcli.commands.local.lib.provider.Function function: Lambda function to generate the configuration for
-        :return samcli.local.lambdafn.env_vars.EnvironmentVariables: Environment variable configuration for this
-            function
+        Parameters
+        ----------
+        function : samcli.commands.local.lib.provider.Function
+            Lambda function to generate the configuration for
+
+        Returns
+        -------
+        samcli.local.lambdafn.env_vars.EnvironmentVariables
+            Environment variable configuration for this function
+
+        Raises
+        ------
+        samcli.commands.local.lib.exceptions.OverridesNotWellDefinedError
+            If the environment dict is in the wrong format to process environment vars
+
         """
 
         name = function.name

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -21,7 +21,7 @@ class LocalLambdaRunner(object):
     """
     PRESENT_DIR = "."
     MAX_DEBUG_TIMEOUT = 36000  # 10 hours in seconds
- 
+
     def __init__(self,
                  local_runtime,
                  function_provider,
@@ -157,7 +157,7 @@ class LocalLambdaRunner(object):
         for env_var_value in self.env_vars_values.values():
             if not isinstance(env_var_value, dict):
                 reason = """
-                            Environment variables must be in either CloudFormation parameter file 
+                            Environment variables must be in either CloudFormation parameter file
                             format or in {FunctionName: {key:value}} JSON pairs
                             """
                 LOG.debug(reason)

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -12,7 +12,7 @@ from samcli.commands.local.lib.exceptions import NoApisDefined
 from samcli.commands.exceptions import UserException
 from samcli.commands.local.lib.local_api_service import LocalApiService
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 LOG = logging.getLogger(__name__)
 
@@ -91,5 +91,5 @@ def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_ar
 
     except NoApisDefined:
         raise UserException("Template does not have any APIs connected to Lambda functions")
-    except (InvalidSamDocumentException, OverridesNotWellDefined) as ex:
+    except (InvalidSamDocumentException, OverridesNotWellDefinedError) as ex:
         raise UserException(str(ex))

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -12,6 +12,7 @@ from samcli.commands.local.lib.exceptions import NoApisDefined
 from samcli.commands.exceptions import UserException
 from samcli.commands.local.lib.local_api_service import LocalApiService
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
 
 LOG = logging.getLogger(__name__)
 
@@ -90,5 +91,5 @@ def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_ar
 
     except NoApisDefined:
         raise UserException("Template does not have any APIs connected to Lambda functions")
-    except InvalidSamDocumentException as ex:
+    except (InvalidSamDocumentException, OverridesNotWellDefined) as ex:
         raise UserException(str(ex))

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -11,7 +11,7 @@ from samcli.commands.local.cli_common.invoke_context import InvokeContext
 from samcli.commands.local.cli_common.user_exceptions import UserException
 from samcli.commands.local.lib.local_lambda_service import LocalLambdaService
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 
 LOG = logging.getLogger(__name__)
@@ -101,5 +101,5 @@ def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylin
                                          host=host)
             service.start()
 
-    except (InvalidSamDocumentException, OverridesNotWellDefined) as ex:
+    except (InvalidSamDocumentException, OverridesNotWellDefinedError) as ex:
         raise UserException(str(ex))

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -11,6 +11,8 @@ from samcli.commands.local.cli_common.invoke_context import InvokeContext
 from samcli.commands.local.cli_common.user_exceptions import UserException
 from samcli.commands.local.lib.local_lambda_service import LocalLambdaService
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+
 
 LOG = logging.getLogger(__name__)
 
@@ -99,5 +101,5 @@ def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylin
                                          host=host)
             service.start()
 
-    except InvalidSamDocumentException as ex:
+    except (InvalidSamDocumentException, OverridesNotWellDefined) as ex:
         raise UserException(str(ex))

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -10,6 +10,8 @@ from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.exceptions import UserException
 from samcli.commands.local.invoke.cli import do_cli as invoke_cli, _get_event as invoke_cli_get_event
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+
 
 STDIN_FILE_NAME = "-"
 
@@ -215,6 +217,34 @@ class TestCli(TestCase):
         msg = str(ex_ctx.exception)
         self.assertEquals(msg, "bad template")
 
+    @patch("samcli.commands.local.invoke.cli.InvokeContext")
+    @patch("samcli.commands.local.invoke.cli._get_event")
+    def test_must_raise_user_exception_on_invalid_env_vars(self, get_event_mock, InvokeContextMock):
+        event_data = "data"
+        get_event_mock.return_value = event_data
+
+        InvokeContextMock.side_effect = OverridesNotWellDefined("bad env vars")
+
+        with self.assertRaises(UserException) as ex_ctx:
+
+            invoke_cli(ctx=None,
+                       function_identifier=self.function_id,
+                       template=self.template,
+                       event=self.eventfile,
+                       no_event=self.no_event,
+                       env_vars=self.env_vars,
+                       debug_port=self.debug_port,
+                       debug_args=self.debug_args,
+                       debugger_path=self.debugger_path,
+                       docker_volume_basedir=self.docker_volume_basedir,
+                       docker_network=self.docker_network,
+                       log_file=self.log_file,
+                       skip_pull_image=self.skip_pull_image,
+                       profile=self.profile,
+                       region=self.region)
+
+        msg = str(ex_ctx.exception)
+        self.assertEquals(msg, "bad env vars")
 
 class TestGetEvent(TestCase):
 

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -241,7 +241,8 @@ class TestCli(TestCase):
                        log_file=self.log_file,
                        skip_pull_image=self.skip_pull_image,
                        profile=self.profile,
-                       region=self.region)
+                       region=self.region,
+                       parameter_overrides=self.parameter_overrides)
 
         msg = str(ex_ctx.exception)
         self.assertEquals(msg, "bad env vars")

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -246,6 +246,7 @@ class TestCli(TestCase):
         msg = str(ex_ctx.exception)
         self.assertEquals(msg, "bad env vars")
 
+
 class TestGetEvent(TestCase):
 
     @parameterized.expand([

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -10,7 +10,7 @@ from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.exceptions import UserException
 from samcli.commands.local.invoke.cli import do_cli as invoke_cli, _get_event as invoke_cli_get_event
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 
 STDIN_FILE_NAME = "-"
@@ -223,7 +223,7 @@ class TestCli(TestCase):
         event_data = "data"
         get_event_mock.return_value = event_data
 
-        InvokeContextMock.side_effect = OverridesNotWellDefined("bad env vars")
+        InvokeContextMock.side_effect = OverridesNotWellDefinedError("bad env vars")
 
         with self.assertRaises(UserException) as ex_ctx:
 

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -10,7 +10,7 @@ from parameterized import parameterized, param
 from samcli.commands.local.lib.local_lambda import LocalLambdaRunner
 from samcli.commands.local.lib.provider import Function
 from samcli.local.lambdafn.exceptions import FunctionNotFound
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 
 class TestLocalLambda_get_aws_creds(TestCase):
@@ -331,11 +331,11 @@ class TestLocalLambda_make_env_vars(TestCase):
 
     @parameterized.expand([
         # Using a invalid file format
-        ({"a": "b"}, OverridesNotWellDefined),
+        ({"a": "b"}, OverridesNotWellDefinedError),
 
-        ({"a": False}, OverridesNotWellDefined),
+        ({"a": False}, OverridesNotWellDefinedError),
 
-        ({"a": [True, False]}, OverridesNotWellDefined)
+        ({"a": [True, False]}, OverridesNotWellDefinedError)
     ])
     @patch("samcli.commands.local.lib.local_lambda.os")
     def test_must_not_work_with_invalid_override_values(self, env_vars_values, expected_exception, os_mock):

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -10,6 +10,7 @@ from parameterized import parameterized, param
 from samcli.commands.local.lib.local_lambda import LocalLambdaRunner
 from samcli.commands.local.lib.provider import Function
 from samcli.local.lambdafn.exceptions import FunctionNotFound
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
 
 
 class TestLocalLambda_get_aws_creds(TestCase):
@@ -298,7 +299,7 @@ class TestLocalLambda_make_env_vars(TestCase):
         ({"otherfunction": {"c": "d"}}, None),
 
         # Using a CloudFormation parameter file format
-        ({"Parameters": {"p1": "v1"}}, {"p1": "v1"}),
+        ({"Parameters": {"p1": "v1"}}, {"p1": "v1"})
     ])
     @patch("samcli.commands.local.lib.local_lambda.EnvironmentVariables")
     @patch("samcli.commands.local.lib.local_lambda.os")
@@ -327,6 +328,33 @@ class TestLocalLambda_make_env_vars(TestCase):
                                                     shell_env_values=os_environ,
                                                     override_values=expected_override_value,
                                                     aws_creds=self.aws_creds)
+
+    @parameterized.expand([
+        # Using a invalid file format
+        ({"a": "b"}, OverridesNotWellDefined),
+
+        ({"a": False}, OverridesNotWellDefined),
+
+        ({"a": [True, False]}, OverridesNotWellDefined)
+    ])
+    @patch("samcli.commands.local.lib.local_lambda.os")
+    def test_must_not_work_with_invalid_override_values(self, env_vars_values, expected_exception, os_mock):
+        os_environ = {"some": "value"}
+        os_mock.environ = os_environ
+
+        function = Function(name="function_name",
+                            runtime="runtime",
+                            memory=1234,
+                            timeout=12,
+                            handler="handler",
+                            codeuri="codeuri",
+                            environment=self.environ,
+                            rolearn=None)
+
+        self.local_lambda.env_vars_values = env_vars_values
+
+        with self.assertRaises(expected_exception):
+            self.local_lambda._make_env_vars(function)
 
     @parameterized.expand([
         param({"a": "b"}),  # Does not have the "Variables" Key

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -9,6 +9,7 @@ from samcli.commands.local.start_api.cli import do_cli as start_api_cli
 from samcli.commands.local.lib.exceptions import NoApisDefined
 from samcli.commands.exceptions import UserException
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
 
 
 class TestCli(TestCase):
@@ -94,6 +95,17 @@ class TestCli(TestCase):
 
         msg = str(context.exception)
         expected = "bad template"
+        self.assertEquals(msg, expected)
+
+    @patch("samcli.commands.local.start_api.cli.InvokeContext")
+    def test_must_raise_user_exception_on_invalid_env_vars(self, invoke_context_mock):
+        invoke_context_mock.side_effect = OverridesNotWellDefined("bad env vars")
+
+        with self.assertRaises(UserException) as context:
+            self.call_cli()
+
+        msg = str(context.exception)
+        expected = "bad env vars"
         self.assertEquals(msg, expected)
 
     def call_cli(self):

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -9,7 +9,7 @@ from samcli.commands.local.start_api.cli import do_cli as start_api_cli
 from samcli.commands.local.lib.exceptions import NoApisDefined
 from samcli.commands.exceptions import UserException
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 
 class TestCli(TestCase):
@@ -99,7 +99,7 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.start_api.cli.InvokeContext")
     def test_must_raise_user_exception_on_invalid_env_vars(self, invoke_context_mock):
-        invoke_context_mock.side_effect = OverridesNotWellDefined("bad env vars")
+        invoke_context_mock.side_effect = OverridesNotWellDefinedError("bad env vars")
 
         with self.assertRaises(UserException) as context:
             self.call_cli()

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -4,7 +4,7 @@ from mock import patch, Mock
 from samcli.commands.local.start_lambda.cli import do_cli as start_lambda_cli
 from samcli.commands.local.cli_common.user_exceptions import UserException
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
 
 
 class TestCli(TestCase):
@@ -72,7 +72,7 @@ class TestCli(TestCase):
 
     @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
     def test_must_raise_user_exception_on_invalid_env_vars(self, invoke_context_mock):
-        invoke_context_mock.side_effect = OverridesNotWellDefined("bad env vars")
+        invoke_context_mock.side_effect = OverridesNotWellDefinedError("bad env vars")
 
         with self.assertRaises(UserException) as context:
             self.call_cli()

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -70,7 +70,6 @@ class TestCli(TestCase):
         expected = "bad template"
         self.assertEquals(msg, expected)
 
-
     @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
     def test_must_raise_user_exception_on_invalid_env_vars(self, invoke_context_mock):
         invoke_context_mock.side_effect = OverridesNotWellDefined("bad env vars")

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -4,6 +4,7 @@ from mock import patch, Mock
 from samcli.commands.local.start_lambda.cli import do_cli as start_lambda_cli
 from samcli.commands.local.cli_common.user_exceptions import UserException
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+from samcli.commands.local.lib.exceptions import OverridesNotWellDefined
 
 
 class TestCli(TestCase):
@@ -67,6 +68,18 @@ class TestCli(TestCase):
 
         msg = str(context.exception)
         expected = "bad template"
+        self.assertEquals(msg, expected)
+
+
+    @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
+    def test_must_raise_user_exception_on_invalid_env_vars(self, invoke_context_mock):
+        invoke_context_mock.side_effect = OverridesNotWellDefined("bad env vars")
+
+        with self.assertRaises(UserException) as context:
+            self.call_cli()
+
+        msg = str(context.exception)
+        expected = "bad env vars"
         self.assertEquals(msg, expected)
 
     def call_cli(self):


### PR DESCRIPTION
*Issue #, if available:* #626 

*Description of changes:*
Introduces an exception to be thrown when an environment variable file is invalid. 

SAM still swallows regular malformed env files, but will throw an error if the json structure doesn't match as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
