### PR TITLE
Support for response multiValueHeaders locally

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -152,7 +152,7 @@ class LocalApigwService(BaseLocalService):
                                                                      route.binary_types,
                                                                      request)
         except (KeyError, TypeError, ValueError):
-            LOG.error("Function returned an invalid response (must include one of: body, headers or "
+            LOG.error("Function returned an invalid response (must include one of: body, headers, multiValueHeaders or "
                       "statusCode in the response object). Response received: %s", lambda_response)
             return ServiceErrorResponses.lambda_failure_response()
 
@@ -193,8 +193,31 @@ class LocalApigwService(BaseLocalService):
         if not isinstance(json_output, dict):
             raise TypeError("Lambda returned %{s} instead of dict", type(json_output))
 
+        # TODO: Implement full tests
+        # Merge multiValueHeaders headers with headers
+        # Convert into CSV for Flask compatibility
+
+        # TODO: Move to separate testable function
+        # Merge multiValueHeaders into h, this will overwrite existing items as per documentation
+        h = {**(json_output.get("headers") or {}), **(json_output.get("multiValueHeaders") or {})}
+
+        # Now we have single headers and arrays, convert arrays to CSV
+        for i, s in enumerate(h):
+            if isinstance(h[s], list):
+                h[s] = ", ".join(h[s])
+
+        # TODO: Cleanup and put in PR/comments for merge reasoning
+        # "headers": {"headerName": "headerValue", ...},
+        # "multiValueHeaders": {"headerName": ["headerValue", "headerValue2", ...], ...},
+        #The headers and multiValueHeaders keys can be unspecified if no extra response headers are to be returned.
+        #The headers key can only contain single-value headers.
+        #The multiValueHeaders key can contain multi-value headers as well as single-value headers.
+        # You can use the multiValueHeaders key to specify all of your extra headers, including any single-value ones.
+        # ASSUMING CORRECTNESS If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
+        # If the same key-value pair is specified in both, only the values from multiValueHeaders will appear in the merged list.
+
         status_code = json_output.get("statusCode") or 200
-        headers = CaseInsensitiveDict(json_output.get("headers") or {})
+        headers = CaseInsensitiveDict(h)
         body = json_output.get("body") or "no data"
         is_base_64_encoded = json_output.get("isBase64Encoded") or False
 
@@ -234,7 +257,10 @@ class LocalApigwService(BaseLocalService):
         True if the body from the request should be converted to binary, otherwise false
 
         """
-        best_match_mimetype = flask_request.accept_mimetypes.best_match([lamba_response_headers["Content-Type"]])
+
+        # Get the first part of the content-type header, to allow for extras such as text/html; charset=utf-8
+        content_type = lamba_response_headers['Content-Type'].split(";", 1)[0]
+        best_match_mimetype = flask_request.accept_mimetypes.best_match([content_type])
         is_best_match_in_binary_types = best_match_mimetype in binary_types or '*/*' in binary_types
 
         return best_match_mimetype and is_best_match_in_binary_types and is_base_64_encoded

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -261,9 +261,9 @@ class TestApiGatewayModel(TestCase):
 
 
 class TestLambdaHeaderDictionaryMerge(TestCase):
-    def test_none_dictionaries_produce_result(self):
-        headers = None
-        multi_value_headers = None
+    def test_empty_dictionaries_produce_empty_result(self):
+        headers = {}
+        multi_value_headers = {}
 
         result = LocalApigwService._merge_response_headers(headers, multi_value_headers)
 
@@ -283,7 +283,7 @@ class TestLambdaHeaderDictionaryMerge(TestCase):
         self.assertEquals(result["h3"], "value3")
 
     def test_multivalue_headers_are_turned_into_csv(self):
-        headers = None
+        headers = {}
         multi_value_headers = {"h1": ["a", "b", "c"]}
 
         result = LocalApigwService._merge_response_headers(headers, multi_value_headers)

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -10,6 +10,7 @@ from samcli.local.lambdafn.exceptions import FunctionNotFound
 
 
 class TestApiGatewayService(TestCase):
+
     def setUp(self):
         self.function_name = Mock()
         self.api_gateway_route = Route(['GET'], self.function_name, '/')
@@ -50,6 +51,7 @@ class TestApiGatewayService(TestCase):
 
     @patch('samcli.local.apigw.local_apigw_service.LambdaOutputParser')
     def test_request_handler_returns_process_stdout_when_making_response(self, lambda_output_parser_mock):
+
         make_response_mock = Mock()
 
         self.service.service_response = make_response_mock
@@ -148,6 +150,7 @@ class TestApiGatewayService(TestCase):
 
     @patch('samcli.local.apigw.local_apigw_service.ServiceErrorResponses')
     def test_request_handles_error_when_invoke_cant_find_function(self, service_error_responses_patch):
+
         not_found_response_mock = Mock()
         self.service._construct_event = Mock()
         self.service._get_current_route = Mock()
@@ -209,6 +212,7 @@ class TestApiGatewayService(TestCase):
 
     @patch('samcli.local.apigw.local_apigw_service.request')
     def test_get_current_route(self, request_patch):
+
         request_mock = Mock()
         request_mock.endpoint = "path"
         request_mock.method = "method"
@@ -245,6 +249,7 @@ class TestApiGatewayService(TestCase):
 
 
 class TestApiGatewayModel(TestCase):
+
     def setUp(self):
         self.function_name = "name"
         self.api_gateway = Route(['POST'], self.function_name, '/')
@@ -297,6 +302,7 @@ class TestLambdaHeaderDictionaryMerge(TestCase):
 
 
 class TestServiceParsingLambdaOutput(TestCase):
+
     def test_default_content_type_header_added_with_no_headers(self):
         lambda_output = '{"statusCode": 200, "body": "{\\"message\\":\\"Hello from Lambda\\"}", ' \
                         '"isBase64Encoded": false}'
@@ -422,6 +428,7 @@ class TestServiceParsingLambdaOutput(TestCase):
 
 
 class TestService_construct_event(TestCase):
+
     def setUp(self):
         self.request_mock = Mock()
         self.request_mock.endpoint = "endpoint"
@@ -505,6 +512,7 @@ class TestService_construct_event(TestCase):
 
 
 class TestService_should_base64_encode(TestCase):
+
     @parameterized.expand([
         param("Mimeyype is in binary types", ['image/gif'], 'image/gif'),
         param("Mimetype defined and binary types has */*", ['*/*'], 'image/gif'),

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -393,7 +393,7 @@ class TestServiceParsingLambdaOutput(TestCase):
 
     def test_status_code_negative_int(self):
         lambda_output = '{"statusCode": -1, "headers": {}, "body": "{\\"message\\":\\"Hello from Lambda\\"}", ' \
-                        '"isBase64Encoded": false}'
+                            '"isBase64Encoded": false}'
 
         with self.assertRaises(TypeError):
             LocalApigwService._parse_lambda_output(lambda_output,


### PR DESCRIPTION
*Issue #, if available:*
Addresses is #830, supporting multiValueHeaders locally.

*Description of changes:*

Merges lamdba response headers and multiValueHeaders in accordance with guidance from here.
https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format

-  You can use the multiValueHeaders key to specify all of your extra headers, including any single-value ones.
- If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
- If the same key-value pair is specified in both, only the values from multiValueHeaders will appear in the merged list.

Within base64 logic, splits Content-Type by ;, to prevent issues with malformed Content types.
`content_type = lamba_response_headers['Content-Type'].split(";", 1)[0]`

- [ ] TODO: Add tests for the `_should_base64_decode_body` change - Guidance needed
 
*Checklist:*

- [x] Write unit tests (Tests for functionality of merger and update to parse_lambda tests for ensuring the component is called)
- [x] Write/update functional tests (Unsure what to add - Guidance needed)
- [x] Write/update integration tests (Unsure what to add - Guidance needed)
- [x] `make pr` passes
- [x ] Write documentation - No adjustment required (unless there is a supported features list somewhere?)

Please let me know what else is required/missing! :smile: This PR plays well with #741, which is for requests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
