### PR TITLE
fix(layers): show warning if `!Sub` function is used in `Layers` section of template.yaml (#948)

### DIFF
--- a/samcli/commands/local/lib/sam_function_provider.py
+++ b/samcli/commands/local/lib/sam_function_provider.py
@@ -239,8 +239,9 @@ class SamFunctionProvider(FunctionProvider):
         layers = []
         for layer in list_of_layers:
             if isinstance(layer, dict) and layer.get("Fn::Sub"):
-                LOG.warning("'!Sub' keyword in Layer configuration does not work locally. "
-                            "Please replace all parameter strings(like '${AWS::Region}') with the original value(like 'ap-northeast-1') and remove '!Sub' keyword.")
+                LOG.warning("'!Sub' keyword in Layer configuration does not work at local. "
+                            "Please replace all parameter strings(like '${AWS::Region}') with the original value "
+                            "and remove '!Sub' keyword from template.yaml .")
 
             # If the layer is a string, assume it is the arn
             if isinstance(layer, six.string_types):

--- a/samcli/commands/local/lib/sam_function_provider.py
+++ b/samcli/commands/local/lib/sam_function_provider.py
@@ -238,6 +238,10 @@ class SamFunctionProvider(FunctionProvider):
         """
         layers = []
         for layer in list_of_layers:
+            if isinstance(layer, dict) and layer.get("Fn::Sub"):
+                LOG.warning("'!Sub' keyword in Layer configuration does not work locally. "
+                            "Please replace all parameter strings(like '${AWS::Region}') with the original value(like 'ap-northeast-1') and remove '!Sub' keyword.")
+
             # If the layer is a string, assume it is the arn
             if isinstance(layer, six.string_types):
                 layers.append(LayerVersion(layer, None))


### PR DESCRIPTION
https://github.com/awslabs/aws-sam-cli/issues/948

*Description of changes:*

If `!Sub` function is used in `Layers` section of template.yaml and run `sam local invoke` and get an error.

- got: Error reason is not clear
- expected: We want to know more information by log

```yml
Resources:
  HelloWorldFunction:
    Type: AWS::Serverless::Function
    Properties:
      CodeUri: hello_world/
      Handler: app.lambdaHandler
      Runtime: nodejs8.10
      Events:
        HelloWorld:
          Type: Api
          Properties:
            Path: /hello
            Method: post
      Layers:
        - !Sub arn:aws:lambda:${AWS::Region}:123456789012:layer:MyLayer:1
```
```sh
$ sam local invoke -e event.json HelloWorldFunction

# This warning log is added by this pull request
2019-01-20 00:56:43 '!Sub' keyword in Layer configuration does not work locally. Please replace all parameter strings(like '${AWS::Region}') with the original value(like 'ap-northeast-1') and remove '!Sub' keyword.

Unable to import module 'app': Error
```

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
