### PR TITLE
API Gateway path validator

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -6,6 +6,7 @@ import base64
 
 from flask import Flask, request
 
+from samcli.commands.exceptions import UserException
 from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser, CaseInsensitiveDict
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.local.events.api_event import ContextIdentity, RequestContext, ApiGatewayLambdaEvent
@@ -72,9 +73,9 @@ class LocalApigwService(BaseLocalService):
         for api_gateway_route in self.routing_list:
 
             if not PathValidator.is_valid(api_gateway_route.path):
-                message = 'Api\'s Event source\'s Path parameter only allow a-zA-Z0-9._- and curly braces.\nInvalid Path: "{}")'.format(api_gateway_route.path )
-                LOG.error(message)
-                raise TypeError(message)
+                message = ("Api's Event source's Path parameter only allow a-zA-Z0-9._-+ and curly braces."
+                           "\nInvalid Path: \"{}\"".format(api_gateway_route.path))
+                raise UserException(message)
 
             path = PathConverter.convert_path_to_flask(api_gateway_route.path)
             for route_key in self._generate_route_keys(api_gateway_route.methods,

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -11,6 +11,7 @@ from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.local.events.api_event import ContextIdentity, RequestContext, ApiGatewayLambdaEvent
 from .service_error_responses import ServiceErrorResponses
 from .path_converter import PathConverter
+from .path_validator import PathValidator
 
 LOG = logging.getLogger(__name__)
 
@@ -69,6 +70,12 @@ class LocalApigwService(BaseLocalService):
                           )
 
         for api_gateway_route in self.routing_list:
+
+            if not PathValidator.is_valid(api_gateway_route.path):
+                message = 'Api\'s Event source\'s Path parameter only allow a-zA-Z0-9._- and curly braces.\nInvalid Path: "{}")'.format(api_gateway_route.path )
+                LOG.error(message)
+                raise TypeError(message)
+
             path = PathConverter.convert_path_to_flask(api_gateway_route.path)
             for route_key in self._generate_route_keys(api_gateway_route.methods,
                                                        path):

--- a/samcli/local/apigw/path_validator.py
+++ b/samcli/local/apigw/path_validator.py
@@ -1,0 +1,34 @@
+"""
+Validator class that checks Api Gateway paths are valid
+
+By validating the paths here, we guarantee paths created with SAM don't result in an error
+on a later stage, when deploying the template.
+"""
+
+import re
+
+# This is the error the Api Gateway returns when the path is not valid:
+# "Resource's path part only allow a-zA-Z0-9._- and curly braces at the beginning and the end."
+
+# Note that this message refers to a specific resource, therefore the curly braces rule
+# (the specific restriction of having them at the beginning and end) shouldn't apply to the
+# path (which is a composition of resources).
+ALLOWED_PATH_CHARS = r"[A-Za-z0-9_-{}\/\.]*$"
+
+PATH_VALIDATOR_REGEX = re.compile(ALLOWED_PATH_CHARS)
+
+class PathValidator(object):
+
+  @staticmethod
+  def is_valid(path):
+    """
+    Validates the Api Gateway Path is valid (only includes a-zA-Z0-9._- and curly braces)
+
+    Examples:
+
+    '/path/to/something' => true
+    '/path/to/~something' => false
+    """
+
+    return bool(PATH_VALIDATOR_REGEX.match(path))
+            

--- a/samcli/local/apigw/path_validator.py
+++ b/samcli/local/apigw/path_validator.py
@@ -13,22 +13,22 @@ import re
 # Note that this message refers to a specific resource, therefore the curly braces rule
 # (the specific restriction of having them at the beginning and end) shouldn't apply to the
 # path (which is a composition of resources).
-ALLOWED_PATH_CHARS = r"[A-Za-z0-9_-{}\/\.]*$"
+ALLOWED_PATH_CHARS = r"[A-Za-z0-9\_\-\{\}\/\.\+]*$"
 
 PATH_VALIDATOR_REGEX = re.compile(ALLOWED_PATH_CHARS)
 
 class PathValidator(object):
 
-  @staticmethod
-  def is_valid(path):
-    """
-    Validates the Api Gateway Path is valid (only includes a-zA-Z0-9._- and curly braces)
+    @staticmethod
+    def is_valid(path):
+        """
+        Validates the Api Gateway Path is valid (only includes a-zA-Z0-9._-+ and curly braces)
 
-    Examples:
+        Examples:
 
-    '/path/to/something' => true
-    '/path/to/~something' => false
-    """
+        '/path/to/something' => true
+        '/path/to/~something' => false
+        """
 
-    return bool(PATH_VALIDATOR_REGEX.match(path))
+        return bool(PATH_VALIDATOR_REGEX.match(path))
             

--- a/samcli/local/apigw/path_validator.py
+++ b/samcli/local/apigw/path_validator.py
@@ -31,4 +31,3 @@ class PathValidator(object):
         """
 
         return bool(PATH_VALIDATOR_REGEX.match(path))
-            

--- a/samcli/local/apigw/path_validator.py
+++ b/samcli/local/apigw/path_validator.py
@@ -17,6 +17,7 @@ ALLOWED_PATH_CHARS = r"[A-Za-z0-9\_\-\{\}\/\.\+]*$"
 
 PATH_VALIDATOR_REGEX = re.compile(ALLOWED_PATH_CHARS)
 
+
 class PathValidator(object):
 
     @staticmethod

--- a/tests/unit/local/apigw/test_path_validator.py
+++ b/tests/unit/local/apigw/test_path_validator.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from samcli.local.apigw.path_validator import PathValidator
+
+
+class TestPathValidator(TestCase):
+
+    @parameterized.expand([("/{resource+}"),
+                           ("/a/{id}/b/{resource+}"),
+                           ("/a/b/{proxy}/{resource+}"),
+                           ("/{id}/{something+}"),
+                           ("/{a}/{b}/{c}/{d+}"),
+                           ("/totally/static/path"),
+                           ("/something/{dynamic}"),
+                           ("/strange-chars/H3ll0_World.1234")
+                           ])
+
+    def test_is_valid_path(self, path):
+        is_valid = PathValidator.is_valid(path)
+
+        self.assertTrue(is_valid)
+
+
+    @parameterized.expand([("/~route-with-tilde"),
+                           ("/path/to/~route"),
+                           ("/~path/{id}")
+                           ])
+                           
+    def test_is_not_valid_path(self, path):
+        is_valid = PathValidator.is_valid(path)
+
+        self.assertFalse(is_valid)

--- a/tests/unit/local/apigw/test_path_validator.py
+++ b/tests/unit/local/apigw/test_path_validator.py
@@ -16,18 +16,15 @@ class TestPathValidator(TestCase):
                            ("/something/{dynamic}"),
                            ("/strange-chars/H3ll0_World.1234")
                            ])
-
     def test_is_valid_path(self, path):
         is_valid = PathValidator.is_valid(path)
 
         self.assertTrue(is_valid)
 
-
     @parameterized.expand([("/~route-with-tilde"),
                            ("/path/to/~route"),
                            ("/~path/{id}")
                            ])
-                           
     def test_is_not_valid_path(self, path):
         is_valid = PathValidator.is_valid(path)
 


### PR DESCRIPTION
*Description of changes:*

By using SAM local, I discovered that while everything was working locally, the `deploy` was failing because of an invalid route path (it contained an invalid char `~`). I found the experience confusing and decided to create a Pull Request for alerting the user early in the development rather on the deploy phase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
