### PR TITLE
feat: allow sam to be invoked as a module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=compat.py
+ignore=compat.py, __main__.py
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/samcli/__main__.py
+++ b/samcli/__main__.py
@@ -4,8 +4,7 @@ Invokable Module for CLI
 python -m samcli
 """
 
-import sys
 from samcli.cli.main import cli
 
 if __name__ == "__main__":
-    sys.exit(cli())
+    cli()

--- a/samcli/__main__.py
+++ b/samcli/__main__.py
@@ -1,0 +1,5 @@
+import sys
+from samcli.cli.main import cli
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/samcli/__main__.py
+++ b/samcli/__main__.py
@@ -1,3 +1,9 @@
+"""
+Invokable Module for CLI
+
+python -m samcli
+"""
+
 import sys
 from samcli.cli.main import cli
 

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -4,6 +4,7 @@ Entry point for the CLI
 
 import logging
 import json
+import sys
 import click
 
 from samcli import __version__
@@ -63,3 +64,7 @@ def cli(ctx):
     https://github.com/awslabs/serverless-application-model.
     """
     pass
+
+
+if __name__ == '__main__':
+    sys.exit(cli())

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -4,7 +4,6 @@ Entry point for the CLI
 
 import logging
 import json
-import sys
 import click
 
 from samcli import __version__
@@ -64,7 +63,3 @@ def cli(ctx):
     https://github.com/awslabs/serverless-application-model.
     """
     pass
-
-
-if __name__ == '__main__':
-    sys.exit(cli())


### PR DESCRIPTION
- `python -m samcli.cli.main` invokes sam cli

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
