### PR TITLE
enable python37 debugging and optional bootstrap file option

### DIFF
--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -157,7 +157,7 @@ class LambdaContainer(Container):
         return image_builder.build(runtime, layers)
 
     @staticmethod
-    def _get_entry_point(runtime, debug_options=None):
+    def _get_entry_point(runtime, debug_options=None):  # pylint: disable=R0912
         """
         Returns the entry point for the container. The default value for the entry point is already configured in the
         Dockerfile. We override this default specifically when enabling debugging. The overridden entry point includes

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -293,13 +293,17 @@ class LambdaContainer(Container):
                        "/var/runtime/awslambda/bootstrap.py"
                    ]
 
+        elif runtime == Runtime.python37.value and debug_args_list:
+
+            entrypoint = ["/var/rapid/init"] + debug_args_list
+
         return entrypoint
 
     @staticmethod
     def _supported_runtimes():
         return {Runtime.java8.value, Runtime.dotnetcore20.value, Runtime.dotnetcore21.value, Runtime.go1x.value,
                 Runtime.nodejs.value, Runtime.nodejs43.value, Runtime.nodejs610.value, Runtime.nodejs810.value,
-                Runtime.python27.value, Runtime.python36.value}
+                Runtime.python27.value, Runtime.python36.value, Runtime.python37.value}
 
 
 class DebuggingNotSupported(Exception):


### PR DESCRIPTION
Fixes #1047

Allow python3.7 debugging. Use the default entrypoint unless `--debug-options` are used to pass in the custom bootstrap file via the `--bootstrap` argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
