### PR TITLE
Add Ruby to Supported Runtime Enum

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -57,6 +57,12 @@ def _get_workflow_config(runtime):
             dependency_manager="npm",
             application_framework=None,
             manifest_name="package.json")
+    elif runtime.startswith("ruby"):
+        return config(
+            language="ruby",
+            dependency_manager="bundler",
+            application_framework=None,
+            manifest_name="Gemfile")
     else:
         raise UnsupportedRuntimeException("'{}' runtime is not supported".format(runtime))
 


### PR DESCRIPTION
This is required for the Ruby support added to aws-lambda-builders to work in SAM CLI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
