### PR TITLE
fix: Remove tests from .whl file (bdist_wheel)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     author_email='aws-sam-developers@amazon.com',
     url='https://github.com/awslabs/aws-sam-cli',
     license='Apache License 2.0',
-    packages=find_packages(exclude=('tests', 'docs')),
+    packages=find_packages(exclude=['tests.*', 'tests']),
     keywords="AWS SAM CLI",
     # Support Python 2.7 and 3.6 or greater
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Python wheels, `.whl` files, produced through `python setup.py bdist_wheel` do not read or understand `MANIFEST.in` files. Since we use this file to remove tests modules from the dists, tests end up in the `.whl` files that get uploaded to PyPi. This PR updates the `exclude` parameter in `find_packages` to exclude all `test.*` modules, following [setuptools documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages).

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
