### PR TITLE
docs: Fix name of source directory in README.md

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs/{{cookiecutter.project_name}}/README.md
@@ -6,7 +6,7 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 .
 ├── README.MD                   <-- This instructions file
 ├── event.json                  <-- API Gateway Proxy Integration event payload
-├── hello_world                 <-- Source code for a lambda function
+├── hello-world                 <-- Source code for a lambda function
 │   └── app.js                  <-- Lambda function code
 │   └── package.json            <-- NodeJS dependencies and scripts
 │   └── tests                   <-- Unit tests

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs6/{{cookiecutter.project_name}}/README.md
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-nodejs6/{{cookiecutter.project_name}}/README.md
@@ -6,7 +6,7 @@ This is a sample template for {{ cookiecutter.project_name }} - Below is a brief
 .
 ├── README.MD                   <-- This instructions file
 ├── event.json                  <-- API Gateway Proxy Integration event payload
-├── hello_world                 <-- Source code for a lambda function
+├── hello-world                 <-- Source code for a lambda function
 │   └── app.js                  <-- Lambda function code
 │   └── package.json            <-- NodeJS dependencies and scripts
 │   └── app-deps.js             <-- Lambda function code with dependencies (Bringing to the next level section)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a purely documentation change. The rest of these README.md files refer to the directory as `hello-world` rather than `hello_world`, and I can confirm the generated folder is named `hello-world`. Simply pulling the documentation into line with reality.

This only is for Node.js templates, other languages appear to use `hello_world`.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
