### PR TITLE
fix: remove dependency on pystache

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 six~=1.11.0
+chevron~=0.12.2
 click~=6.7
 enum34~=1.1.6; python_version<"3.4"
 Flask~=1.0.2
@@ -10,5 +11,4 @@ docker>=3.3.0
 dateparser~=0.7
 python-dateutil~=2.6
 pathlib2~=2.3.2; python_version<"3.4"
-pystache~=0.5
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 six~=1.11.0
-chevron~=0.12.2
+chevron~=0.12
 click~=6.7
 enum34~=1.1.6; python_version<"3.4"
 Flask~=1.0.2

--- a/samcli/commands/local/lib/generated_sample_events/events.py
+++ b/samcli/commands/local/lib/generated_sample_events/events.py
@@ -7,7 +7,7 @@ import json
 import base64
 from requests.utils import quote
 
-import pystache
+from chevron import renderer
 
 
 class Events(object):
@@ -126,5 +126,4 @@ class Events(object):
         data = json.dumps(data, indent=2)
 
         # return the substituted file
-        renderer = pystache.Renderer()
         return renderer.render(data, values_to_sub)


### PR DESCRIPTION
- pystache does not explicitly state it supports py36
- last release was in 2014
- using chevron instead
- tested creation of sample events, and they worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
