### PR TITLE
refactor: Update pylint and fix functional tests

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,8 @@ tox==2.2.1
 pytest-cov==2.4.0
 # astroid > 2.0.4 is not compatible with pylint1.7
 astroid>=1.5.8,<2.1.0
-pylint==1.7.2
+# pylint > 1.9 is not Python2.7 compatible
+pylint==1.9
 
 # Test requirements
 pytest==3.0.7

--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -41,7 +41,7 @@ class BaseCommand(click.MultiCommand):
     will produce a command name "baz".
     """
 
-    def __init__(self, cmd_packages=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Initializes the class, optionally with a list of available commands
 
@@ -49,6 +49,8 @@ class BaseCommand(click.MultiCommand):
         :param args: Other Arguments passed to super class
         :param kwargs: Other Arguments passed to super class
         """
+        cmd_packages = kwargs.pop("cmd_packages", None)
+
         super(BaseCommand, self).__init__(*args, **kwargs)
 
         if not cmd_packages:
@@ -94,7 +96,7 @@ class BaseCommand(click.MultiCommand):
         """
         if cmd_name not in self._commands:
             logger.error("Command %s not available", cmd_name)
-            return
+            return None
 
         pkg_name = self._commands[cmd_name]
 
@@ -102,10 +104,10 @@ class BaseCommand(click.MultiCommand):
             mod = importlib.import_module(pkg_name)
         except ImportError:
             logger.exception("Command '%s' is not configured correctly. Unable to import '%s'", cmd_name, pkg_name)
-            return
+            return None
 
         if not hasattr(mod, "cli"):
             logger.error("Command %s is not configured correctly. It must expose an function called 'cli'", cmd_name)
-            return
+            return None
 
         return mod.cli

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -341,8 +341,7 @@ class InvokeContext(object):
                 else:
                     raise error
 
-            # We turn off pylint here due to https://github.com/PyCQA/pylint/issues/1660
-            if not debugger.is_dir():  # pylint: disable=no-member
+            if not debugger.is_dir():
                 raise DebugContextException("'{}' should be a directory with the debugger in it.".format(debugger_path))
             debugger_path = str(debugger)
 

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -168,3 +168,5 @@ class LocalApiService(object):
         if os.path.exists(static_dir_path):
             LOG.info("Mounting static files from %s at /", static_dir_path)
             return static_dir_path
+
+        return None

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -64,7 +64,7 @@ class LocalLambdaRunner(object):
         function = self.provider.get(function_name)
 
         if not function:
-            raise FunctionNotFound("Unable to find a Function with name '%s'", function_name)
+            raise FunctionNotFound("Unable to find a Function with name '{}'".format(function_name))
 
         LOG.debug("Found one Lambda function with name '%s'", function_name)
 

--- a/samcli/commands/local/lib/sam_base_provider.py
+++ b/samcli/commands/local/lib/sam_base_provider.py
@@ -4,9 +4,10 @@ Base class for SAM Template providers
 
 import logging
 
-from samcli.lib.samlib.wrapper import SamTranslatorWrapper
-from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.intrinsics.actions import RefAction
+from samtranslator.intrinsics.resolver import IntrinsicsResolver
+
+from samcli.lib.samlib.wrapper import SamTranslatorWrapper
 
 
 LOG = logging.getLogger(__name__)

--- a/samcli/commands/local/lib/swagger/integration_uri.py
+++ b/samcli/commands/local/lib/swagger/integration_uri.py
@@ -168,6 +168,7 @@ class LambdaUri(object):
         # Some unknown format
         LOG.debug("Ignoring integration ARN. Unable to parse Function Name from function arn %s",
                   function_arn)
+        return None
 
     @staticmethod
     def _resolve_fn_sub(uri_data):

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -119,3 +119,5 @@ class SwaggerParser(object):
                 and integration.get("type") == IntegrationType.aws_proxy.value:
             # Integration must be "aws_proxy" otherwise we don't care about it
             return LambdaUri.get_function_name(integration.get("uri"))
+
+        return None

--- a/samcli/commands/local/lib/swagger/reader.py
+++ b/samcli/commands/local/lib/swagger/reader.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import logging
 
+# https://github.com/PyCQA/pylint/issues/2180
 from six.moves.urllib.parse import urlparse, parse_qs  # pylint: disable=relative-import
 from six import string_types
 import boto3
@@ -43,10 +44,10 @@ def parse_aws_include_transform(data):
     """
 
     if not data:
-        return
+        return None
 
     if _FN_TRANSFORM not in data:
