### PR TITLE
Remove maxage off badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ SAM CLI (Beta)
 
 ![Build
 Status](https://travis-ci.org/awslabs/aws-sam-cli.svg?branch=develop)
-![Apache-2.0](https://img.shields.io/npm/l/aws-sam-local.svg?maxAge=2592000)
-![Contributers](https://img.shields.io/github/contributors/awslabs/aws-sam-cli.svg?maxAge=2592000)
-![GitHub-release](https://img.shields.io/github/release/awslabs/aws-sam-cli.svg?maxAge=2592000)
+![Apache-2.0](https://img.shields.io/npm/l/aws-sam-local.svg)
+![Contributers](https://img.shields.io/github/contributors/awslabs/aws-sam-cli.svg)
+![GitHub-release](https://img.shields.io/github/release/awslabs/aws-sam-cli.svg)
 ![PyPI version](https://badge.fury.io/py/aws-sam-cli.svg)
 
 [Join the SAM developers channel (\#samdev) on


### PR DESCRIPTION
Remove the max age off the badge images so the default gets used

*Issue #, if available:*

*Description of changes:*
😄 

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
