### PR TITLE
WIP: Implemented support for CORS in start-api command

### DIFF
--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -100,7 +100,7 @@ class LocalApiService(object):
         routes = []
         for api in api_provider.get_all():
             route = Route(methods=[api.method], function_name=api.function_name, path=api.path,
-                          binary_types=api.binary_media_types)
+                          binary_types=api.binary_media_types, cors=api.cors)
             routes.append(route)
 
         return routes

--- a/samcli/commands/local/lib/provider.py
+++ b/samcli/commands/local/lib/provider.py
@@ -229,7 +229,7 @@ class Api(_ApiTuple):
         return hash(self.path) * hash(self.method) * hash(self.function_name)
 
 
-Cors = namedtuple("Cors", ["AllowOrigin", "AllowMethods", "AllowHeaders"])
+Cors = namedtuple("Cors", ["allow_origin", "allow_methods", "allow_headers", "max_age"])
 
 
 class ApiProvider(object):


### PR DESCRIPTION
*Issue #, if available:*

#323

*Description of changes:*

This adds a basic support for CORS in `start-api` command. Currently it only understands format specified in [SAM](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#cors-configuration) and doesn't understand explicit definition with `x-amazon-apigateway-integration` with `type=mock`. I believe that this should solve most of the use cases and support for the explicit specification can be added at the later stage as it is a more complex task.

At this stage I'm looking for the confirmation that the direction is right and if so I'll proceed with a cleanup, tests and documentation.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.