### PR TITLE
fix: golang template path

### DIFF
--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -56,7 +56,7 @@ RUNTIME_DEP_TEMPLATE_MAPPING = {
         {
             "runtimes": ["go1.x"],
             "dependency_manager": None,
-            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-go"),
+            "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-golang"),
             "build": False
         }
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I modify invalid golang template path.

The golang template path is
`aws-sam-cli/samcli/local/init/templates/cookiecutter-aws-sam-hello-golang/`
But, invalid path is set in `samcli/local/common/runtime_template.py` file.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
