### PR TITLE
fix: Include dotnet build artifacts from possible subfolders.

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/build.cake
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/build.cake
@@ -190,7 +190,7 @@ Task("Pack")
 
 			Information("Packing '{0}'...", projectName);
 			var path = System.IO.Path.Combine(publishDir, projectName);
-			var files = GetFiles(path + "/*.*");
+			var files = GetFiles(path + "/**/*.*");
 			Zip(
 				path, 
 				System.IO.Path.Combine(artifactsDir, $"{projectName}.zip"),


### PR DESCRIPTION
*Description of changes:*

Pack task doesn't include possible runtime specific nuget packages which are located in the "runtimes" folder of the build directory. This will cause an error such as "An assembly specified in the application dependencies manifest (application.deps.json) was not found" when certain nuget packages are referenced. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
