### PR TITLE
Chore: Bump aws-sam-translator

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ Flask~=1.0.2
 boto3~=1.9, >=1.9.56
 PyYAML~=3.12
 cookiecutter~=1.6.0
-aws-sam-translator==1.9.1
+aws-sam-translator==1.10.0
 docker>=3.3.0
 dateparser~=0.7
 python-dateutil~=2.6

--- a/samcli/commands/validate/lib/sam_template_validator.py
+++ b/samcli/commands/validate/lib/sam_template_validator.py
@@ -59,29 +59,10 @@ class SamTemplateValidator(object):
 
         self._replace_local_codeuri()
 
-        # In the Paser class, within the SAM Translator, they log a warning for when the template
-        # does not match the schema. The logger they use is the root logger instead of one scoped to
-        # their module. Currently this does not cause templates to fail, so we will suppress this
-        # by patching the logging.warning method that is used in that class.
-        class WarningSuppressLogger(object):
-
-            def __init__(self, obj_to_patch):
-                self.obj_to_patch = obj_to_patch
-
-            def __enter__(self):
-                self.obj_to_patch.warning = self.warning
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                self.obj_to_patch.warning = self.obj_to_patch.warning
-
-            def warning(self, message):
-                pass
-
         try:
-            with WarningSuppressLogger(parser.logging):
-                template = sam_translator.translate(sam_template=self.sam_template,
-                                                    parameter_values={})
-                LOG.debug("Translated template is:\n%s", yaml_dump(template))
+            template = sam_translator.translate(sam_template=self.sam_template,
+                                                parameter_values={})
+            LOG.debug("Translated template is:\n%s", yaml_dump(template))
         except InvalidDocumentException as e:
             raise InvalidSamDocumentException(
                 functools.reduce(lambda message, error: message + ' ' + str(error), e.causes, str(e)))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump version of `aws-sam-translator`.

This PR also removes a monkey patch we created to suppress some root level logging the `aws-sam-translator` was doing. With the release of 1.10.0, there is no longer a `logging`module in the samtranslator.parser.parser module. When running `make pr`, pylint was complaining about this as well (see below)

```
************* Module samcli.commands.validate.lib.sam_template_validator
E: 81,39: Module 'samtranslator.parser.parser' has no 'logging' member (no-member)
```

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
