### PR TITLE
fix: Attempt to recover/invoke function when docker connectivity is poor

### DIFF
--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -12,6 +12,7 @@ from samcli.commands.local.cli_common.invoke_context import InvokeContext
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
+from samcli.local.docker.manager import DockerImagePullFailedException
 
 
 LOG = logging.getLogger(__name__)
@@ -97,6 +98,8 @@ def do_cli(ctx, function_identifier, template, event, no_event, env_vars, debug_
     except FunctionNotFound:
         raise UserException("Function {} not found in template".format(function_identifier))
     except (InvalidSamDocumentException, OverridesNotWellDefinedError) as ex:
+        raise UserException(str(ex))
+    except DockerImagePullFailedException as ex:
         raise UserException(str(ex))
 
 

--- a/tests/unit/local/docker/test_manager.py
+++ b/tests/unit/local/docker/test_manager.py
@@ -6,8 +6,8 @@ import io
 
 from unittest import TestCase
 from mock import Mock
-from docker.errors import ImageNotFound
-from samcli.local.docker.manager import ContainerManager, DockerImageNotFoundException
+from docker.errors import APIError, ImageNotFound
+from samcli.local.docker.manager import ContainerManager, DockerImagePullFailedException
 
 
 class TestContainerManager_init(TestCase):
@@ -86,6 +86,41 @@ class TestContainerManager_run(TestCase):
         self.manager.pull_image.assert_not_called()
         self.container_mock.start.assert_called_with(input_data=input_data)
 
+    def test_must_fail_if_image_pull_failed_and_image_does_not_exist(self):
+        input_data = "input data"
+
+        self.manager.has_image = Mock()
+        self.manager.pull_image = Mock(side_effect=DockerImagePullFailedException("Failed to pull image"))
+
+        # Assume the image exist.
+        self.manager.has_image.return_value = False
+        # And, don't skip pulling => Pull again
+        self.manager.skip_pull_image = False
+
+        with self.assertRaises(DockerImagePullFailedException):
+            self.manager.run(self.container_mock, input_data)
+
+        self.manager.has_image.assert_called_with(self.image_name)
+        self.manager.pull_image.assert_called_with(self.image_name)
+        self.container_mock.start.assert_not_called()
+
+    def test_must_run_if_image_pull_failed_and_image_does_exist(self):
+        input_data = "input data"
+
+        self.manager.has_image = Mock()
+        self.manager.pull_image = Mock(side_effect=DockerImagePullFailedException("Failed to pull image"))
+
+        # Assume the image exist.
+        self.manager.has_image.return_value = True
+        # And, don't skip pulling => Pull again
+        self.manager.skip_pull_image = False
+
+        self.manager.run(self.container_mock, input_data)
+
+        self.manager.has_image.assert_called_with(self.image_name)
+        self.manager.pull_image.assert_called_with(self.image_name)
+        self.container_mock.start.assert_called_with(input_data=input_data)
+
     def test_must_create_container_if_not_exists(self):
         input_data = "input data"
         self.manager.has_image = Mock()
@@ -143,9 +178,9 @@ class TestContainerManager_pull_image(TestCase):
 
     def test_must_raise_if_image_not_found(self):
         msg = "some error"
-        self.mock_docker_client.api.pull.side_effect = ImageNotFound(msg)
+        self.mock_docker_client.api.pull.side_effect = APIError(msg)
 
-        with self.assertRaises(DockerImageNotFoundException) as context:
+        with self.assertRaises(DockerImagePullFailedException) as context:
             self.manager.pull_image("imagename")
 
         ex = context.exception


### PR DESCRIPTION
*Issue #, if available:*
#529 and #451

*Description of changes:*
When working completely offline, SAM CLI fails when trying to download the docker image. Instead of failing right away, we will check to see if we have an older image that we could use instead. If we do not have an image locally, we fail gracefully with a message describing we could not download the image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
