### PR TITLE
AWS::AppSync::FunctionConfiguration mapping templates packaging support

### DIFF
--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -23,6 +23,7 @@ _RESOURCES_WITH_LOCAL_PATHS = {
     "AWS::Serverless::Api": ["DefinitionUri"],
     "AWS::AppSync::GraphQLSchema": ["DefinitionS3Location"],
     "AWS::AppSync::Resolver": ["RequestMappingTemplateS3Location", "ResponseMappingTemplateS3Location"],
+    "AWS::AppSync::FunctionConfiguration": ["RequestMappingTemplateS3Location", "ResponseMappingTemplateS3Location"],
     "AWS::Lambda::Function": ["Code"],
     "AWS::ApiGateway::RestApi": ["BodyS3Location"],
     "AWS::ElasticBeanstalk::ApplicationVersion": ["SourceBundle"],


### PR DESCRIPTION
Add packaging of local files support for "AWS::AppSync::FunctionConfiguration" resource (AWS AppSync Function) mapping templates:

RequestMappingTemplateS3Location
ResponseMappingTemplateS3Location

*Issue #, if available:*
https://github.com/awslabs/aws-sam-cli/issues/897

*Description of changes:*
Added new AppSync FunctionConfiguration resource and 2 properties to be supported to configuration file along other supported properties.

*Checklist:*

- [x] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [x] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
