### PR TITLE
feat: Error on --use-container for dotnet builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,5 +380,7 @@ $RECYCLE.BIN/
 
 # Temporary scratch directory used by the tests
 tests/integration/buildcmd/scratch
+tests/integration/testdata/buildcmd/Dotnetcore2.0/bin
+tests/integration/testdata/buildcmd/Dotnetcore2.0/obj
 
 # End of https://www.gitignore.io/api/osx,node,macos,linux,python,windows,pycharm,intellij,sublimetext,visualstudiocode

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -31,9 +31,10 @@ Supported Resource Types
 Supported Runtimes
 ------------------
 1. Python 2.7, 3.6, 3.7 using PIP\n
-4. Nodejs 8.10, 6.10 using NPM
-4. Ruby 2.5 using Bundler
-5. Java 8 using Gradle
+2. Nodejs 8.10, 6.10 using NPM\n
+3. Ruby 2.5 using Bundler\n
+4. Java 8 using Gradle\n
+5. Dotnetcore2.0 and 2.1 using Dotnet CLI\n
 \b
 Examples
 --------

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -35,7 +35,7 @@ Supported Runtimes
 2. Nodejs 8.10, 6.10 using NPM\n
 3. Ruby 2.5 using Bundler\n
 4. Java 8 using Gradle\n
-5. Dotnetcore2.0 and 2.1 using Dotnet CLI\n
+5. Dotnetcore2.0 and 2.1 using Dotnet CLI (without --use-container flag)\n
 \b
 Examples
 --------
