### PR TITLE
Fix astroid version

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,7 @@ coverage==4.3.4
 flake8==3.3.0
 tox==2.2.1
 pytest-cov==2.4.0
+# astroid > 2.0.4 is not compatible with pylint1.7
 astroid>=1.5.8,<2.1.0
 pylint==1.7.2
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,7 @@ coverage==4.3.4
 flake8==3.3.0
 tox==2.2.1
 pytest-cov==2.4.0
+astroid>=1.5.8,<2.1.0
 pylint==1.7.2
 
 # Test requirements


### PR DESCRIPTION
## Problem
Unit tests started to fail with unexpected error: `AttributeError: module 'astroid' has no attribute 'YES'`

## Solution
Pinned `astroid` package version in >=1.5.8,<2.1.0 range

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
