### PR TITLE
Flush streams after lambda function invocation

### DIFF
--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -108,6 +108,12 @@ class LambdaRuntime(object):
                     timer.cancel()
                 self._container_manager.stop(container)
 
+                # Flush stdout and stderr streams so that logs from the invocation are written out
+                if stdout:
+                    stdout.flush()
+                if stderr:
+                    stderr.flush()
+
     def _configure_interrupt(self, function_name, timeout, container, is_debugging):
         """
         When a Lambda function is executing, we setup certain interrupt handlers to stop the execution.

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -34,8 +34,8 @@ class LambdaRuntime_invoke(TestCase):
     def test_must_run_container_and_wait_for_logs(self, LambdaContainerMock):
         event = "event"
         code_dir = "some code dir"
-        stdout = "stdout"
-        stderr = "stderr"
+        stdout = Mock()
+        stderr = Mock()
         container = Mock()
         timer = Mock()
         debug_options = Mock()
@@ -81,12 +81,16 @@ class LambdaRuntime_invoke(TestCase):
         timer.cancel.assert_called_with()
         self.manager_mock.stop.assert_called_with(container)
 
+        # Flush streams
+        stdout.flush.assert_called()
+        stderr.flush.assert_called()
+
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_exception_from_run_must_trigger_cleanup(self, LambdaContainerMock):
         event = "event"
         code_dir = "some code dir"
-        stdout = "stdout"
-        stderr = "stderr"
+        stdout = Mock()
+        stderr = Mock()
         container = Mock()
         timer = Mock()
 
@@ -119,13 +123,16 @@ class LambdaRuntime_invoke(TestCase):
         timer.cancel.assert_not_called()
         # In any case, stop the container
         self.manager_mock.stop.assert_called_with(container)
+        # Flush streams
+        stdout.flush.assert_called()
+        stderr.flush.assert_called()
 
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_exception_from_wait_for_logs_must_trigger_cleanup(self, LambdaContainerMock):
         event = "event"
         code_dir = "some code dir"
-        stdout = "stdout"
-        stderr = "stderr"
+        stdout = Mock()
+        stderr = Mock()
         container = Mock()
         timer = Mock()
         debug_options = Mock()
@@ -159,13 +166,16 @@ class LambdaRuntime_invoke(TestCase):
         timer.cancel.assert_called_with()
         # In any case, stop the container
         self.manager_mock.stop.assert_called_with(container)
+        # Flush streams
+        stdout.flush.assert_called()
+        stderr.flush.assert_called()
 
     @patch("samcli.local.lambdafn.runtime.LambdaContainer")
     def test_keyboard_interrupt_must_not_raise(self, LambdaContainerMock):
         event = "event"
         code_dir = "some code dir"
-        stdout = "stdout"
-        stderr = "stderr"
+        stdout = Mock()
+        stderr = Mock()
         container = Mock()
 
         self.runtime = LambdaRuntime(self.manager_mock)
@@ -191,6 +201,9 @@ class LambdaRuntime_invoke(TestCase):
 
         # Finally block must be called
         self.manager_mock.stop.assert_called_with(container)
+        # Flush streams
+        stdout.flush.assert_called()
+        stderr.flush.assert_called()
 
 
 class TestLambdaRuntime_configure_interrupt(TestCase):


### PR DESCRIPTION
*Description of changes:*
The output from a single function invocation doesn't get necessarily written out due to buffering, and to get the output, you need to invoke the function again. 

I added conditional `stdout.flush()` and `stderr.flush()` to the `finally` block of the `invoke` function of the `LambdaRuntime`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
