### PR TITLE
Fix incorrect Gradle project configuration.

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/HelloWorldFunction/build.gradle
@@ -7,17 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.awssdk:annotations:2.1.0'
-	compile (
-        'com.amazonaws:aws-lambda-java-core:1.1.0'
-    )
-    testCompile 'junit:junit:4.12'
-}
-
-sourceSets {
-    main {
-        java {
-            srcDir 'src/main'
-        }
-    }
+    implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
+    testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
*Issue #, if available:*

This issue is reported in AWS Toolkit JetBrains, but the root cause is the Gradle template
https://github.com/aws/aws-toolkit-jetbrains/issues/854

*Description of changes:*

Remove the redundant `sourceSets` configuration and replace the deprecated methods. 

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
