### PR TITLE
Documentation updates + "sam package" defaults to built template

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -18,6 +18,8 @@ from samcli.commands.exceptions import UserException
 
 class BuildContext(object):
 
+    # Build directories need not be world writable.
+    # This is usually a optimal permission for directories
     _BUILD_DIR_PERMISSIONS = 0o755
 
     def __init__(self,

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -24,7 +24,7 @@ Use this command to build your AWS Lambda Functions source code to generate arti
 Supported Resource Types
 ------------------------
 1. AWS::Serverless::Function\n
-2.AWS::Lambda::Function\n
+2. AWS::Lambda::Function\n
 \b
 Supported Runtimes
 ------------------

--- a/samcli/commands/deploy/__init__.py
+++ b/samcli/commands/deploy/__init__.py
@@ -23,4 +23,4 @@ def cli(ctx, args):
 
 
 def do_cli(args):
-    execute_command("deploy", args)
+    execute_command("deploy", args, template_file=None)

--- a/samcli/commands/package/__init__.py
+++ b/samcli/commands/package/__init__.py
@@ -2,9 +2,11 @@
 CLI command for "package" command
 """
 
+from functools import partial
 import click
 
 from samcli.cli.main import pass_context, common_options
+from samcli.commands._utils.options import get_or_default_template_file_name, _TEMPLATE_OPTION_DEFAULT_VALUE
 from samcli.lib.samlib.cloudformation_command import execute_command
 
 
@@ -12,15 +14,21 @@ SHORT_HELP = "Package an AWS SAM application. This is an alias for 'aws cloudfor
 
 
 @click.command("package", short_help=SHORT_HELP, context_settings={"ignore_unknown_options": True})
+@click.option('--template-file',
+              default=_TEMPLATE_OPTION_DEFAULT_VALUE,
+              type=click.Path(),
+              callback=partial(get_or_default_template_file_name, include_build=True),
+              show_default=False,
+              help="The path where your AWS SAM template is located")
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 @common_options
 @pass_context
-def cli(ctx, args):
+def cli(ctx, args, template_file):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(args)  # pragma: no cover
+    do_cli(args, template_file)  # pragma: no cover
 
 
-def do_cli(args):
-    execute_command("package", args)
+def do_cli(args, template_file):
+    execute_command("package", args, template_file)

--- a/samcli/lib/samlib/cloudformation_command.py
+++ b/samcli/lib/samlib/cloudformation_command.py
@@ -10,11 +10,17 @@ import sys
 LOG = logging.getLogger(__name__)
 
 
-def execute_command(command, args):
+def execute_command(command, args, template_file):
     LOG.debug("%s command is called", command)
     try:
         aws_cmd = 'aws' if platform.system().lower() != 'windows' else 'aws.cmd'
-        subprocess.check_call([aws_cmd, 'cloudformation', command] + list(args))
+
+        args = list(args)
+        if template_file:
+            # Since --template-file was parsed separately, add it here manually
+            args.extend(["--template-file", template_file])
+
+        subprocess.check_call([aws_cmd, 'cloudformation', command] + args)
         LOG.debug("%s command successful", command)
     except subprocess.CalledProcessError as e:
         # Underlying aws command will print the exception to the user

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -19,7 +19,7 @@ def mkdir_temp(mode=0o755):
     Parameters
     ----------
     mode : octal
-        Permissions to apply to the directory
+        Permissions to apply to the directory. Defaults to '755' because don't want directories world writable
 
     Returns
     -------

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/README.md
@@ -6,10 +6,10 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 .
 ├── README.md                   <-- This instructions file
 ├── hello_world                 <-- Source code for a lambda function
-│   ├── __init__.py
-│   └── app.py                  <-- Lambda function code
-├── requirements.txt            <-- Python dependencies
-├── template.yaml               <-- SAM template
+│   ├── __init__.py
+│   ├── app.py                  <-- Lambda function code
+│   └── requirements.txt        <-- Python dependencies
+├── template.yaml               <-- SAM Template
 └── tests                       <-- Unit tests
     └── unit
         ├── __init__.py
@@ -29,19 +29,21 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 
 ## Setup process
 
-### Installing dependencies
+### Building the project
 
-[AWS Lambda requires a flat folder](https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html) with the application as well as its dependencies. Therefore, we need to have a 2 step process in order to enable local testing as well as packaging/deployment later on - This consist of two commands you can run as follows:
-
+[AWS Lambda requires a flat folder](https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html) with the application as well as its dependencies. When you make changes to your source code or dependency manifest,
+run the following command to build your project local testing and deployment:
+ 
 ```bash
-pip install -r requirements.txt -t hello_world/build/
-cp hello_world/*.py hello_world/build/
+sam build
 ```
 
-1. Step 1 install our dependencies into ``build`` folder 
-2. Step 2 copies our application into ``build`` folder
-
-**NOTE:** As you change your application code as well as dependencies during development you'll need to make sure these steps are repeated in order to execute your Lambda and/or API Gateway locally.
+If your dependencies contain native modules that need to be compiled specifically for the operating system running on AWS Lambda, use this command to build inside a Lambda-like Docker container instead:
+```bash
+sam build --use-container
+```
+ 
+By default, this command writes built artifacts to `.aws-sam/build` folder.
 
 ### Local development
 
@@ -88,7 +90,6 @@ Next, run the following command to package our Lambda function to S3:
 
 ```bash
 sam package \
-    --template-file template.yaml \
     --output-template-file packaged.yaml \
     --s3-bucket REPLACE_THIS_WITH_YOUR_S3_BUCKET_NAME
 ```
@@ -161,7 +162,6 @@ AWS CLI commands to package, deploy and describe outputs defined within the clou
 
 ```bash
 sam package \
-    --template-file template.yaml \
     --output-template-file packaged.yaml \
     --s3-bucket REPLACE_THIS_WITH_YOUR_S3_BUCKET_NAME
 

--- a/tests/unit/commands/test_deploy.py
+++ b/tests/unit/commands/test_deploy.py
@@ -17,4 +17,4 @@ class TestCli(TestCase):
     def test_deploy_must_pass_args(self, execute_command_mock):
         execute_command_mock.return_value = True
         deploy_cli(self.args)
-        execute_command_mock.assert_called_with("deploy", self.args)
+        execute_command_mock.assert_called_with("deploy", self.args, template_file=None)

--- a/tests/unit/commands/test_package.py
+++ b/tests/unit/commands/test_package.py
@@ -16,5 +16,5 @@ class TestCli(TestCase):
     @patch("samcli.commands.package.execute_command")
     def test_package_must_pass_args(self, execute_command_mock):
         execute_command_mock.return_value = True
-        package_cli(self.args)
-        execute_command_mock.assert_called_with("package", self.args)
+        package_cli(self.args, "template_file")
+        execute_command_mock.assert_called_with("package", self.args, "template_file")

--- a/tests/unit/lib/samlib/test_cloudformation_command.py
+++ b/tests/unit/lib/samlib/test_cloudformation_command.py
@@ -17,10 +17,21 @@ class TestCli(TestCase):
 
     @patch("subprocess.check_call")
     @patch("platform.system")
+    def test_must_add_template_file(self, platform_system_mock, check_call_mock):
+        platform_system_mock.return_value = "Linux"
+        check_call_mock.return_value = True
+        execute_command("command", self.args, "/path/to/template")
+
+        check_call_mock.assert_called_with(["aws", "cloudformation", "command"] +
+                                           ["--arg1", "value1", "different args", "more",
+                                            "--template-file", "/path/to/template"])
+
+    @patch("subprocess.check_call")
+    @patch("platform.system")
     def test_command_must_call_aws_linux(self, platform_system_mock, check_call_mock):
         platform_system_mock.return_value = "Linux"
         check_call_mock.return_value = True
-        execute_command("command", self.args)
+        execute_command("command", self.args, None)
         check_call_mock.assert_called_with(["aws", "cloudformation", "command"] + list(self.args))
 
     @patch("subprocess.check_call")
@@ -28,7 +39,7 @@ class TestCli(TestCase):
     def test_command_must_call_aws_windows(self, platform_system_mock, check_call_mock):
         platform_system_mock.return_value = "Windows"
         check_call_mock.return_value = True
-        execute_command("command", self.args)
+        execute_command("command", self.args, None)
         check_call_mock.assert_called_with(["aws.cmd", "cloudformation", "command"] + list(self.args))
 
     @patch("sys.exit")
@@ -38,5 +49,5 @@ class TestCli(TestCase):
         platform_system_mock.return_value = "Any"
         check_call_mock.side_effect = CalledProcessError(2, "Error")
         exit_mock.return_value = True
-        execute_command("command", self.args)
+        execute_command("command", self.args, None)
         exit_mock.assert_called_with(2)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `sam init` Python example README changes to include `sam build`
- `sam package` command now just defaults to a built template. So you can do `sam build && sam package --s3-bucket foo` to build and then package. Don't need to manually wire the intermediate template files through.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
