### PR TITLE
add pytest-mock for testing in init template

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/README.md
@@ -114,7 +114,7 @@ aws cloudformation describe-stacks \
 
 ## Testing
 
-We use **Pytest** for testing our code and you can install it using pip: ``pip install pytest`` 
+We use **Pytest** and **pytest-mock** for testing our code and you can install it using pip: ``pip install pytest pytest-mock`` 
 
 Next, we run `pytest` against our `tests` folder to run our initial unit tests:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I created project using `sam init --runtime python` .
An error occurred in `python -m pytest tests/ -v`. We also need install pytest-mock.
```
$ python -m pytest tests/ -v
====================================================== test session starts =======================================================
platform darwin -- Python 3.6.3, pytest-3.8.2, py-1.6.0, pluggy-0.7.1 -- sam-app/.venv/bin/python
cachedir: .pytest_cache
rootdir: sam-app, inifile:
collected 1 item

tests/unit/test_handler.py::test_lambda_handler ERROR                                                                      [100%]

============================================================= ERRORS =============================================================
_____________________________________________ ERROR at setup of test_lambda_handler ______________________________________________
file sam-app/tests/unit/test_handler.py, line 66
  def test_lambda_handler(apigw_event, mocker):
E       fixture 'mocker' not found
>       available fixtures: apigw_event, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_property, record_xml_attribute, record_xml_property, recwarn, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

sam-app/tests/unit/test_handler.py:66
==================================================== 1 error in 0.20 seconds =====================================================
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