-        return
+        return None
 
     transform_data = data[_FN_TRANSFORM]
 
@@ -55,6 +56,8 @@ def parse_aws_include_transform(data):
     if name == "AWS::Include":
         LOG.debug("Successfully parsed location from AWS::Include transform: %s", location)
         return location
+
+    return None
 
 
 class SamSwaggerReader(object):
@@ -152,7 +155,7 @@ class SamSwaggerReader(object):
         """
 
         if not location:
-            return
+            return None
 
         bucket, key, version = self._parse_s3_location(location)
         if bucket and key:
@@ -163,7 +166,7 @@ class SamSwaggerReader(object):
         if not isinstance(location, string_types):
             # This is not a string and not a S3 Location dictionary. Probably something invalid
             LOG.debug("Unable to download Swagger file. Invalid location: %s", location)
-            return
+            return None
 
         # ``location`` is a string and not a S3 path. It is probably a local path. Let's resolve relative path if any
         filepath = location
@@ -173,7 +176,7 @@ class SamSwaggerReader(object):
 
         if not os.path.exists(filepath):
             LOG.debug("Unable to download Swagger file. File not found at location %s", filepath)
-            return
+            return None
 
         LOG.debug("Reading Swagger document from local file at %s", filepath)
         with open(filepath, "r") as fp:

--- a/samcli/commands/logs/logs_context.py
+++ b/samcli/commands/logs/logs_context.py
@@ -211,7 +211,7 @@ class LogsCommandContext(object):
             If the string cannot be parsed as a timestamp
         """
         if not time_str:
-            return
+            return None
 
         parsed = parse_date(time_str)
         if not parsed:

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -14,12 +14,12 @@ except ImportError:
     import pathlib2 as pathlib
 
 import docker
-
-import samcli.lib.utils.osutils as osutils
-from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 from aws_lambda_builders.builder import LambdaBuilder
 from aws_lambda_builders.exceptions import LambdaBuilderError
 from aws_lambda_builders import RPC_PROTOCOL_VERSION as lambda_builders_protocol_version
+
+import samcli.lib.utils.osutils as osutils
+from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 
 
 LOG = logging.getLogger(__name__)
@@ -211,7 +211,7 @@ class ApplicationBuilder(object):
 
         return artifacts_dir
 
