### PR TITLE
Go debugging Delve API support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -476,6 +476,15 @@ Then invoke [sam]{.title-ref} similar to the following:
 NOTE: The `--debugger-path` is the path to the directory that contains
 the [dlv]{.title-ref} binary compiled from the above.
 
+**Delve API Version**
+
+[SAM]{.title-ref} now supports to run the [/dlv]{.title-ref} debugger with API verison **'2.0'**, this 
+is important for when debugging in IDEs like Goland, Visual Studio Code, etc.
+
+`sam local start-api -d 5986 --debugger-path <delve folder path> --debug-args "-delveAPI=2"`
+
+**Example**
+
 The following is an example launch configuration for Visual Studio Code
 to attach to a debug session.
 


### PR DESCRIPTION
*Issue #886 

*Description of changes:*
Update Usage documentation on how to run GO [Delve](https://github.com/go-delve/delve) debugger using API version 2 mode.

*Checklist:*

- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
