### PR TITLE
chore: Use OrderedDict in yamlhelper to preserve template elements order

### DIFF
--- a/samcli/yamlhelper.py
+++ b/samcli/yamlhelper.py
@@ -3,6 +3,7 @@ Helper to be able to parse/dump YAML files
 """
 
 import json
+from collections import OrderedDict
 import six
 
 import yaml
@@ -46,13 +47,22 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     return {cfntag: value}
 
 
+def _dict_representer(dumper, data):
+    return dumper.represent_dict(data.items())
+
+
 def yaml_dump(dict_to_dump):
     """
     Dumps the dictionary as a YAML document
     :param dict_to_dump:
     :return:
     """
+    yaml.SafeDumper.add_representer(OrderedDict, _dict_representer)
     return yaml.safe_dump(dict_to_dump, default_flow_style=False)
+
+
+def _dict_constructor(loader, node):
+    return OrderedDict(loader.construct_pairs(node))
 
 
 def yaml_parse(yamlstr):
@@ -61,7 +71,8 @@ def yaml_parse(yamlstr):
         # PyYAML doesn't support json as well as it should, so if the input
         # is actually just json it is better to parse it with the standard
         # json parser.
-        return json.loads(yamlstr)
+        return json.loads(yamlstr, object_pairs_hook=OrderedDict)
     except ValueError:
+        yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor)
         yaml.SafeLoader.add_multi_constructor("!", intrinsics_multi_constructor)
         return yaml.safe_load(yamlstr)

--- a/samcli/yamlhelper.py
+++ b/samcli/yamlhelper.py
@@ -62,6 +62,8 @@ def yaml_dump(dict_to_dump):
 
 
 def _dict_constructor(loader, node):
+    # Necessary in order to make yaml merge tags work
+    loader.flatten_mapping(node)
     return OrderedDict(loader.construct_pairs(node))
 
 

--- a/tests/unit/test_yamlhelper.py
+++ b/tests/unit/test_yamlhelper.py
@@ -1,7 +1,6 @@
 """
 Helper to be able to parse/dump YAML files
 """
-import re
 from collections import OrderedDict
 
 from unittest import TestCase
@@ -111,16 +110,16 @@ class TestYaml(TestCase):
 
     def test_parse_yaml_preserve_elements_order(self):
         input_template = (
-        'B_Resource:\n'
-        '  Key2:\n'
-        '    Name: name2\n'
-        '  Key1:\n'
-        '    Name: name1\n'
-        'A_Resource:\n'
-        '  Key2:\n'
-        '    Name: name2\n'
-        '  Key1:\n'
-        '    Name: name1\n'
+            'B_Resource:\n'
+            '  Key2:\n'
+            '    Name: name2\n'
+            '  Key1:\n'
+            '    Name: name1\n'
+            'A_Resource:\n'
+            '  Key2:\n'
+            '    Name: name2\n'
+            '  Key1:\n'
+            '    Name: name1\n'
         )
         output_dict = yaml_parse(input_template)
         expected_dict = OrderedDict([

--- a/tests/unit/test_yamlhelper.py
+++ b/tests/unit/test_yamlhelper.py
@@ -110,18 +110,18 @@ class TestYaml(TestCase):
         self.assertEqual(expected_dict, output_dict)
 
     def test_parse_yaml_preserve_elements_order(self):
-        input_template = """
-        B_Resource:
-            Key2:
-                Name: name2
-            Key1:
-                Name: name1
-        A_Resource:
-            Key2:
-                Name: name2
-            Key1:
-                Name: name1
-        """
+        input_template = (
+        'B_Resource:\n'
+        '  Key2:\n'
+        '    Name: name2\n'
+        '  Key1:\n'
+        '    Name: name1\n'
+        'A_Resource:\n'
+        '  Key2:\n'
+        '    Name: name2\n'
+        '  Key1:\n'
+        '    Name: name1\n'
+        )
         output_dict = yaml_parse(input_template)
         expected_dict = OrderedDict([
             ('B_Resource', OrderedDict([('Key2', {'Name': 'name2'}), ('Key1', {'Name': 'name1'})])),
@@ -130,9 +130,7 @@ class TestYaml(TestCase):
         self.assertEqual(expected_dict, output_dict)
 
         output_template = yaml_dump(output_dict)
-        # yaml dump changes indentation, remove spaces and new line characters to just compare the text
-        self.assertEqual(re.sub(r'\n|\s', '', input_template),
-                         re.sub(r'\n|\s', '', output_template))
+        self.assertEqual(input_template, output_template)
 
     def test_yaml_merge_tag(self):
         test_yaml = """

--- a/tests/unit/test_yamlhelper.py
+++ b/tests/unit/test_yamlhelper.py
@@ -133,3 +133,14 @@ class TestYaml(TestCase):
         # yaml dump changes indentation, remove spaces and new line characters to just compare the text
         self.assertEqual(re.sub(r'\n|\s', '', input_template),
                          re.sub(r'\n|\s', '', output_template))
+
+    def test_yaml_merge_tag(self):
+        test_yaml = """
+        base: &base
+            property: value
+        test:
+            <<: *base
+        """
+        output = yaml_parse(test_yaml)
+        self.assertTrue(isinstance(output, OrderedDict))
+        self.assertEqual(output.get('test').get('property'), 'value')


### PR DESCRIPTION
*Description of changes:*
Currently elements in templates are scrambled after parsing and dumping, use OrderedDict to preserve elements order.

Updated unit test case to match aws-cli

Note:
Original PR: https://github.com/awslabs/aws-sam-cli/pull/924
Wasn't able to update the original PR as I don't have permissions. Since the submitter of that PR is away on vacation, and we want to get this addressed as soon as possible, I am creating a new PR with the changes pulled in from the original PR. Comments have been addressed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
