### PR TITLE
Add Docker Delegated Consistency to Volume

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -84,7 +84,7 @@ class Container(object):
         if self.is_created():
             raise RuntimeError("This container already exists. Cannot create again.")
 
-        LOG.info("Mounting %s as %s:ro inside runtime container", self._host_dir, self._working_dir)
+        LOG.info("Mounting %s as %s:ro,delegated inside runtime container", self._host_dir, self._working_dir)
 
         kwargs = {
             "command": self._cmd,
@@ -95,7 +95,7 @@ class Container(object):
                     # https://docs.docker.com/storage/bind-mounts
                     # Mount the host directory as "read only" inside container
                     "bind": self._working_dir,
-                    "mode": "ro"
+                    "mode": "ro,delegated"
                 }
             },
             # We are not running an interactive shell here.

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -76,7 +76,7 @@ class TestContainer_create(TestCase):
         expected_volumes = {
             self.host_dir: {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,delegated"
             }
         }
         generated_id = "fooobar"
@@ -109,7 +109,7 @@ class TestContainer_create(TestCase):
         expected_volumes = {
             self.host_dir: {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,delegated"
             },
             '/somepath': {"blah": "blah value"}
         }
@@ -167,7 +167,7 @@ class TestContainer_create(TestCase):
         translated_volumes = {
             "/c/Users/Username/AppData/Local/Temp/tmp1337": {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,delegated"
             }
         }
 
@@ -222,7 +222,7 @@ class TestContainer_create(TestCase):
         expected_volumes = {
             self.host_dir: {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,delegated"
             }
         }
 
@@ -264,7 +264,7 @@ class TestContainer_create(TestCase):
         expected_volumes = {
             self.host_dir: {
                 "bind": self.working_dir,
-                "mode": "ro"
+                "mode": "ro,delegated"
             }
         }
 


### PR DESCRIPTION
ISSUE: Performance for Docker runs using `sam local start-api` on Mac is horrible. I benchmarked requiring a large Ruby application at ~45seconds.

FIX: Resolve Docker on Mac performance issues by allowing the project folder to be mounted as both "read only" (current behavior) and "delegated". The docs for Docker mention that a comma-separated list is an allowed value. Hence I maintained the `ro` mode and simply added `delegated` to the list. Doc: https://docs.docker.com/v17.09/engine/admin/volumes/volumes/

Please see this article for a description of the new option added. https://docs.docker.com/docker-for-mac/osxfs-caching/. If tests pass, I assume this option being added is a noop for non Mac platforms. 
