### PR TITLE
Add support for prebuilt layer archives and function resources

### DIFF
--- a/samcli/commands/build/build_context.py
+++ b/samcli/commands/build/build_context.py
@@ -54,7 +54,7 @@ class BuildContext(object):
         except ValueError as ex:
             raise UserException(str(ex))
 
-        self._function_provider = SamFunctionProvider(self._template_dict, self._parameter_overrides)
+        self._function_provider = SamFunctionProvider(self._template_dict, self._parameter_overrides, self._template_file)
 
         if not self._base_dir:
             # Base directory, if not provided, is the directory containing the template

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -127,7 +127,7 @@ class InvokeContext(object):
 
         # Grab template from file and create a provider
         self._template_dict = self._get_template_data(self._template_file)
-        self._function_provider = SamFunctionProvider(self._template_dict, self.parameter_overrides)
+        self._function_provider = SamFunctionProvider(self._template_dict, self.parameter_overrides, self._template_file)
 
         self._env_vars_value = self._get_env_vars_value(self._env_vars_file)
         self._log_file_handle = self._setup_log_file(self._log_file)

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -185,6 +185,10 @@ class ApplicationBuilder(object):
         # artifacts directory will be created by the builder
         artifacts_dir = str(pathlib.Path(self._build_dir, function_name))
 
+        if code_dir.lower().endswith(".zip"):
+           LOG.debug("Serverless function '%s' is already built", function_name)
+           return code_dir
+
         with osutils.mkdir_temp() as scratch_dir:
             manifest_path = self._manifest_path_override or os.path.join(code_dir, config.manifest_name)
 

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -8,7 +8,7 @@ import boto3
 from botocore.exceptions import NoCredentialsError, ClientError
 
 from samcli.lib.utils.codeuri import resolve_code_path
-from samcli.local.lambdafn.zip import unzip_from_uri
+from samcli.local.lambdafn.zip import unzip, unzip_from_uri
 from samcli.commands.local.cli_common.user_exceptions import CredentialsRequired, ResourceNotFound
 
 try:
@@ -92,6 +92,13 @@ class LayerDownloader(object):
         if layer.is_defined_within_template:
             LOG.info("%s is a local Layer in the template", layer.name)
             layer.codeuri = resolve_code_path(self.cwd, layer.codeuri)
+
+            if layer.codeuri.lower().endswith('.zip'):
+                LOG.info("Decompressing %s", layer.codeuri)
+                layer_zip_path = layer.codeuri
+                layer.codeuri = layer.codeuri[:-4]
+                unzip(layer_zip_path, layer.codeuri)
+
             return layer
 
         # disabling no-member due to https://github.com/PyCQA/pylint/issues/1660


### PR DESCRIPTION
*Issue #, if available:*
Fixes #947

*Description of changes:*
Adds support for pre-archived Lambda Layers and Functions. The current code does not reliably support directories or zip archives - 'sam local invoke' supports function archives but not layer archives, while 'sam build' supports layer archives but not function archives.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
