### PR TITLE
the bind mount content is private and unshared

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -92,7 +92,7 @@ class Container(object):
                     # https://docs.docker.com/storage/bind-mounts
                     # Mount the host directory as "read only" inside container
                     "bind": self._working_dir,
-                    "mode": "ro"
+                    "mode": "ro,Z"
                 }
             },
             # We are not running an interactive shell here.

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -44,7 +44,7 @@ class LambdaContainer(Container):
     _DEFAULT_CONTAINER_DBG_GO_PATH = _DEBUGGER_VOLUME_MOUNT_PATH + "/dlv"
 
     # This is the dictionary that represents where the debugger_path arg is mounted in docker to as readonly.
-    _DEBUGGER_VOLUME_MOUNT = {"bind": _DEBUGGER_VOLUME_MOUNT_PATH, "mode": "ro"}
+    _DEBUGGER_VOLUME_MOUNT = {"bind": _DEBUGGER_VOLUME_MOUNT_PATH, "mode": "ro,Z"}
 
     def __init__(self,
                  runtime,

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -76,7 +76,7 @@ class TestContainer_create(TestCase):
         expected_volumes = {
             self.host_dir: {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,Z"
             }
         }
         generated_id = "fooobar"
@@ -109,7 +109,7 @@ class TestContainer_create(TestCase):
         expected_volumes = {
             self.host_dir: {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,Z"
             },
             '/somepath': {"blah": "blah value"}
         }
@@ -167,7 +167,7 @@ class TestContainer_create(TestCase):
         translated_volumes = {
             "/c/Users/Username/AppData/Local/Temp/tmp1337": {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,Z"
             }
         }
 

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -194,7 +194,7 @@ class TestLambdaContainer_get_additional_volumes(TestCase):
         self.assertIsNone(result)
 
     def test_additional_volumes_returns_volume_with_debugger_path_is_set(self):
-        expected = {'/somepath': {"bind": "/tmp/lambci_debug_files", "mode": "ro"}}
+        expected = {'/somepath': {"bind": "/tmp/lambci_debug_files", "mode": "ro,Z"}}
 
         debug_options = DebugContext(debug_port=1234, debugger_path='/somepath')
 


### PR DESCRIPTION
Issue #676 

*Description of changes:*

The Z option indicates that the bind mount content is private and unshared.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
