### PR TITLE
docs: fix links to .rst files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ information to effectively respond to your bug report or contribution.
 
 ## Development Guide
 
-Refer to the [Development Guide](DEVELOPMENT_GUIDE.rst) for help with environment setup, running tests, submitting a PR, or anything that will make you more productive.
+Refer to the [Development Guide](DEVELOPMENT_GUIDE.md) for help with environment setup, running tests, submitting a PR, or anything that will make you more productive.
 
 
 ## Reporting Bugs/Feature Requests

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -156,7 +156,7 @@ Design Document
 
 A design document is a written description of the feature/capability you
 are building. We have a [design document
-template](./designs/_template.rst) to help you quickly fill in the
+template](./designs/_template.md) to help you quickly fill in the
 blanks and get you working quickly. We encourage you to write a design
 document for any feature you write, but for some types of features we
 definitely require a design document to proceed with implementation.


### PR DESCRIPTION
I was trying to get to the development guide, then I found the link didn't exist.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
