### PR TITLE
WIP/Feedback: X-Ray daemon & service integrations.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,3 +13,4 @@ python-dateutil~=2.6
 pathlib2~=2.3.2; python_version<"3.4"
 requests~=2.20.0
 aws_lambda_builders==0.0.3
+aws-xray-sdk~=2.2.0

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -196,13 +196,20 @@ class LocalApiService(object):
         container_manager = self.lambda_runner.local_runtime.get_container_manager()
         xray_daemon_service = LocalXrayDaemonService(container_manager)
 
-        aws_creds = self.lambda_runner.get_aws_creds()
         region = None or self.lambda_runner.aws_region
+        key = None
+        secret = None
+        aws_creds = self.lambda_runner.get_aws_creds()
+
         if 'region' in aws_creds:  # Prefer aws creds region
             region = aws_creds['region']
 
-        xray_daemon_service.create(key=aws_creds['key'],
-                                   secret=aws_creds['secret'],
+        if 'key' in aws_creds and 'secret' in aws_creds:
+            key = aws_creds['key']
+            secret = aws_creds['secret']
+
+        xray_daemon_service.create(key=key,
+                                   secret=secret,
                                    region=region)
 
         return xray_daemon_service

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -39,13 +39,17 @@ and point SAM to the directory or file containing build artifacts.
               default="public",
               help="Any static assets (e.g. CSS/Javascript/HTML) files located in this directory "
                    "will be presented at /")
+@click.option("--xray", "-x",
+              is_flag=True,
+              envvar="SAM_ENABLE_XRAY",
+              help="Run X-Ray daemon and replicate Lambda X-Ray service integrations.")
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options  # pylint: disable=R0914
 @pass_context
 def cli(ctx,
         # start-api Specific Options
-        host, port, static_dir,
+        host, port, static_dir, xray,
 
         # Common Options for Lambda Invoke
         template, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
@@ -54,12 +58,12 @@ def cli(ctx,
 
     do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_args, debugger_path,
            docker_volume_basedir, docker_network, log_file, layer_cache_basedir, skip_pull_image, force_image_build,
-           parameter_overrides)  # pragma: no cover
+           parameter_overrides, xray)  # pragma: no cover
 
 
 def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_args,  # pylint: disable=R0914
            debugger_path, docker_volume_basedir, docker_network, log_file, layer_cache_basedir, skip_pull_image,
-           force_image_build, parameter_overrides):
+           force_image_build, parameter_overrides, xray):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
@@ -88,7 +92,8 @@ def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_ar
             service = LocalApiService(lambda_invoke_context=invoke_context,
                                       port=port,
                                       host=host,
-                                      static_dir=static_dir)
+                                      static_dir=static_dir,
+                                      xray_enable=xray)
             service.start()
 
     except NoApisDefined:

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -32,7 +32,7 @@ class Container(object):
                  image,
                  cmd,
                  working_dir,
-                 host_dir,
+                 host_dir=None,
                  memory_limit_mb=None,
                  exposed_ports=None,
                  entrypoint=None,
@@ -89,7 +89,12 @@ class Container(object):
         kwargs = {
             "command": self._cmd,
             "working_dir": self._working_dir,
-            "volumes": {
+            "volumes": {},
+            # We are not running an interactive shell here.
+            "tty": False
+        }
+        if self._host_dir:
+            kwargs["volumes"].update({
                 self._host_dir: {
                     # Mount the host directory as "read only" directory inside container at working_dir
                     # https://docs.docker.com/storage/bind-mounts
@@ -97,10 +102,7 @@ class Container(object):
                     "bind": self._working_dir,
                     "mode": "ro"
                 }
-            },
-            # We are not running an interactive shell here.
-            "tty": False
-        }
+            })
 
         if self._container_opts:
             kwargs.update(self._container_opts)

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -17,7 +17,8 @@ class LambdaContainer(Container):
     is provided by the base class
     """
 
-    _IMAGE_REPO_NAME = "lambci/lambda"
+    # _IMAGE_REPO_NAME = "lambci/lambda"
+    _IMAGE_REPO_NAME = "tanbouz/docker-lambda"  # TODO Temp fix for X-Ray trace id for testing.
     _WORKING_DIR = "/var/task"
 
     # The Volume Mount path for debug files in docker

--- a/samcli/local/docker/xray_container.py
+++ b/samcli/local/docker/xray_container.py
@@ -1,0 +1,36 @@
+"""
+Represents an AWS X-Ray daemon container.
+"""
+
+from .container import Container
+
+
+class XrayContainer(Container):
+    """
+    Represents an AWS X-Ray daemon container.
+    """
+
+    _IMAGE_REPO_NAME = "tanbouz/aws-xray-daemon:3.x"
+    _WORKING_DIR = "/var/task"
+
+    def __init__(self, memory_mb=128, env_vars=None):
+        """
+        Initializes the class
+
+        :param int memory_mb: Optional. Max limit of memory in MegaBytes this X-Ray daemon can use.
+        :param dict env_vars: Pass X-Ray daemon AWS credentials and AWS region using env variables.
+        """
+
+        xray_daemon_options = " ".join(["--local-mode",
+                                        "--bind 0.0.0.0:2000",
+                                        "--bind-tcp 0.0.0.0:2000"])
+
+        # Expose port to host so SAM CLI can access X-Ray daemon
+        # for simulating service integrations with X-Ray locally.
+        # TODO: make exposed port user configurable
+        super(XrayContainer, self).__init__(self._IMAGE_REPO_NAME,
+                                            xray_daemon_options,
+                                            self._WORKING_DIR,
+                                            exposed_ports={'2000/udp': 2000},
+                                            memory_limit_mb=memory_mb,
+                                            env_vars=env_vars)

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -180,6 +180,9 @@ class LambdaRuntime(object):
             if decompressed_dir:
                 shutil.rmtree(decompressed_dir)
 
+    def get_container_manager(self):
+        return self._container_manager
+
 
 def _unzip_file(filepath):
     """

