### PR TITLE
WIP: Adding AppVeyor config 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,7 @@
 version: 1.0.{build}
 image: Visual Studio 2017
+install:
+- docker version
 build_script:
-- docker run hello-world:linux
+- docker run hello-world
+- docker image hello-world

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,6 @@ environment:
       PYTHON_VERSION: "3.6.6"
       PYTHON_ARCH: "64"
 install:
-- "%PYTHON%\\python.exe -m pip -e install '.[dev]'"
+- "%PYTHON%\\python.exe -m pip install '.[dev]'"
 test_script:
 - "%PYTHON%\\pytest tests\\unit"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,5 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-environment:
-  matrix:
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.6"
-      PYTHON_ARCH: "64"
-install:
-- "%PYTHON%\\python.exe --version"
+build: off
 test_script:
-- "docker run hello-world:linux"
+- sh: docker run hello-world:linux

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 image: ubuntu
 stack: python 3.7.0
 build: off
+environment:
+  AWS_REGION: us-east-1
 install:
 - pip install -e '.[dev]'
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
 version: 1.0.{build}
 image: Visual Studio 2017
 build: 
-- sh: docker run hello-world:linux
+- "docker run hello-world:linux"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,10 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-#environment:
-#  matrix:
-#    - PYTHON: "C:\\Python36-x64"
-#      PYTHON_VERSION: "3.6.6"
-#      PYTHON_ARCH: "64"
+environment:
+  matrix:
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.6"
+      PYTHON_ARCH: "64"
 install:
 - "%PYTHON%\\python.exe --version"
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-build: 
-- "docker run hello-world:linux"
+build_script:
+- docker run hello-world:linux

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 image: Visual Studio 2017
 install:
-- %PYTHON%\python.exe -m pip -e install '.[dev]'
+- "%PYTHON%\\python.exe -m pip -e install '.[dev]'"
 test_script:
-- %PYTHON%\pytest tests/unit
+- "%PYTHON%\\pytest tests\\unit"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ image: ubuntu
 stack: python 3.7.0
 build: off
 environment:
-  AWS_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-1
 install:
 - pip install -e '.[dev]'
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,8 @@
 version: 1.0.{build}
 image: ubuntu
+stack: python 3.7.0
 install:
-- docker version
-- docker info
-build_script:
-- docker run hello-world:linux
+- pip install -e '.[dev]'
+test_script:
+- pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit
+- pytest tests/integration

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,7 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: ubuntu
 install:
 - docker version
 - docker info
 build_script:
-- docker run --platform linux hello-world:linux
-- docker image hello-world
+- docker run hello-world:linux

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,4 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-build: off
-test_script:
+build: 
 - sh: docker run hello-world:linux

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,7 @@
 version: 1.0.{build}
 image: ubuntu
 stack: python 3.7.0
+build: off
 install:
 - pip install -e '.[dev]'
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,6 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+install:
+- %PYTHON%\python.exe -m pip -e install '.[dev]'
+test_script:
+- %PYTHON%\pytest tests/unit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,11 @@
 version: 1.0.{build}
 image: Visual Studio 2017
-environment:
-  matrix:
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.6"
-      PYTHON_ARCH: "64"
-install:
-- "%PYTHON%\\python.exe -m pip install '.[dev]'"
+#environment:
+#  matrix:
+#    - PYTHON: "C:\\Python36-x64"
+#      PYTHON_VERSION: "3.6.6"
+#      PYTHON_ARCH: "64"
+#install:
+#- "%PYTHON%\\python.exe -m pip install '.[dev]'"
 test_script:
-- "%PYTHON%\\pytest tests\\unit"
+- "docker run hello-world:linux"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ version: 1.0.{build}
 image: Visual Studio 2017
 install:
 - docker version
+- docker info
 build_script:
-- docker run hello-world
+- docker run --platform linux hello-world:linux
 - docker image hello-world

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ image: Visual Studio 2017
 #    - PYTHON: "C:\\Python36-x64"
 #      PYTHON_VERSION: "3.6.6"
 #      PYTHON_ARCH: "64"
-#install:
-#- "%PYTHON%\\python.exe -m pip install '.[dev]'"
+install:
+- "%PYTHON%\\python.exe --version"
 test_script:
 - "docker run hello-world:linux"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,10 @@
 version: 1.0.{build}
 image: Visual Studio 2017
+environment:
+  matrix:
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.6"
+      PYTHON_ARCH: "64"
 install:
 - "%PYTHON%\\python.exe -m pip -e install '.[dev]'"
 test_script:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allows us to run integration tests that use Docker because AppVeyor supports running Docker, which Travis doesn't. We should also consider porting all Travis steps to AppVeyor so we can maintain one system. 

Also, AppVeyor supports Windows but doesn't support running linux containers inside Windows. So even though we can't run all integ tests on Windows, we should be able to run a subset of them.

AppVeyor comes built-in with multiple Python versions (incl 3.7) so we can test on a matrix of Py versions.

As I am working through the config, see https://ci.appveyor.com/project/sanathkr/aws-sam-cli for latest builds.

Remaining items:
- [ ] Make all integ tests work
- [ ] Run on a matrix of Python versions (2.7, 3.6 and 3.7)
- [ ] Run unit tests on Windows

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
