### PR TITLE
chore: Bump up serverlessrepo version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,4 +13,4 @@ python-dateutil~=2.6
 pathlib2~=2.3.2; python_version<"3.4"
 requests==2.20.1
 aws_lambda_builders==0.0.5
-serverlessrepo==0.1.5
+serverlessrepo==0.1.6


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-serverlessrepo-python/issues/21

*Description of changes:*
[serverlessrepo](https://pypi.org/project/serverlessrepo/) added support for Python 3.4 and 3.5 in version 0.1.6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
