### PR TITLE
feat(request-templates): API Request Data Mapping

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,4 +11,5 @@ docker>=3.3.0
 dateparser~=0.7
 python-dateutil~=2.6
 pathlib2~=2.3.2; python_version<"3.4"
-
+airspeed~=0.5.10
+jsonpath-rw~=1.4.0

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -100,7 +100,7 @@ class LocalApiService(object):
         routes = []
         for api in api_provider.get_all():
             route = Route(methods=[api.method], function_name=api.function_name, path=api.path,
-                          binary_types=api.binary_media_types)
+                          binary_types=api.binary_media_types, request_template=api.request_template)
             routes.append(route)
 
         return routes

--- a/samcli/commands/local/lib/provider.py
+++ b/samcli/commands/local/lib/provider.py
@@ -75,10 +75,16 @@ _ApiTuple = namedtuple("Api", [
     "cors",
 
     # List(Str). List of the binary media types the API
-    "binary_media_types"
+    "binary_media_types",
+
+    # String. Optional velocity template.
+    # If this configuration is set, then the event passed to the function
+    # will be transformed using Velocity templating language.
+    "request_template"
 ])
 _ApiTuple.__new__.__defaults__ = (None,  # Cors is optional and defaults to None
-                                  []     # binary_media_types is optional and defaults to empty
+                                  [],    # binary_media_types is optional and defaults to empty
+                                  None   # request_template is optional and defaults to None
                                   )
 
 

--- a/samcli/local/velocity/mapping_models.py
+++ b/samcli/local/velocity/mapping_models.py
@@ -1,0 +1,72 @@
+"""Velocity template model definitions"""
+
+from samcli.local.velocity import util
+
+
+class VelocityObject(object):
+    def __init__(self, adict):
+        """Convert a dictionary to a class
+
+        @param :adict Dictionary
+        """
+        self.__dict__.update(adict)
+        for k, v in adict.items():
+            if isinstance(v, dict):
+                self.__dict__[k] = VelocityObject(v)
+
+    def size(self):
+        return len(self.__dict__.keys())
+
+
+class BaseModel(object):
+    def __init__(self, event):
+        self.event = event
+
+    def _get_param(self, param=None):
+        import pytest
+        pytest.set_trace()
+
+        if param is None:
+            # return everything if no specific parameter is specified
+            return {
+                'header': self.event.headers,
+                'querystring': self.event.query_string_params,
+                'path': self.event.path_parameters
+            }
+
+        # return the parameter if it exists
+        # if param exists in multiple places, use hierarchy: path, query, header
+        return self.event.path_parameters.get(param) \
+            or self.event.get.query_string_parameters.get(param) \
+            or self.event.headers.get(param)
+
+    def _get_json_path(self, path):
+        return util.get_json_path(path, self.event.body)
+
+
+class ApiGatewayRequestModel(BaseModel):
+    """
+    Constructs an API Gateway Request Model
+
+    The variables and helpers in this model are available for use
+    by velocity template for API Gateway requests.
+    """
+
+    def to_model(self):
+        return {
+            "input": {
+                "body": self.event.body,
+                "json": self._get_json_path,
+                "params": self._get_param,
+                "path": self._get_json_path
+            },
+            "context": self.event.request_context.to_dict(),
+            "util": {
+                "escapeJavaScript": util.escape_javascript,
+                "parseJson": util.parse_json,
+                "urlEncode": util.url_encode,
+                "urlDecode": util.url_decode,
+                "base64Encode": util.base64_encode,
+                "base64Decode": util.base64_decode
+            }
+        }

--- a/samcli/local/velocity/render.py
+++ b/samcli/local/velocity/render.py
@@ -1,0 +1,9 @@
+"""Request mapping and helper functions"""
+
+from airspeed import Template
+
+
+class VelocityTemplateRenderer(object):
+    @staticmethod
+    def render(template, event):
+        return Template(template).merge(event.to_model())

--- a/samcli/local/velocity/util.py
+++ b/samcli/local/velocity/util.py
@@ -1,0 +1,39 @@
+"""Utility functions that can be used in velocity templates."""
+
+from json import loads, dumps
+from urllib2 import quote, unquote
+from base64 import b64encode, b64decode
+from jsonpath_rw import parse
+
+
+def escape_javascript(unescaped_str):
+    return dumps(unescaped_str)
+
+
+def parse_json(raw_json):
+    return loads(raw_json)
+
+
+def url_encode(url):
+    return quote(url)
+
+
+def url_decode(url):
+    return unquote(url)
+
+
+def base64_encode(val):
+    return b64encode(val)
+
+
+def base64_decode(val):
+    return b64decode(val)
+
+
+def get_json_path(path, data):
+    match_result = [match.value for match in parse(path).find(loads(data))]
+
+    if match_result > 0:
+        return match_result[0]
+
+    return None

