### PR TITLE
Fix context doc URL of Ruby runtime 

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-ruby/{{cookiecutter.project_name}}/hello_world/app.rb
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-ruby/{{cookiecutter.project_name}}/hello_world/app.rb
@@ -12,7 +12,7 @@ def lambda_handler(event:, context:)
 
   # context: object, required
   #     Lambda Context runtime methods and attributes
-  #     Context doc: https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
+  #     Context doc: https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html
 
   # Returns
   # ------


### PR DESCRIPTION
*Issue #, if available:*
Nothing.

*Description of changes:*
Fix context doc URL of Ruby runtime.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
