### PR TITLE
Add a check to Build command for Docker if the --use-container flag i…

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -180,7 +180,10 @@ class ApplicationBuilder(object):
             # By default prefer to build in-process for speed
             build_method = self._build_function_in_process
             if self._container_manager:
-                build_method = self._build_function_on_container
+                if self._container_manager.is_docker_reachable:
+                    build_method = self._build_function_on_container
+                else:
+                    raise BuildError("--use-container flag passed but Docker is not running")
 
             return build_method(config,
                                 code_dir,

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -180,10 +180,7 @@ class ApplicationBuilder(object):
             # By default prefer to build in-process for speed
             build_method = self._build_function_in_process
             if self._container_manager:
-                if self._container_manager.is_docker_reachable:
-                    build_method = self._build_function_on_container
-                else:
-                    raise BuildError("--use-container flag passed but Docker is not running")
+                build_method = self._build_function_on_container
 
             return build_method(config,
                                 code_dir,
@@ -223,6 +220,9 @@ class ApplicationBuilder(object):
                                      scratch_dir,
                                      manifest_path,
                                      runtime):
+
+        if not self._container_manager.is_docker_reachable:
+            raise BuildError("Docker is unreachable. Docker needs to be running to build inside a container.")
 
         # If we are printing debug logs in SAM CLI, the builder library should also print debug logs
         log_level = LOG.getEffectiveLevel()

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -309,6 +309,22 @@ class TestApplicationBuilder_build_function_on_container(TestCase):
         self.assertEquals(str(ctx.exception), msg)
         self.container_manager.stop.assert_called_with(container_mock)
 
+    def test_must_raise_on_docker_not_running(self):
+        config = Mock()
+
+        self.container_manager.is_docker_reachable = False
+
+        with self.assertRaises(BuildError) as ctx:
+            self.builder._build_function_on_container(config,
+                                                      "source_dir",
+                                                      "artifacts_dir",
+                                                      "scratch_dir",
+                                                      "manifest_path",
+                                                      "runtime")
+
+        self.assertEquals(str(ctx.exception),
+                          "Docker is unreachable. Docker needs to be running to build inside a container.")
+
 
 class TestApplicationBuilder_parse_builder_response(TestCase):
 


### PR DESCRIPTION
If you use the `--use-container` flag with the `sam build` command but Docker isn't running you get some nasty output. You get a bunch of errors and stack traces about endpoints being inaccessible and so on. This is really confusing and takes some digging to find out what the problem is. I've been tripped up several times and wasted a bunch of time trying to figure out what went wrong.

This PR adds a check to the `build` command to make sure Docker is reachable before trying to actually build the project inside of Docker. If Docker isn't reachable, it errors with a clear message indicating what the issue is. It also only tries to check for Docker when the `--use-container` flag is passed.

*How to reproduce problem:*

Run `sam build --use-container` while Docker isn't running.

*Description of changes:*

Changes include an added 'if' statement in the `app_build.py` file. This uses the already existing `ContainerManager.is_docker_reachable` property to determine if SAM can reach Docker. This only checks if the `--use-container` flag is passed. If it can't reach Docker, then it raises and exception.