### PR TITLE
Fix example in docs: `read_timeout` has invalid value (0) for urllib3.Timeout(read).

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,7 +114,7 @@ if running_locally:
         verify=False,
         config=botocore.client.Config(
             signature_version=botocore.UNSIGNED,
-            read_timeout=0,
+            read_timeout=None,
             retries={'max_attempts': 0},
         )
     )

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -44,7 +44,7 @@ Here is a Python example:
                                   use_ssl=False,
                                   verify=False,
                                   config=Config(signature_version=UNSIGNED,
-                                                read_timeout=0,
+                                                read_timeout=None,
                                                 retries={'max_attempts': 0}))
     self.lambda_client.invoke(FunctionName="HelloWorldFunction")
 """


### PR DESCRIPTION
This should use if intention was to define "infinite timeout".

*Issue #, if available:*
I have couple of long-running lambdas over 1 minute. In order to not get timeouts I used `read_timeout=0` from example in docs, but that doesn't work:
```
ValueError: Attempted to set read timeout to 0, but the timeout cannot be set to a value less than or equal to 0.
```

*Description of changes:*
Use `None` instead as per 
https://urllib3.readthedocs.io/en/latest/reference/index.html#urllib3.Timeout
(Works in both py2 and py3)

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
