### PR TITLE
Layer Downloader now looks for AWS_CA_BUNDLE if it exists

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -91,6 +91,10 @@ Move back to your SAM CLI directory and re-run init, If necessary: open requirem
 Running Tests
 -------------
 
+### Unit testing with one Python version
+
+If you're trying to do a quick run, it's ok to use the current python version.  Run `make pr`.
+
 ### Unit testing with multiple Python versions
 
 [tox](http://tox.readthedocs.io/en/latest/) is used to run tests against

--- a/samcli/local/lambdafn/zip.py
+++ b/samcli/local/lambdafn/zip.py
@@ -107,7 +107,8 @@ def unzip_from_uri(uri, layer_zip_path, unzip_output_dir, progressbar_label):
         Label to use in the Progressbar
     """
     try:
-        get_request = requests.get(uri, stream=True)
+
+        get_request = requests.get(uri, stream=True, verify=os.environ.get('AWS_CA_BUNDLE', True))
 
         with open(layer_zip_path, 'wb') as local_layer_file:
             file_length = int(get_request.headers['Content-length'])

--- a/samcli/local/lambdafn/zip.py
+++ b/samcli/local/lambdafn/zip.py
@@ -107,7 +107,6 @@ def unzip_from_uri(uri, layer_zip_path, unzip_output_dir, progressbar_label):
         Label to use in the Progressbar
     """
     try:
-
         get_request = requests.get(uri, stream=True, verify=os.environ.get('AWS_CA_BUNDLE', True))
 
         with open(layer_zip_path, 'wb') as local_layer_file:

--- a/tests/unit/local/lambdafn/test_zip.py
+++ b/tests/unit/local/lambdafn/test_zip.py
@@ -5,7 +5,7 @@ import shutil
 from unittest import TestCase
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile, mkdtemp
-from mock import Mock, patch
+from mock import Mock, patch, mock
 
 from nose_parameterized import parameterized, param
 
@@ -86,6 +86,7 @@ class TestUnzipFromUri(TestCase):
     @patch('samcli.local.lambdafn.zip.progressbar')
     @patch('samcli.local.lambdafn.zip.requests')
     @patch('samcli.local.lambdafn.zip.open')
+    @mock.patch.dict(os.environ, {})
     def test_successfully_unzip_from_uri(self, open_patch, requests_patch, progressbar_patch, path_patch, unzip_patch):
         get_request_mock = Mock()
         get_request_mock.headers = {"Content-length": "200"}
@@ -104,7 +105,7 @@ class TestUnzipFromUri(TestCase):
 
         unzip_from_uri('uri', 'layer_zip_path', 'output_zip_dir', 'layer_arn')
 
-        requests_patch.get.assert_called_with('uri', stream=True)
+        requests_patch.get.assert_called_with('uri', stream=True, verify=os.environ.get('AWS_CA_BUNDLE', True))
         get_request_mock.iter_content.assert_called_with(chunk_size=None)
         open_patch.assert_called_with('layer_zip_path', 'wb')
         file_mock.write.assert_called_with(b'data1')
@@ -118,6 +119,7 @@ class TestUnzipFromUri(TestCase):
     @patch('samcli.local.lambdafn.zip.progressbar')
     @patch('samcli.local.lambdafn.zip.requests')
     @patch('samcli.local.lambdafn.zip.open')
+    @mock.patch.dict(os.environ, {})
     def test_not_unlink_file_when_file_doesnt_exist(self,
                                                     open_patch,
                                                     requests_patch,
@@ -141,7 +143,7 @@ class TestUnzipFromUri(TestCase):
 
         unzip_from_uri('uri', 'layer_zip_path', 'output_zip_dir', 'layer_arn')
 
-        requests_patch.get.assert_called_with('uri', stream=True)
+        requests_patch.get.assert_called_with('uri', stream=True, verify=os.environ.get('AWS_CA_BUNDLE', True))
         get_request_mock.iter_content.assert_called_with(chunk_size=None)
         open_patch.assert_called_with('layer_zip_path', 'wb')
         file_mock.write.assert_called_with(b'data1')

--- a/tests/unit/local/lambdafn/test_zip.py
+++ b/tests/unit/local/lambdafn/test_zip.py
@@ -5,7 +5,7 @@ import shutil
 from unittest import TestCase
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile, mkdtemp
-from mock import Mock, patch, mock
+from mock import Mock, patch
 
 from nose_parameterized import parameterized, param
 
@@ -86,8 +86,14 @@ class TestUnzipFromUri(TestCase):
     @patch('samcli.local.lambdafn.zip.progressbar')
     @patch('samcli.local.lambdafn.zip.requests')
     @patch('samcli.local.lambdafn.zip.open')
-    @mock.patch.dict(os.environ, {})
-    def test_successfully_unzip_from_uri(self, open_patch, requests_patch, progressbar_patch, path_patch, unzip_patch):
+    @patch('samcli.local.lambdafn.zip.os')
+    def test_successfully_unzip_from_uri(self,
+                                         os_patch,
+                                         open_patch,
+                                         requests_patch,
+                                         progressbar_patch,
+                                         path_patch,
+                                         unzip_patch):
         get_request_mock = Mock()
         get_request_mock.headers = {"Content-length": "200"}
         get_request_mock.iter_content.return_value = [b'data1']
@@ -103,9 +109,11 @@ class TestUnzipFromUri(TestCase):
         path_mock.exists.return_value = True
         path_patch.return_value = path_mock
 
+        os_patch.environ.get.return_value = True
+
         unzip_from_uri('uri', 'layer_zip_path', 'output_zip_dir', 'layer_arn')
 
-        requests_patch.get.assert_called_with('uri', stream=True, verify=os.environ.get('AWS_CA_BUNDLE', True))
+        requests_patch.get.assert_called_with('uri', stream=True, verify=True)
         get_request_mock.iter_content.assert_called_with(chunk_size=None)
         open_patch.assert_called_with('layer_zip_path', 'wb')
         file_mock.write.assert_called_with(b'data1')
@@ -113,14 +121,16 @@ class TestUnzipFromUri(TestCase):
         path_patch.assert_called_with('layer_zip_path')
         path_mock.unlink.assert_called()
         unzip_patch.assert_called_with('layer_zip_path', 'output_zip_dir', permission=0o700)
+        os_patch.environ.get.assert_called_with('AWS_CA_BUNDLE', True)
 
     @patch('samcli.local.lambdafn.zip.unzip')
     @patch('samcli.local.lambdafn.zip.Path')
     @patch('samcli.local.lambdafn.zip.progressbar')
     @patch('samcli.local.lambdafn.zip.requests')
     @patch('samcli.local.lambdafn.zip.open')
-    @mock.patch.dict(os.environ, {})
+    @patch('samcli.local.lambdafn.zip.os')
     def test_not_unlink_file_when_file_doesnt_exist(self,
+                                                    os_patch,
                                                     open_patch,
                                                     requests_patch,
                                                     progressbar_patch,
@@ -141,9 +151,11 @@ class TestUnzipFromUri(TestCase):
         path_mock.exists.return_value = False
         path_patch.return_value = path_mock
 
+        os_patch.environ.get.return_value = True
+
         unzip_from_uri('uri', 'layer_zip_path', 'output_zip_dir', 'layer_arn')
 
-        requests_patch.get.assert_called_with('uri', stream=True, verify=os.environ.get('AWS_CA_BUNDLE', True))
+        requests_patch.get.assert_called_with('uri', stream=True, verify=True)
         get_request_mock.iter_content.assert_called_with(chunk_size=None)
         open_patch.assert_called_with('layer_zip_path', 'wb')
         file_mock.write.assert_called_with(b'data1')
@@ -151,6 +163,48 @@ class TestUnzipFromUri(TestCase):
         path_patch.assert_called_with('layer_zip_path')
         path_mock.unlink.assert_not_called()
         unzip_patch.assert_called_with('layer_zip_path', 'output_zip_dir', permission=0o700)
+        os_patch.environ.get.assert_called_with('AWS_CA_BUNDLE', True)
+
+    @patch('samcli.local.lambdafn.zip.unzip')
+    @patch('samcli.local.lambdafn.zip.Path')
+    @patch('samcli.local.lambdafn.zip.progressbar')
+    @patch('samcli.local.lambdafn.zip.requests')
+    @patch('samcli.local.lambdafn.zip.open')
+    @patch('samcli.local.lambdafn.zip.os')
+    def test_unzip_from_uri_reads_AWS_CA_BUNDLE_env_var(self, os_patch,
+                                                        open_patch,
+                                                        requests_patch,
+                                                        progressbar_patch,
+                                                        path_patch,
+                                                        unzip_patch):
+        get_request_mock = Mock()
+        get_request_mock.headers = {"Content-length": "200"}
+        get_request_mock.iter_content.return_value = [b'data1']
+        requests_patch.get.return_value = get_request_mock
+
+        file_mock = Mock()
+        open_patch.return_value.__enter__.return_value = file_mock
+
+        progressbar_mock = Mock()
+        progressbar_patch.return_value.__enter__.return_value = progressbar_mock
+
+        path_mock = Mock()
+        path_mock.exists.return_value = True
+        path_patch.return_value = path_mock
+
+        os_patch.environ.get.return_value = '/some/path/on/the/system'
+
+        unzip_from_uri('uri', 'layer_zip_path', 'output_zip_dir', 'layer_arn')
+
+        requests_patch.get.assert_called_with('uri', stream=True, verify='/some/path/on/the/system')
+        get_request_mock.iter_content.assert_called_with(chunk_size=None)
+        open_patch.assert_called_with('layer_zip_path', 'wb')
+        file_mock.write.assert_called_with(b'data1')
+        progressbar_mock.update.assert_called_with(5)
+        path_patch.assert_called_with('layer_zip_path')
+        path_mock.unlink.assert_called()
+        unzip_patch.assert_called_with('layer_zip_path', 'output_zip_dir', permission=0o700)
+        os_patch.environ.get.assert_called_with('AWS_CA_BUNDLE', True)
 
 
 class TestOverridePermissions(TestCase):


### PR DESCRIPTION
*Issue #, if available:* #917 

*Description of changes:*  This enables the layer downloader to us AWS_CA_BUNDLE environment variable if it exists.  It defaults to SSL verify True if it doesn't.

*Checklist:*

- [x] Write Design Document - No.  Doesn't meet reqs. ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [x] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
