### PR TITLE
fix(init): Add runtime to template when dotnetcore runtime is asked for

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
       Runtime: {{ cookiecutter.runtime }}
-      {%- elif cookiecutter.runtime == 'dotnetcore2.1' or cookiecutter.runtime == 'dotnet' %}
+      {%- else %}
       Runtime: dotnetcore2.1
       {%- endif %}
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
`sam init --runtime dotnetcore` produced a template without a Runtime, making the template invalid. This change removes an else if case in the template generation to allow always producing the latest dotnetcore runtime. The cli (click) will validate the options before cookiecutter runs, so we don't need strict match checks expect for the none latest cases (in this case for dotnetcore2.0).

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
