### PR TITLE
fix: add --template-file into template common options

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -74,7 +74,7 @@ def template_click_option(include_build=True):
     """
     Click Option for template option
     """
-    return click.option('--template', '-t',
+    return click.option('--template', '-t', '--template-file',
                         default=_TEMPLATE_OPTION_DEFAULT_VALUE,
                         type=click.Path(),
                         envvar="SAM_TEMPLATE_FILE",


### PR DESCRIPTION
*Description of changes:*
`package` and `deploy` commands use `--template-file` option to specify templates, but other commands like `validate` and `publish` use `--template|-t`. To make it consistent, we should add `--template-file` as an option for these commands.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
