### PR TITLE
Init templates: Correct permissions for AWS CLI under requirements

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/README.md
@@ -4,7 +4,7 @@ This is a sample template for {{ cookiecutter.project_name }}
 
 ## Requirements
 
-* AWS CLI already configured with at least PowerUser permission
+* AWS CLI already configured with Administrator permission
 * [Docker installed](https://www.docker.com/community-edition)
 * [SAM Local installed](https://github.com/awslabs/aws-sam-cli)
 * [DotNet Core installed](https://www.microsoft.com/net/download)

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-golang/{{cookiecutter.project_name}}/README.md
@@ -14,7 +14,7 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 
 ## Requirements
 
-* AWS CLI already configured with at least PowerUser permission
+* AWS CLI already configured with Administrator permission
 * [Docker installed](https://www.docker.com/community-edition)
 * [Golang](https://golang.org)
 

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-java/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-java/{{cookiecutter.project_name}}/README.md
@@ -21,7 +21,7 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 
 ## Requirements
 
-* AWS CLI already configured with at least PowerUser permission
+* AWS CLI already configured with Administrator permission
 * [Java SE Development Kit 8 installed](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 * [Docker installed](https://www.docker.com/community-edition)
 * [Maven](https://maven.apache.org/install.html)

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/README.md
@@ -16,7 +16,7 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 
 ## Requirements
 
-* AWS CLI already configured with at least PowerUser permission
+* AWS CLI already configured with Administrator permission
 {%- if cookiecutter.runtime == 'nodejs6.10' %}
 * [NodeJS 6.10 installed](https://nodejs.org/en/download/releases/)
 {%- elif cookiecutter.runtime =='nodejs4.3' %}

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/README.md
@@ -18,7 +18,7 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 
 ## Requirements
 
-* AWS CLI already configured with at least PowerUser permission
+* AWS CLI already configured with Administrator permission
 {%- if cookiecutter.runtime == 'python3.6' %}
 * [Python 3 installed](https://www.python.org/downloads/)
 {%- else %}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Corrects AWS permissions from PowerUser to Administrator.

SAM creates an implicit IAM Role as part of `AWS::Serverless::Function` resource and therefore needs Administrator access as an initial requirement or else this will fail.

Thanks to @sliedig for spotting this at last minute

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
