### PR TITLE
Speed up local layer builds by skipping unnecessary compression of docker context

### DIFF
--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -23,7 +23,7 @@ def create_tarball(tar_paths):
     """
     tarballfile = TemporaryFile()
 
-    with tarfile.open(fileobj=tarballfile, mode='w:gz') as archive:
+    with tarfile.open(fileobj=tarballfile, mode='w') as archive:
         for path_on_system, path_in_tarball in tar_paths.items():
             archive.add(path_on_system, arcname=path_in_tarball)
 

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -182,7 +182,6 @@ class LambdaImage(object):
                     self.docker_client.images.build(fileobj=tarballfile,
                                                     custom_context=True,
                                                     rm=True,
-                                                    encoding='gzip',
                                                     tag=docker_tag,
                                                     pull=not self.skip_pull_image)
                 except (docker.errors.BuildError, docker.errors.APIError):

--- a/tests/unit/lib/utils/test_tar.py
+++ b/tests/unit/lib/utils/test_tar.py
@@ -25,4 +25,4 @@ class TestTar(TestCase):
         temp_file_mock.flush.assert_called_once()
         temp_file_mock.seek.assert_called_once_with(0)
         temp_file_mock.close.assert_called_once()
-        tarfile_open_patch.assert_called_once_with(fileobj=temp_file_mock, mode='w:gz')
+        tarfile_open_patch.assert_called_once_with(fileobj=temp_file_mock, mode='w')

--- a/tests/unit/local/docker/test_lambda_image.py
+++ b/tests/unit/local/docker/test_lambda_image.py
@@ -171,8 +171,7 @@ class TestLambdaImage(TestCase):
                                                                 rm=True,
                                                                 tag="docker_tag",
                                                                 pull=False,
-                                                                custom_context=True,
-                                                                encoding='gzip')
+                                                                custom_context=True)
 
         docker_full_path_mock.unlink.assert_called_once()
 
@@ -218,8 +217,7 @@ class TestLambdaImage(TestCase):
                                                                 rm=True,
                                                                 tag="docker_tag",
                                                                 pull=False,
-                                                                custom_context=True,
-                                                                encoding='gzip')
+                                                                custom_context=True)
 
         docker_full_path_mock.unlink.assert_not_called()
 
@@ -264,6 +262,5 @@ class TestLambdaImage(TestCase):
                                                                 rm=True,
                                                                 tag="docker_tag",
                                                                 pull=False,
-                                                                custom_context=True,
-                                                                encoding='gzip')
+                                                                custom_context=True)
         docker_full_path_mock.unlink.assert_called_once()


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/863

*Description of changes:*

Stopped using compression when creating tarball of docker context for building `samcli/lambda` docker image containing local Lambda layers. With compression, the stream-and-build procedure takes roughly 27 seconds for a sample 215 MB file tree of Python dependencies (compressing to 51 MB). Without compression, the same procedure takes less than 4 seconds.

*Checklist:*

- [ ] Write Design Document
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
