### PR TITLE
Adding specific configuration for gradle projects using kotlin build script

### DIFF
--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -41,6 +41,13 @@ JAVA_GRADLE_CONFIG = CONFIG(
                 manifest_name="build.gradle",
                 executable_search_paths=None)
 
+JAVA_KOTLIN_GRADLE_CONFIG = CONFIG(
+                language="java",
+                dependency_manager="gradle",
+                application_framework=None,
+                manifest_name="build.gradle.kts",
+                executable_search_paths=None)
+
 JAVA_MAVEN_CONFIG = CONFIG(
                 language="java",
                 dependency_manager="maven",
@@ -100,6 +107,7 @@ def get_workflow_config(runtime, code_dir, project_dir):
         "java8": ManifestWorkflowSelector([
             # Gradle builder needs custom executable paths to find `gradlew` binary
             JAVA_GRADLE_CONFIG._replace(executable_search_paths=[code_dir, project_dir]),
+            JAVA_KOTLIN_GRADLE_CONFIG._replace(executable_search_paths=[code_dir, project_dir]),
             JAVA_MAVEN_CONFIG
         ]),
     }

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -249,14 +249,17 @@ class TestBuildCommand_Java(BuildIntegBase):
     FUNCTION_LOGICAL_ID = "Function"
     USING_GRADLE_PATH = os.path.join("Java", "gradle")
     USING_GRADLEW_PATH = os.path.join("Java", "gradlew")
+    USING_GRADLE_KOTLIN_PATH = os.path.join("Java", "gradle-kotlin")
     USING_MAVEN_PATH = str(Path('Java', 'maven'))
 
     @parameterized.expand([
         ("java8", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE, False),
         ("java8", USING_GRADLEW_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE, False),
+        ("java8", USING_GRADLE_KOTLIN_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE, False),
         ("java8", USING_MAVEN_PATH, EXPECTED_FILES_PROJECT_MANIFEST_MAVEN, False),
         ("java8", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE, "use_container"),
         ("java8", USING_GRADLEW_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE, "use_container"),
+        ("java8", USING_GRADLE_KOTLIN_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE, "use_container"),
         ("java8", USING_MAVEN_PATH, EXPECTED_FILES_PROJECT_MANIFEST_MAVEN, "use_container")
     ])
     def test_with_building_java(self, runtime, code_path, expected_files, use_container):

--- a/tests/integration/testdata/buildcmd/Java/gradle-kotlin/build.gradle.kts
+++ b/tests/integration/testdata/buildcmd/Java/gradle-kotlin/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("software.amazon.awssdk:annotations:2.1.0")
+	compile("com.amazonaws:aws-lambda-java-core:1.1.0")
+}

--- a/tests/integration/testdata/buildcmd/Java/gradle-kotlin/src/main/java/aws/example/Hello.java
+++ b/tests/integration/testdata/buildcmd/Java/gradle-kotlin/src/main/java/aws/example/Hello.java
@@ -1,0 +1,13 @@
+package aws.example;
+
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+
+public class Hello {
+    public String myHandler(Context context) {
+        LambdaLogger logger = context.getLogger();
+        logger.log("Function Invoked\n");
+        return "Hello World";
+    }
+}

--- a/tests/unit/lib/build_module/test_workflow_config.py
+++ b/tests/unit/lib/build_module/test_workflow_config.py
@@ -51,6 +51,7 @@ class Test_get_workflow_config(TestCase):
 
     @parameterized.expand([
         ("java8", "build.gradle", "gradle"),
+        ("java8", "build.gradle.kts", "gradle"),
         ("java8", "pom.xml", "maven")
     ])
     @patch("samcli.lib.build.workflow_config.os")


### PR DESCRIPTION

* Issue #1097
* Allows to use `build.gradle.kts` instead of `build.gradle`