-    def _build_function_on_container(self,  # pylint: disable=too-many-locals
+    def _build_function_on_container(self,
                                      config,
                                      source_dir,
                                      artifacts_dir,

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -191,7 +191,7 @@ class LocalApigwService(BaseLocalService):
         json_output = json.loads(lambda_output)
 
         if not isinstance(json_output, dict):
-            raise TypeError("Lambda returned %{s} instead of dict", type(json_output))
+            raise TypeError("Lambda returned {} instead of dict".format(type(json_output)))
 
         status_code = json_output.get("statusCode") or 200
         headers = CaseInsensitiveDict(json_output.get("headers") or {})

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -27,7 +27,7 @@ class LambdaContainer(Container):
     # This is the dictionary that represents where the debugger_path arg is mounted in docker to as readonly.
     _DEBUGGER_VOLUME_MOUNT = {"bind": _DEBUGGER_VOLUME_MOUNT_PATH, "mode": "ro"}
 
-    def __init__(self,  # pylint: disable=R0914
+    def __init__(self,
                  runtime,
                  handler,
                  code_dir,

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -106,6 +106,8 @@ class LocalLambdaInvokeService(BaseLocalService):
             return LambdaErrorResponses.not_implemented_locally(
                 "invocation-type: {} is not supported. RequestResponse is only supported.".format(invocation_type))
 
+        return None
+
     def _construct_error_handling(self):
         """
         Updates the Flask app with Error Handlers for different Error Codes

--- a/samcli/local/lambdafn/env_vars.py
+++ b/samcli/local/lambdafn/env_vars.py
@@ -196,7 +196,7 @@ class EnvironmentVariables(object):
         # do not stringify unicode in Py2, Py3 str supports unicode
         elif sys.version_info.major > 2:
             result = str(value)
-        elif not isinstance(value, unicode):  # noqa: F821 pylint: disable=undefined-variable
+        elif not isinstance(value, unicode):
             result = str(value)
         else:
             result = value

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -148,6 +148,8 @@ class LambdaRuntime(object):
             timer.start()
             return timer
 
+        return None
+
     @contextmanager
     def _get_code_dir(self, code_path):
         """

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -94,8 +94,7 @@ class LayerDownloader(object):
             layer.codeuri = resolve_code_path(self.cwd, layer.codeuri)
             return layer
 
-        # disabling no-member due to https://github.com/PyCQA/pylint/issues/1660
-        layer_path = Path(self.layer_cache).joinpath(layer.name).resolve()  # pylint: disable=no-member
+        layer_path = Path(self.layer_cache).joinpath(layer.name).resolve()
         is_layer_downloaded = self._is_layer_cached(layer_path)
         layer.codeuri = str(layer_path)
 

--- a/tests/functional/commands/local/lib/test_local_api_service.py
+++ b/tests/functional/commands/local/lib/test_local_api_service.py
@@ -67,7 +67,7 @@ class TestFunctionalLocalLambda(TestCase):
         self.lambda_invoke_context_mock = Mock()
         manager = ContainerManager()
         layer_downloader = LayerDownloader("./", "./")
-        lambda_image = LambdaImage(layer_downloader, False)
+        lambda_image = LambdaImage(layer_downloader, False, False)
         local_runtime = LambdaRuntime(manager, lambda_image)
         lambda_runner = LocalLambdaRunner(local_runtime, self.mock_function_provider, self.cwd, env_vars_values=None,
                                           debug_context=None)

--- a/tests/functional/commands/local/lib/test_local_lambda.py
+++ b/tests/functional/commands/local/lib/test_local_lambda.py
@@ -68,7 +68,7 @@ class TestFunctionalLocalLambda(TestCase):
 
         manager = ContainerManager()
         layer_downloader = LayerDownloader("./", "./")
-        lambda_image = LambdaImage(layer_downloader, False)
+        lambda_image = LambdaImage(layer_downloader, False, False)
         local_runtime = LambdaRuntime(manager, lambda_image)
         runner = LocalLambdaRunner(local_runtime, self.mock_function_provider, self.cwd, self.env_var_overrides,
                                    debug_context=None)

--- a/tests/functional/local/apigw/test_local_apigw_service.py
+++ b/tests/functional/local/apigw/test_local_apigw_service.py
@@ -615,7 +615,7 @@ def make_service(list_of_routes, function_provider, cwd):
     port = random_port()
     manager = ContainerManager()
     layer_downloader = LayerDownloader("./", "./")
-    lambda_image = LambdaImage(layer_downloader, False)
+    lambda_image = LambdaImage(layer_downloader, False, False)
     local_runtime = LambdaRuntime(manager, lambda_image)
     lambda_runner = LocalLambdaRunner(local_runtime=local_runtime,
                                       function_provider=function_provider,

--- a/tests/functional/local/docker/test_lambda_container.py
+++ b/tests/functional/local/docker/test_lambda_container.py
@@ -69,7 +69,7 @@ class TestLambdaContainer(TestCase):
         A docker container must be successfully created
         """
         layer_downloader = LayerDownloader("./", "./")
-        image_builder = LambdaImage(layer_downloader, False)
+        image_builder = LambdaImage(layer_downloader, False, False)
         container = LambdaContainer(self.runtime, self.handler, self.code_dir, self.layers, image_builder)
 
         self.assertIsNone(container.id, "Container must not have ID before creation")
@@ -87,7 +87,7 @@ class TestLambdaContainer(TestCase):
     def test_debug_port_is_created_on_host(self):
 
         layer_downloader = LayerDownloader("./", "./")
-        image_builder = LambdaImage(layer_downloader, False)
+        image_builder = LambdaImage(layer_downloader, False, False)
         container = LambdaContainer(self.runtime, self.handler, self.code_dir, self.layers, image_builder, debug_options=self.debug_context)
 
         with self._create(container):
@@ -102,7 +102,7 @@ class TestLambdaContainer(TestCase):
 
     def test_container_is_attached_to_network(self):
         layer_downloader = LayerDownloader("./", "./")
-        image_builder = LambdaImage(layer_downloader, False)
+        image_builder = LambdaImage(layer_downloader, False, False)
         container = LambdaContainer(self.runtime, self.handler, self.code_dir, self.layers, image_builder)
 
         with self._network_create() as network:
@@ -128,7 +128,7 @@ class TestLambdaContainer(TestCase):
         expected_stderr = b"**This string is printed from Lambda function**"
 
         layer_downloader = LayerDownloader("./", "./")
-        image_builder = LambdaImage(layer_downloader, False)
+        image_builder = LambdaImage(layer_downloader, False, False)
         container = LambdaContainer(self.runtime, self.handler, self.code_dir, self.layers, image_builder)
         stdout_stream = io.BytesIO()
         stderr_stream = io.BytesIO()

--- a/tests/functional/local/lambda_service/test_local_lambda_invoke.py
+++ b/tests/functional/local/lambda_service/test_local_lambda_invoke.py
@@ -314,7 +314,7 @@ def make_service(function_provider, cwd):
     port = random_port()
     manager = ContainerManager()
     layer_downloader = LayerDownloader("./", "./")
-    image_builder = LambdaImage(layer_downloader, False)
+    image_builder = LambdaImage(layer_downloader, False, False)
     local_runtime = LambdaRuntime(manager, image_builder)
     lambda_runner = LocalLambdaRunner(local_runtime=local_runtime,
                                       function_provider=function_provider,

--- a/tests/functional/local/lambdafn/test_runtime.py
+++ b/tests/functional/local/lambdafn/test_runtime.py
@@ -39,7 +39,7 @@ class TestLambdaRuntime(TestCase):
 
         self.container_manager = ContainerManager()
         layer_downloader = LayerDownloader("./", "./")
-        self.lambda_image = LambdaImage(layer_downloader, False)
+        self.lambda_image = LambdaImage(layer_downloader, False, False)
         self.runtime = LambdaRuntime(self.container_manager, self.lambda_image)
 
     def tearDown(self):
@@ -190,7 +190,7 @@ class TestLambdaRuntime_MultipleInvokes(TestCase):
 
         container_manager = ContainerManager()
         layer_downloader = LayerDownloader("./", "./")
-        self.lambda_image = LambdaImage(layer_downloader, False)
+        self.lambda_image = LambdaImage(layer_downloader, False, False)
         self.runtime = LambdaRuntime(container_manager, self.lambda_image)
 
     def tearDown(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Here is the dump of things pylint complained about after updating that this PR addresses:
```
$ make lint                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
# Linter performs static analysis to catch latent bugs
pylint --rcfile .pylintrc samcli
Using config file /Users/jfuss/sam-github/aws-sam-cli/.pylintrc
************* Module samcli.cli.command
W: 44, 4: Keyword argument before variable positional arguments list in the definition of __init__ function (keyword-arg-before-vararg)
R: 87, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module samcli.local.apigw.local_apigw_service
W:194,12: Exception arguments suggest string formatting might be intended (raising-format-tuple)
************* Module samcli.local.lambdafn.runtime
R:118, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module samcli.local.lambda_service.local_lambda_invoke_service
R: 57, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module samcli.lib.build.app_builder
C: 20, 0: third party import "from aws_lambda_builders.builder import LambdaBuilder" should be placed before "import samcli.lib.utils.osutils as osutils" (wrong-import-order)
C: 21, 0: third party import "from aws_lambda_builders.exceptions import LambdaBuilderError" should be placed before "import samcli.lib.utils.osutils as osutils" (wrong-import-order)
C: 22, 0: third party import "from aws_lambda_builders import RPC_PROTOCOL_VERSION as lambda_builders_protocol_version" should be placed before "import samcli.lib.utils.osutils as osutils" (wrong-import-order)
************* Module samcli.commands.validate.lib.sam_template_validator
C: 10, 0: third party import "import six" should be placed before "from samcli.yamlhelper import yaml_dump" (wrong-import-order)
************* Module samcli.commands.local.lib.local_api_service
R:154, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module samcli.commands.local.lib.sam_base_provider
C:  8, 0: third party import "from samtranslator.intrinsics.resolver import IntrinsicsResolver" should be placed before "from samcli.lib.samlib.wrapper import SamTranslatorWrapper" (wrong-import-order)
C:  9, 0: third party import "from samtranslator.intrinsics.actions import RefAction" should be placed before "from samcli.lib.samlib.wrapper import SamTranslatorWrapper" (wrong-import-order)
************* Module samcli.commands.local.lib.local_lambda
W: 67,12: Exception arguments suggest string formatting might be intended (raising-format-tuple)
************* Module samcli.commands.local.lib.swagger.parser
R: 94, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module samcli.commands.local.lib.swagger.reader
R: 20, 0: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
R:138, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module samcli.commands.local.lib.swagger.integration_uri
R:131, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
************* Module samcli.commands.logs.logs_context
R:191, 4: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)

-------------------------------------------------------------------
Your code has been rated at 9.94/10 (previous run: 10.00/10, -0.06)

make: *** [lint] Error 28
```

I went through existing comments that make pylint quite and removed/addressed the ones I could.

I ran functional tests and found they where broken. So this PR also addresses those failures.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [x] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
