### PR TITLE
Depend on development version of lambda-builders for dev builds

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE
 include requirements/base.txt
 include requirements/prod.txt
 include requirements/dev.txt
+include requirements/tools.txt
 recursive-include samcli/local/init/templates *
 recursive-include samcli/lib *.json
 recursive-include samcli/commands/local/lib/generated_sample_events *.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include requirements/base.txt
+include requirements/prod.txt
 include requirements/dev.txt
 recursive-include samcli/local/init/templates *
 recursive-include samcli/lib *.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 init:
 	SAM_CLI_DEV=1 pip install -e .
 	SAM_CLI_DEV=1 pip install -r requirements/dev.txt
+	SAM_CLI_DEV=1 pip install -r requirements/tools.txt
 
 test:
 	# Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 init:
-	SAM_CLI_DEV=1 pip install -e '.[dev]'
+	SAM_CLI_DEV=1 pip install -e .
+	SAM_CLI_DEV=1 pip install -r requirements/dev.txt
 
 test:
 	# Run unit tests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,5 +12,4 @@ dateparser~=0.7
 python-dateutil~=2.6
 pathlib2~=2.3.2; python_version<"3.4"
 requests==2.20.1
-aws_lambda_builders==0.2.1
 serverlessrepo==0.1.8

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,7 @@
+# Following are "dev" version of libraries that SAM CLI consumes for development purposes.
+# For production releases, see prod.txt where these libraries are pinned to a particular version
+-e git://github.com/awslabs/aws-lambda-builders.git@develop#egg=aws_lambda_builders
+
 coverage==4.3.4
 flake8==3.3.0
 tox==2.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,21 +1,3 @@
 # Following are "dev" version of libraries that SAM CLI consumes for development purposes.
 # For production releases, see prod.txt where these libraries are pinned to a particular version
 -e git://github.com/awslabs/aws-lambda-builders.git@develop#egg=aws_lambda_builders
-
-coverage==4.3.4
-flake8==3.3.0
-tox==2.2.1
-pytest-cov==2.4.0
-# astroid > 2.0.4 is not compatible with pylint1.7
-astroid>=1.5.8,<2.1.0
-pylint==1.7.2
-
-# Test requirements
-pytest==3.0.7
-py==1.4.33
-mock==2.0.0
-parameterized==0.6.1
-pathlib2==2.3.2; python_version<"3.4"
-futures==3.2.0; python_version<"3.2.3"
-# Py3.2 backport
-backports.tempfile==1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,4 @@
+# SAM CLI depends on these libraries that the team authors/controls. Pinning them to particular version here
+# for production usage.
+
+aws_lambda_builders==0.2.1

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -1,0 +1,17 @@
+coverage==4.3.4
+flake8==3.3.0
+tox==2.2.1
+pytest-cov==2.4.0
+# astroid > 2.0.4 is not compatible with pylint1.7
+astroid>=1.5.8,<2.1.0
+pylint==1.7.2
+
+# Test requirements
+pytest==3.0.7
+py==1.4.33
+mock==2.0.0
+parameterized==0.6.1
+pathlib2==2.3.2; python_version<"3.4"
+futures==3.2.0; python_version<"3.2.3"
+# Py3.2 backport
+backports.tempfile==1.0

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,18 @@ def read_version():
     return re.search(r"__version__ = '([^']+)'", content).group(1)
 
 
+base_reqs = read_requirements("base.txt")
+prod_reqs = read_requirements("prod.txt")
+
+requirements = base_reqs + prod_reqs
 cmd_name = "sam"
+
 if os.getenv("SAM_CLI_DEV"):
     # We are installing in a dev environment
     cmd_name = "samdev"
+
+    # Don't install prod requirements for dev release
+    requirements = base_reqs
 
 setup(
     name='aws-sam-cli',
@@ -52,10 +60,7 @@ setup(
             '{}=samcli.cli.main:cli'.format(cmd_name)
         ]
     },
-    install_requires=read_requirements('base.txt'),
-    extras_require={
-        'dev': read_requirements('dev.txt')
-    },
+    install_requires=requirements,
     include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
*Issue #, if available:*
During development, we can't easily use development versions of other dependencies such as AWS Lambda Builders.

*Description of changes:*
In this change, I have separated out dev requirements from prod requirements. For Production, the dependencies are version pinned and pulled from PyPi. For dev requirements, the dependencies are pulled directly from Github source. 

I had to remote the `extras_requires` in setup.py because it did not support installing from Github. Instead I modified the Makefile to pip install these dependencies separately. This is acceptable for development builds.

For production, I concatenate `base.txt` with `prod.txt` and use it as the final list of requirements.

*Testing:*
Following commands worked as expected

- `SAM_CLI_DEV=1 pip install -e .`
- `pip install -e .`
- `make init`

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