@@ -149,11 +149,9 @@ def do_cli(template,  # pylint: disable=too-many-locals
 
             click.secho(msg, fg="yellow")
 
-        except ContainerBuildNotSupported as ex:
-            click.secho("--use-container is unsupported: {}".format(str(ex)), fg="red")
-
-        except (UnsupportedRuntimeException, BuildError, UnsupportedBuilderLibraryVersionError) as ex:
-            click.secho("Build Failed", fg="red")
+        except (UnsupportedRuntimeException, BuildError, UnsupportedBuilderLibraryVersionError,
+                ContainerBuildNotSupported) as ex:
+            click.secho("\nBuild Failed", fg="red")
             raise UserException(str(ex))
 
 

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -11,7 +11,8 @@ from samcli.cli.main import pass_context, common_options as cli_framework_option
 from samcli.commands._utils.options import template_option_without_build, docker_common_options, \
     parameter_override_option
 from samcli.commands.build.build_context import BuildContext
-from samcli.lib.build.app_builder import ApplicationBuilder, BuildError, UnsupportedBuilderLibraryVersionError
+from samcli.lib.build.app_builder import ApplicationBuilder, BuildError, UnsupportedBuilderLibraryVersionError, \
+    ContainerBuildNotSupported
 from samcli.lib.build.workflow_config import UnsupportedRuntimeException
 from samcli.commands._utils.template import move_template
 
@@ -147,6 +148,9 @@ def do_cli(template,  # pylint: disable=too-many-locals
                                   os.path.abspath(ctx.build_dir) == os.path.abspath(DEFAULT_BUILD_DIR))
 
             click.secho(msg, fg="yellow")
+
+        except ContainerBuildNotSupported as ex:
+            click.secho("--use-container is unsupported: {}".format(str(ex)), fg="red")
 
         except (UnsupportedRuntimeException, BuildError, UnsupportedBuilderLibraryVersionError) as ex:
             click.secho("Build Failed", fg="red")

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -33,6 +33,10 @@ class UnsupportedBuilderLibraryVersionError(Exception):
         Exception.__init__(self, msg.format(container_name=container_name, error_msg=error_msg))
 
 
+class ContainerBuildNotSupported(Exception):
+    pass
+
+
 class BuildError(Exception):
     pass
 
@@ -229,6 +233,10 @@ class ApplicationBuilder(object):
 
         if not self._container_manager.is_docker_reachable:
             raise BuildError("Docker is unreachable. Docker needs to be running to build inside a container.")
+
+        container_build_supported, reason = supports_build_in_container(config)
+        if not container_build_supported:
+            raise ContainerBuildNotSupported(reason)
 
         # If we are printing debug logs in SAM CLI, the builder library should also print debug logs
         log_level = LOG.getEffectiveLevel()

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -184,13 +184,7 @@ class ApplicationBuilder(object):
             # By default prefer to build in-process for speed
             build_method = self._build_function_in_process
             if self._container_manager:
-
-                container_build_supported, reason = supports_build_in_container(config)
-                if container_build_supported:
-                    build_method = self._build_function_on_container
-                else:
-                    LOG.warning(reason)
-                    LOG.warning("Continuing build without a container")
+                build_method = self._build_function_on_container
 
             return build_method(config,
                                 code_dir,

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -117,6 +117,32 @@ def get_workflow_config(runtime, code_dir, project_dir):
                                           .format(runtime, str(ex)))
 
 
+def supports_build_in_container(config):
+    """
+    Given a workflow config, this method provides a boolean on whether the workflow can run within a container or not.
+
+    Parameters
+    ----------
+    config namedtuple(Capability)
+        Config specifying the particular build workflow
+
+    Returns
+    -------
+    tuple(bool, str)
+        True, if this workflow can be built inside a container. False, along with a reason message if it cannot be.
+    """
+
+    unsupported = {
+        DOTNET_CLIPACKAGE_CONFIG: "We do not support building dotnet Lambda functions within a container. Most "
+                                  "dotnet functions can be successfully built without a container.",
+    }
+
+    if config in unsupported:
+        return False, unsupported[config]
+
+    return True, None
+
+
 class BasicWorkflowSelector(object):
     """
     Basic workflow selector that returns the first available configuration in the given list of configurations

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -141,7 +141,7 @@ def supports_build_in_container(config):
     """
 
     def _key(c):
-        return c.language + c.dependency_manager + str(c.application_framework)
+        return str(c.language) + str(c.dependency_manager) + str(c.application_framework)
 
     # This information could have beeen bundled inside the Workflow Config object. But we this way because
     # ultimately the workflow's implementation dictates whether it can run within a container or not.

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -146,8 +146,9 @@ def supports_build_in_container(config):
     # map to identify which workflows can support building within a container.
 
     unsupported = {
-        DOTNET_CLIPACKAGE_CONFIG: "We do not support building dotnet Lambda functions within a container. Most "
-                                  "dotnet functions can be successfully built without a container.",
+        DOTNET_CLIPACKAGE_CONFIG: "We do not support building .NET Core Lambda functions within a container. "
+                                  "Try building without the container. Most .NET Core functions will build "
+                                  "successfully.",
     }
 
     if config in unsupported:

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -140,6 +140,11 @@ def supports_build_in_container(config):
         True, if this workflow can be built inside a container. False, along with a reason message if it cannot be.
     """
 
+    # This information could have beeen bundled inside the Workflow Config object. But we this way because
+    # ultimately the workflow's implementation dictates whether it can run within a container or not.
+    # A "workflow config" is like a primary key to identify the workflow. So we use the config as a key in the
+    # map to identify which workflows can support building within a container.
+
     unsupported = {
         DOTNET_CLIPACKAGE_CONFIG: "We do not support building dotnet Lambda functions within a container. Most "
                                   "dotnet functions can be successfully built without a container.",

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -140,18 +140,21 @@ def supports_build_in_container(config):
         True, if this workflow can be built inside a container. False, along with a reason message if it cannot be.
     """
 
+    def _key(c):
+        return c.language + c.dependency_manager + str(c.application_framework)
+
     # This information could have beeen bundled inside the Workflow Config object. But we this way because
     # ultimately the workflow's implementation dictates whether it can run within a container or not.
     # A "workflow config" is like a primary key to identify the workflow. So we use the config as a key in the
     # map to identify which workflows can support building within a container.
 
     unsupported = {
-        DOTNET_CLIPACKAGE_CONFIG: "We do not support building .NET Core Lambda functions within a container. "
-                                  "Try building without the container. Most .NET Core functions will build "
-                                  "successfully.",
+        _key(DOTNET_CLIPACKAGE_CONFIG): "We do not support building .NET Core Lambda functions within a container. "
+                                        "Try building without the container. Most .NET Core functions will build "
+                                        "successfully.",
     }
 
-    if config in unsupported:
+    if _key(config) in unsupported:
         return False, unsupported[config]
 
     return True, None

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -356,6 +356,24 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
 
         self.verify_docker_container_cleanedup(runtime)
 
+    @parameterized.expand([
+        ("dotnetcore2.0", "Dotnetcore2.0"),
+        ("dotnetcore2.1", "Dotnetcore2.1"),
+    ])
+    def test_must_fail_with_container(self, runtime, code_uri):
+        use_container = True
+        overrides = {"Runtime": runtime, "CodeUri": code_uri,
+                     "Handler": "HelloWorld::HelloWorld.Function::FunctionHandler"}
+        cmdlist = self.get_command_list(use_container=use_container,
+                                        parameter_overrides=overrides)
+
+        LOG.info("Running Command: {}".format(cmdlist))
+        process = subprocess.Popen(cmdlist, cwd=self.working_dir)
+        process.wait()
+
+        # Must error out, because container builds are not supported
+        self.assertEquals(process.returncode, 1)
+
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
 
         self.assertTrue(build_dir.exists(), "Build directory should be created")

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -176,6 +176,47 @@ class TestApplicationBuilder_build_function(TestCase):
                                                                      manifest_path,
                                                                      runtime)
 