--- a/samcli/local/xray/local_xray_daemon_service.py
+++ b/samcli/local/xray/local_xray_daemon_service.py
@@ -30,7 +30,7 @@ class LocalXrayDaemonService(object):
         :param string secret: AWS secret access key.
         :param string region: AWS region where X-Ray segments will be emitted to.
 
-        :raises UserException: If AWS region is missing.
+        :raises UserException: If the AWS region or AWS credentials are missing.
         """
         xray_daemon_envs = {
             'AWS_ACCESS_KEY_ID': key,
@@ -39,7 +39,9 @@ class LocalXrayDaemonService(object):
         }
 
         if not region:
-            raise UserException("X-Ray requires an AWS region to be specified using --region or an AWS profile.")
+            raise UserException("X-Ray option requires an AWS region. Please configure your credentials with a region or specify a region using --region.")
+        if not key and not secret:
+            raise UserException("X-Ray option requires AWS credentials. Please configure your credentials.")
 
         self._xray_container = XrayContainer(env_vars=xray_daemon_envs)
 

--- a/samcli/local/xray/local_xray_daemon_service.py
+++ b/samcli/local/xray/local_xray_daemon_service.py
@@ -1,0 +1,63 @@
+"""
+AWS X-ray daemon service.
+"""
+
+import logging
+import docker
+
+from samcli.local.docker.xray_container import XrayContainer
+from samcli.commands.exceptions import UserException
+
+LOG = logging.getLogger(__name__)
+
+
+class LocalXrayDaemonService(object):
+    def __init__(self, container_manager):
+        """
+        Creates an LocalXrayDaemonService
+
+        :param container_manager samcli.local.docker.manager.ContainerManager:
+            Container manager being used to run Lambda invokations.
+        """
+        self._xray_container = None
+        self._container_manager = container_manager
+
+    def create(self, key, secret, region):
+        """
+        Creates an X-Ray docker container.
+
+        :param string key: AWS access key ID with necessary X-Ray IAM write permissions.
+        :param string secret: AWS secret access key.
+        :param string region: AWS region where X-Ray segments will be emitted to.
+
+        :raises UserException: If AWS region is missing.
+        """
+        xray_daemon_envs = {
+            'AWS_ACCESS_KEY_ID': key,
+            'AWS_SECRET_ACCESS_KEY': secret,
+            'AWS_REGION': region
+        }
+
+        if not region:
+            raise UserException("X-Ray requires an AWS region to be specified using --region or an AWS profile.")
+
+        self._xray_container = XrayContainer(env_vars=xray_daemon_envs)
+
+    def run(self):
+        """
+        Run an X-Ray docker container.
+        """
+        self._container_manager.run(self._xray_container)
+
+    def stop(self):
+        """
+        Stop an X-Ray docker container.
+        """
+        self._container_manager.stop(self._xray_container)
+
+    def get_daemon_address(self):
+        """
+        Get IP address of the X-Ray daemon container in the the Docker network.
+        """
+        client = docker.from_env()
+        return client.api.inspect_container(self._xray_container.id)['NetworkSettings']['IPAddress']

--- a/samcli/local/xray/xray_lambda.py
+++ b/samcli/local/xray/xray_lambda.py
@@ -1,0 +1,68 @@
+"""
+Replicate AWS X-Ray Lambda integration locally.
+"""
+import logging
+from aws_xray_sdk.core import xray_recorder
+
+LOG = logging.getLogger(__name__)
+
+
+class XrayLambdaIntegration(object):
+    def __init__(self, xray_daemon_address):
+        """
+        Creates an XrayLambdaIntegration for a Lambda runtime.
+        XrayLambdaIntegration should run in Lambda's own thread since
+        xray_recorder's context can only synchronously handle one active segment at a time.
+        """
+        self._xray_daemon_address = xray_daemon_address
+        self._current_trace_id = ""
+
+    def begin_lambda_segment(self, function_name):
+        """
+        Replicates Lambda X-Ray integration segments.
+
+        :param string function_name: Name of the Lambda function being invoked.
+        """
+        xray_recorder.configure(sampling=False, daemon_address='127.0.0.1:2000')
+
+        # Replicate AWS::Lambda segment
+        xray_recorder.begin_segment(function_name)
+        lambda_segment = xray_recorder.current_segment()
+        lambda_segment.set_service(None)
+        setattr(lambda_segment, 'origin', 'AWS::Lambda')
+        xray_recorder.end_segment()
+
+        # Replicate AWS::Lambda::Function and Initialization subsegment
+        xray_recorder.begin_segment(function_name, traceid=lambda_segment.trace_id, parent_id=lambda_segment.id)
+
+        lambda_function_segment = xray_recorder.current_segment()
+        lambda_function_segment.set_service(None)
+        setattr(lambda_function_segment, 'origin', 'AWS::Lambda::Function')
+
+        xray_recorder.begin_subsegment('Initialization')
+        xray_recorder.end_subsegment()
+        # Don't end AWS::Lambda::Function segment yet. To be ended after the user's function returns.
+
+        # Generate the Trace ID environment variable
+        self._current_trace_id = 'Root={trace_id};Parent={parent_id};Sampled=1'.format(
+            trace_id=lambda_segment.trace_id, parent_id=lambda_function_segment.id)
+
+    def end_lambda_segment(self):
+        """
+        Call to end AWS::Lambda::Function segment after invoked user's lambda function returns.
+        """
+        xray_recorder.end_segment()
+
+    def get_lambda_envs(self):
+        """
+        Prepare X-Ray related Lambda environment variables.
+
+        :return dict: X-Ray environment variables.
+        """
+        return {
+            '_AWS_XRAY_DAEMON_ADDRESS': self._xray_daemon_address,
+            '_AWS_XRAY_DAEMON_PORT': '2000',
+            'AWS_XRAY_DAEMON_ADDRESS': self._xray_daemon_address + ':2000',
+            'AWS_XRAY_CONTEXT_MISSING': 'LOG_ERROR',
+            '_X_AMZN_TRACE_ID': self._current_trace_id
+        }


### PR DESCRIPTION
***Issue:*** _[Feature Request] Add support for X-Ray on SAM Local_ https://github.com/awslabs/aws-sam-cli/issues/217

This does **not** replicate AWS X-Ray service itself. It attempts to:

- Run X-Ray daemon in a docker container locally to be available for SAM CLI and Invoked Lambda functions.
- Mimic [X-Ray Lambda integration](https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html) "Tracing" or "Enable active tracing" locally.
- Mimic [X-Ray API Gateway intergration](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) "Enable X-Ray Tracing" locally.

The X-Ray segments **will still be** emitted to your AWS account if the AWS creds allow so. Better use a non-production AWS account!

***Description of changes:***

- [x] Optionally run (`--xray` `-x` only in `start-api`) an X-Ray daemon service in [a docker container](https://hub.docker.com/r/tanbouz/aws-xray-daemon/) alongside other invoked Lambdas.
- [x] Enable Lambda's X-Ray integration by emitting segments created by real Lambdas. `AWS::Lambda` and `AWS::Lambda::Function`.
- [x] Make usable X-Ray environment variables inside the Lambda runtime (Working `_X_AMZN_TRACE_ID` and `let segment = new AWSXRay.getSegment()` for example)
- [ ] 🚨 **Blocking** - PR to upstream Lambda docker container to allow `_X_AMZN_TRACE_ID` to be available inside Lambda in all runtimes. Fix only applied to nodejs8.10 for testing https://github.com/Tanbouz/docker-lambda/commit/4328937d0b436da4483e644bd4c1d8246ea20e68
- [ ] ⚠️ Important - Respect SAM template Lambda's `Tracing` setting.
- [ ] ⚠️ Important - Improve handling of a failed X-Ray daemon service.
- [ ] ⚠️ Important - Maybe allow exposed port to be reconfigured by user to avoid port conflicts.
- [ ] ⚠️ Important - Attempt to make generated X-Ray Integration segments match as closely as possible.
- [ ] 🍰 Additional feature - X-Ray API Gateway integration.
- [ ] 🔮 Future - Tests awaiting feedback and finalizing API/features.
- [ ] 🔮 Future - Respect SAM template API Gateway's X-Ray setting https://github.com/awslabs/serverless-application-model/issues/581

**Sample**
X-Ray segments submitted from SAM CLI. `Interceptor` was my Lambda function name. The crossed out subsegment was added inside my Lambda function code.
![X-Ray segments submitted from SAM CLI](https://i.imgur.com/tNRSDzJ.png)

**Other issues:**
- X-Ray daemon seems to buffer segments and didn't work at least from my testing if started and stopped with a Lambda function. Must be a long running background process. That is why only `start-api` for now.

**Tests:**
- [x] Lint pass
- [ ] Tests were mostly fixed locally - awaiting feedback.
- [ ] Fails due to code coverage

**Requesting feedback.**  
😞 *Had a hard time figuring where to place the code within the project structure too, feedback welcome*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 👍 