### PR TITLE
Updated isBase64Encoded value to bool as defined in documentation

### DIFF
--- a/samcli/commands/local/lib/generated_sample_events/events/apigateway/AwsProxy.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/apigateway/AwsProxy.json
@@ -3,7 +3,7 @@
   "resource": "{{resource}}",
   "path": "/{{path}}",
   "httpMethod": "{{method}}",
-  "isBase64Encoded": false,
+  "isBase64Encoded": true,
   "queryStringParameters": {
     "foo": "bar"
   },

--- a/samcli/commands/local/lib/generated_sample_events/events/apigateway/AwsProxy.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/apigateway/AwsProxy.json
@@ -3,7 +3,7 @@
   "resource": "{{resource}}",
   "path": "/{{path}}",
   "httpMethod": "{{method}}",
-  "isBase64Encoded": "false",
+  "isBase64Encoded": false,
   "queryStringParameters": {
     "foo": "bar"
   },

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -150,7 +150,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertEquals(response.get("Payload").read().decode('utf-8'),
                           '{"errorMessage": "Lambda is raising an exception", '
                           '"errorType": "Exception", '
-                          '"stackTrace": [["/var/task/main.py", 43, "raise_exception", '
+                          '"stackTrace": [["/var/task/main.py", 47, "raise_exception", '
                           '"raise Exception(\\"Lambda is raising an exception\\")"]]}')
         self.assertEquals(response.get("FunctionError"), 'Unhandled')
         self.assertEquals(response.get("StatusCode"), 200)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Documentation states that the isBase64Encoded key is a bool value (see [https://amzn.to/2QAWECb](https://amzn.to/2QAWECb)). The aws-proxy generated sample event defines it as a string. This is causing type casting issues in languages like Go.
 
Also, fixed integration test assertion for "test_lambda_function_raised_error"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