--- a/tests/unit/commands/local/lib/test_local_api_service.py
+++ b/tests/unit/commands/local/lib/test_local_api_service.py
@@ -106,13 +106,13 @@ class TestLocalApiService_make_routing_list(TestCase):
     def test_must_return_routing_list_from_apis(self):
         api_provider = Mock()
         apis = [
-            Api(path="/1", method="GET1", function_name="name1", cors="CORS1"),
-            Api(path="/2", method="GET2", function_name="name2", cors="CORS2"),
+            Api(path="/1", method="GET1", function_name="name1", cors="CORS1", request_template="TEMPLATE1"),
+            Api(path="/2", method="GET2", function_name="name2", cors="CORS2", request_template="TEMPLATE2"),
             Api(path="/3", method="GET3", function_name="name3", cors="CORS3"),
         ]
         expected = [
-            Route(path="/1", methods=["GET1"], function_name="name1"),
-            Route(path="/2", methods=["GET2"], function_name="name2"),
+            Route(path="/1", methods=["GET1"], function_name="name1", request_template="TEMPLATE1"),
+            Route(path="/2", methods=["GET2"], function_name="name2", request_template="TEMPLATE2"),
             Route(path="/3", methods=["GET3"], function_name="name3")
         ]
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -409,14 +409,16 @@ class TestService_construct_event(TestCase):
         self.expected_dict = json.loads(expected)
 
     def test_construct_event_with_data(self):
-        actual_event_str = LocalApigwService._construct_event(self.request_mock, 3000, binary_types=[])
+        actual_event_str = LocalApigwService._construct_event(self.request_mock, 3000,
+                                                              binary_types=[], request_template=None)
         self.assertEquals(json.loads(actual_event_str), self.expected_dict)
 
     def test_construct_event_no_data(self):
         self.request_mock.get_data.return_value = None
         self.expected_dict["body"] = None
 
-        actual_event_str = LocalApigwService._construct_event(self.request_mock, 3000, binary_types=[])
+        actual_event_str = LocalApigwService._construct_event(self.request_mock, 3000,
+                                                              binary_types=[], request_template=None)
         self.assertEquals(json.loads(actual_event_str), self.expected_dict)
 
     @patch('samcli.local.apigw.local_apigw_service.LocalApigwService._should_base64_encode')
@@ -430,7 +432,8 @@ class TestService_construct_event(TestCase):
         self.expected_dict["body"] = base64_body
         self.expected_dict["isBase64Encoded"] = True
 
-        actual_event_str = LocalApigwService._construct_event(self.request_mock, 3000, binary_types=[])
+        actual_event_str = LocalApigwService._construct_event(self.request_mock, 3000,
+                                                              binary_types=[], request_template=None)
         self.assertEquals(json.loads(actual_event_str), self.expected_dict)
 
     def test_query_string_params_with_empty_params(self):


### PR DESCRIPTION
*Issue #, if available:*
#299 

*Description of changes:*
- Add support for VTL request template mapping (matches [API Gateway Mapping Template Reference Documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html)). The following are supported:
  - `$context`
  - `$input`
  - `$stageVariables`
  - `$util`
- Request templates must be defined in `x-amazon-apigateway-integration` in the swagger definition, for example:
```
...
x-amazon-apigateway-integration:
    uri:
      Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations
    requestTemplates:
      application/json: "...VTL TEMPLATE HERE..."
...
```

This is a WIP. Remaining:
- [ ] Tests
- [ ] Documentation
- [ ] Examples

Known caveats/limitations:
- [`$method`](https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html) is not supported.
- Java string functions (e.g. `replaceAll`) are not supported. This means that things like `$util.escapeJavaScript($input.json('$.errorMessage')).replaceAll("\\'","'")` don't work, but `$util.escapeJavaScript($input.json('$.errorMessage'))` will.
- Kinda unrelated, but something I noticed. `Fn::Sub` isn't fully implemented so the following will result in the wrong function name being returned:
```
# parsed function name is CORRECT
Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations

# parsed function name is INCORRECT (returns "FunctionArn" instead of MyFunction.Arn)
Fn::Sub:
  - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FunctionArn}/invocations
  - { FunctionArn: !GetAtt MyFunction.Arn }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
