### PR TITLE
fix: always ensure the base command is set to "sam"

### DIFF
--- a/samcli/__main__.py
+++ b/samcli/__main__.py
@@ -7,4 +7,6 @@ python -m samcli
 from samcli.cli.main import cli
 
 if __name__ == "__main__":
-    cli()
+    # NOTE(TheSriram): prog_name is always set to "sam". This way when the CLI is invoked as a module,
+    # the help text that is generated still says "sam" instead of "__main__".
+    cli(prog_name="sam")

--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -5,7 +5,6 @@ Base classes that implement the CLI framework
 import logging
 import importlib
 import click
-import six
 
 logger = logging.getLogger(__name__)
 
@@ -111,28 +110,3 @@ class BaseCommand(click.MultiCommand):
             return
 
         return mod.cli
-
-    # NOTE(TheSriram): info_name is always set to "sam". This way when the CLI is invoked as a module,
-    # the help text that is generated still says "sam" instead of "__main__".
-    def make_context(self, info_name, args, parent=None, **extra):
-        """This function when given an info name and arguments will kick
-        off the parsing and create a new :class:`Context`.  It does not
-        invoke the actual command callback though.
-
-        :param info_name: the info name for this invokation.  Generally this
-                          is the most descriptive name for the script or
-                          command.  For the toplevel script it's usually
-                          the name of the script, for commands below it it's
-                          the name of the script.
-        :param args: the arguments to parse as list of strings.
-        :param parent: the parent context if available.
-        :param extra: extra keyword arguments forwarded to the context
-                      constructor.
-        """
-        for key, value in six.iteritems(self.context_settings):
-            if key not in extra:
-                extra[key] = value
-        ctx = click.Context(self, info_name="sam", parent=parent, **extra)
-        with ctx.scope(cleanup=False):
-            self.parse_args(ctx, args)
-        return ctx


### PR DESCRIPTION
- irrespective of the module name that invokes the CLI, the command that
  is seen on the help/description text, should always say "sam"

Example

```
(aws_sam_cli_WS) srirammv@localrainbow:20:20:34:~/aws_sam_cli_WS/aws-sam-cli$python -m samcli
Usage: sam [OPTIONS] COMMAND [ARGS]...

  AWS Serverless Application Model (SAM) CLI

  The AWS Serverless Application Model extends AWS CloudFormation to provide
  a simplified way of defining the Amazon API Gateway APIs, AWS Lambda
  functions, and Amazon DynamoDB tables needed by your serverless
  application. You can find more in-depth guide about the SAM specification
  here: https://github.com/awslabs/serverless-application-model.

Options:
  --debug    Turn on debug logging to print debug message generated by SAM
             CLI.
  --version  Show the version and exit.
  --info
  --help     Show this message and exit.

Commands:
  publish   Publish a packaged AWS SAM template to the AWS Serverless
            Application Repository.
  package   Package an AWS SAM application. This is an alias for 'aws
            cloudformation package'.
  init      Initialize a serverless application with a...
  build     Build your Lambda function code
  validate  Validate an AWS SAM template.
  local     Run your Serverless application locally for...
  logs      Fetch logs for a function
  deploy    Deploy an AWS SAM application. This is an alias for 'aws
            cloudformation deploy'.
```

we now see `sam [OPTIONS] COMMAND [ARGS]...` instead of `__main__.py [OPTIONS] COMMAND [ARGS]...`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
