### PR TITLE
Fix empty Error message when using 'sam validate'

### DIFF
--- a/samcli/commands/validate/lib/sam_template_validator.py
+++ b/samcli/commands/validate/lib/sam_template_validator.py
@@ -84,7 +84,7 @@ class SamTemplateValidator(object):
                 LOG.debug("Translated template is:\n%s", yaml_dump(template))
         except InvalidDocumentException as e:
             raise InvalidSamDocumentException(
-                functools.reduce(lambda message, error: message + ' ' + str(error), e.causes, str(e)))
+                functools.reduce(lambda message, error: message + '\n\t' + error.message, e.causes, e.message))
 
     def _replace_local_codeuri(self):
         """

--- a/tests/unit/commands/validate/lib/test_sam_template_validator.py
+++ b/tests/unit/commands/validate/lib/test_sam_template_validator.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from mock import Mock, patch
 
-from samtranslator.public.exceptions import InvalidDocumentException
+from samtranslator.public.exceptions import InvalidDocumentException, InvalidTemplateException
 
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.commands.validate.lib.sam_template_validator import SamTemplateValidator
@@ -45,7 +45,7 @@ class TestSamTemplateValidator(TestCase):
         sam_parser.Parser.return_value = parser
 
         translate_mock = Mock()
-        translate_mock.translate.side_effect = InvalidDocumentException([Exception('message')])
+        translate_mock.translate.side_effect = InvalidDocumentException([InvalidTemplateException('message')])
         sam_translator.return_value = translate_mock
 
         validator = SamTemplateValidator(template, managed_policy_mock)


### PR DESCRIPTION
*Issue #, if available:*
Haven't opened an issue for it, just went straight for a PR

*Description of changes:*
Fixes empty Error message when `sam validate` is run. Apparently these exceptions don't stringify as expected, so go straight for the message. Also, join with newline+tab for readable output.

**Before:**
```
[ec2-user@host project]$ sam validate -t dist/template.yaml
2019-01-16 22:34:47 Found credentials in shared credentials file: ~/.aws/credentials
Template provided at '/home/ec2-user/project/dist/template.yaml' was invalid SAM Template.
Error:
```

**After:**
```
[ec2-user@host project]$ sam validate -t dist/template.yaml
2019-01-16 22:55:48 Found credentials in shared credentials file: ~/.aws/credentials
Template provided at '/home/ec2-user/project/dist/template.yaml' was invalid SAM Template.
Error: Invalid Serverless Application Specification document. Number of errors found: 1.
        Resource with id [FunctionTransferAuth] is invalid. property CodeURI not defined for resource of type AWS::Serverless::Function
```

*Checklist:*
- [ ] `make pr` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