+    @patch("samcli.lib.build.app_builder.supports_build_in_container")
+    @patch("samcli.lib.build.app_builder.get_workflow_config")
+    @patch("samcli.lib.build.app_builder.osutils")
+    def test_must_fallback_to_build_in_process_for_unsupported_containers(self,
+                                                                          osutils_mock,
+                                                                          get_workflow_config_mock,
+                                                                          supports_build_in_container_mock):
+        function_name = "function_name"
+        codeuri = "path/to/source"
+        runtime = "runtime"
+        scratch_dir = "scratch"
+        config_mock = get_workflow_config_mock.return_value = Mock()
+        config_mock.manifest_name = "manifest_name"
+
+        osutils_mock.mkdir_temp.return_value.__enter__ = Mock(return_value=scratch_dir)
+        osutils_mock.mkdir_temp.return_value.__exit__ = Mock()
+
+        self.builder._build_function_on_container = Mock()
+        self.builder._build_function_in_process = Mock()
+
+        code_dir = "/base/dir/path/to/source"
+        artifacts_dir = "/build/dir/function_name"
+        manifest_path = os.path.join(code_dir, config_mock.manifest_name)
+
+        # Setting the container manager will make us use the container
+        self.builder._container_manager = Mock()
+
+        # Mark the container build as unsupported
+        supports_build_in_container_mock.return_value = (False, "reason")
+
+        self.builder._build_function(function_name, codeuri, runtime)
+
+        self.builder._build_function_on_container.assert_not_called()
+        self.builder._build_function_in_process.assert_called_with(config_mock,
+                                                                   code_dir,
+                                                                   artifacts_dir,
+                                                                   scratch_dir,
+                                                                   manifest_path,
+                                                                   runtime)
+        supports_build_in_container_mock.assert_called_with(config_mock)
+
 
 class TestApplicationBuilder_build_function_in_process(TestCase):
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
"sam build" for Dotnet does not really need to support building within a container because majority of the dotnet modules don't have native bindings and can compile on any platform and run successfully on Lambda.

PR is marked WIP because the exact error message and UX is still not signed off.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
