### PR TITLE
fix: update license key in setup() to expected value by PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,11 @@ setup(
     author='Amazon Web Services',
     author_email='aws-sam-developers@amazon.com',
     url='https://github.com/awslabs/aws-sam-cli',
-    license=read('LICENSE'),
+    license='Apache License 2.0',
     packages=find_packages(exclude=('tests', 'docs')),
     keywords="AWS SAM CLI",
     # Support Python 2.7 and 3.6 or greater
-    python_requires=('>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*'),
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     entry_points={
         'console_scripts': [
             '{}=samcli.cli.main:cli'.format(cmd_name)


### PR DESCRIPTION
*Issue #, if available:*
#889

*Description of changes:*
Previously we were adding the complete license into the `license` key in `setup()`. This cause a corruption of the `METADATA` file that exist within the packaged `whl` or `tar` file.  PyPi uses this file to render the homepage for the project and pip uses this for validation locally (should it install into X python version for example).

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
