### PR TITLE
fix: fix validate command error reporting for python 2

### DIFF
--- a/samcli/commands/validate/lib/sam_template_validator.py
+++ b/samcli/commands/validate/lib/sam_template_validator.py
@@ -84,7 +84,7 @@ class SamTemplateValidator(object):
                 LOG.debug("Translated template is:\n%s", yaml_dump(template))
         except InvalidDocumentException as e:
             raise InvalidSamDocumentException(
-                functools.reduce(lambda message, error: message + ' ' + str(error), e.causes, str(e)))
+                functools.reduce(lambda message, error: message + ' ' + str(error.message), e.causes, str(e.message)))
 
     def _replace_local_codeuri(self):
         """

--- a/tests/unit/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/unit/commands/validate/lib/test_sam_template_validator.py
@@ -45,7 +45,8 @@ class TestSamTemplateValidator(TestCase):
         sam_parser.Parser.return_value = parser
 
         translate_mock = Mock()
-        translate_mock.translate.side_effect = InvalidDocumentException([InvalidResourceException('LogicalId', 'message')])
+        translate_mock.translate.side_effect = InvalidDocumentException(
+            [InvalidResourceException('LogicalId', 'message')])
         sam_translator.return_value = translate_mock
 
         validator = SamTemplateValidator(template, managed_policy_mock)

--- a/tests/unit/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/unit/commands/validate/lib/test_sam_template_validator.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from mock import Mock, patch
 
-from samtranslator.public.exceptions import InvalidDocumentException
+from samtranslator.public.exceptions import InvalidDocumentException, InvalidResourceException
 
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.validate.lib.sam_template_validator import SamTemplateValidator
@@ -45,7 +45,7 @@ class TestSamTemplateValidator(TestCase):
         sam_parser.Parser.return_value = parser
 
         translate_mock = Mock()
-        translate_mock.translate.side_effect = InvalidDocumentException([Exception('message')])
+        translate_mock.translate.side_effect = InvalidDocumentException([InvalidResourceException('LogicalId', 'message')])
         sam_translator.return_value = translate_mock
 
         validator = SamTemplateValidator(template, managed_policy_mock)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The errors were not showing when running in Python 2. Changed it to explicitly print the exception's `message` property.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
