### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -194,6 +194,9 @@ If your AWS Cloud9 environment has a SAM CLI version < 0.3.0 installed there are
    
     # Create new symlink
     $ ln -sf $(which sam) ~/.c9/bin/sam
+    
+    # Reset the bash cache
+    $ hash -r
    
     # Verify your installation worked
     $ sam –-version


### PR DESCRIPTION
Cloud9 upgrade commands. If we don't reset the bash cache, it would output "No such file or directory" after `sam --version`  command. I have tested it on a fresh Cloud9 environment.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
