### PR TITLE
(chore): Node.js default tests improvements

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/tests/unit/test-handler.js
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/hello-world/tests/unit/test-handler.js
@@ -6,17 +6,37 @@ const expect = chai.expect;
 var event, context;
 
 describe('Tests index', function () {
-    it('verifies successful response', async () => {
-        const result = await app.lambdaHandler(event, context)
+    let result;
+    before( async () => {
+        result = await app.lambdaHandler(event, context);
+    });
+    
+    describe('result', () => {
+        it('is an object', () => {  
+            expect(result).to.be.an('object');
+        });
+        it('is a successful request', () => { 
+            expect(result.statusCode).to.equal(200);
+        });
+        it('has a string as result body', () => { 
+            expect(result.body).to.be.an('string');
+        });
+    })
 
-        expect(result).to.be.an('object');
-        expect(result.statusCode).to.equal(200);
-        expect(result.body).to.be.an('string');
-
-        let response = JSON.parse(result.body);
-
-        expect(response).to.be.an('object');
-        expect(response.message).to.be.equal("hello world");
-        // expect(response.location).to.be.an("string");
+    describe('result.body', ()=> {
+        let body; 
+        before(() => {
+            body = JSON.parse(result.body);
+        })
+        it('parses to object', () => {
+            expect(body).to.be.an('object');
+        });
+        it('message is hello world', () => {
+            expect(body.message).to.be.equal('hello world');
+        });
+        it('location is a string', () => { 
+            expect(body.location).to.be.an('string');
+        });
     });
 });
+


### PR DESCRIPTION
*Description of changes:*




* 1 assertion per test. This is easier to digest and debug
* consistent usage of semicolons and string quotes
* body and result test split

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
