### PR TITLE
feat(build): Build a single function

### DIFF
--- a/designs/sam_build_cmd.md
+++ b/designs/sam_build_cmd.md
@@ -50,7 +50,8 @@ Success criteria for the change
     -   Python with PIP
     -   Golang with Go CLI
     -   Dotnetcore with DotNet CLI
-2.  Each Lambda function in SAM template gets built
+2.  Each Lambda function in SAM template gets built by default unless a `function_identifier` (LogicalID) is passed 
+    to the build command
 3.  Produce stable builds (best effort): If the source files did not
     change, built artifacts should not change.
 4.  Built artifacts should \"just work\" with `sam local` and

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -14,6 +14,7 @@ from samcli.commands.build.build_context import BuildContext
 from samcli.lib.build.app_builder import ApplicationBuilder, BuildError, UnsupportedBuilderLibraryVersionError, \
     ContainerBuildNotSupported
 from samcli.lib.build.workflow_config import UnsupportedRuntimeException
+from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.commands._utils.template import move_template
 
 LOG = logging.getLogger(__name__)
@@ -81,8 +82,10 @@ $ sam build && sam package --s3-bucket <bucketname>
 @docker_common_options
 @cli_framework_options
 @aws_creds_options
+@click.argument('function_identifier', required=False)
 @pass_context
 def cli(ctx,
+        function_identifier,
         template,
         base_dir,
         build_dir,
@@ -96,11 +99,12 @@ def cli(ctx,
 
     mode = _get_mode_value_from_envvar("SAM_BUILD_MODE", choices=["debug"])
 
-    do_cli(template, base_dir, build_dir, True, use_container, manifest, docker_network,
+    do_cli(function_identifier, template, base_dir, build_dir, True, use_container, manifest, docker_network,
            skip_pull_image, parameter_overrides, mode)  # pragma: no cover
 
 
-def do_cli(template,  # pylint: disable=too-many-locals
+def do_cli(function_identifier,  # pylint: disable=too-many-locals
+           template,
            base_dir,
            build_dir,
            clean,
@@ -119,7 +123,8 @@ def do_cli(template,  # pylint: disable=too-many-locals
     if use_container:
         LOG.info("Starting Build inside a container")
 
-    with BuildContext(template,
+    with BuildContext(function_identifier,
+                      template,
                       base_dir,
                       build_dir,
                       clean=clean,
@@ -129,14 +134,16 @@ def do_cli(template,  # pylint: disable=too-many-locals
                       docker_network=docker_network,
                       skip_pull_image=skip_pull_image,
                       mode=mode) as ctx:
+        try:
+            builder = ApplicationBuilder(ctx.functions_to_build,
+                                         ctx.build_dir,
+                                         ctx.base_dir,
+                                         manifest_path_override=ctx.manifest_path_override,
+                                         container_manager=ctx.container_manager,
+                                         mode=ctx.mode)
+        except FunctionNotFound as ex:
+            raise UserException(str(ex))
 
-        builder = ApplicationBuilder(ctx.function_provider,
-                                     ctx.build_dir,
-                                     ctx.base_dir,
-                                     manifest_path_override=ctx.manifest_path_override,
-                                     container_manager=ctx.container_manager,
-                                     mode=ctx.mode
-                                     )
         try:
             artifacts = builder.build()
             modified_template = builder.update_template(ctx.template_dict,

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -49,7 +49,7 @@ class ApplicationBuilder(object):
     """
 
     def __init__(self,
-                 function_provider,
+                 functions_to_build,
                  build_dir,
                  base_dir,
                  manifest_path_override=None,
@@ -61,8 +61,8 @@ class ApplicationBuilder(object):
 
         Parameters
         ----------
-        function_provider : samcli.commands.local.lib.sam_function_provider.SamFunctionProvider
-            Provider that can vend out functions available in the SAM template
+        functions_to_build: Iterator
+            Iterator that can vend out functions available in the SAM template
 
         build_dir : str
             Path to the directory where we will be storing built artifacts
@@ -79,7 +79,7 @@ class ApplicationBuilder(object):
         mode : str
             Optional, name of the build mode to use ex: 'debug'
         """
-        self._function_provider = function_provider
+        self._functions_to_build = functions_to_build
         self._build_dir = build_dir
         self._base_dir = base_dir
         self._manifest_path_override = manifest_path_override
@@ -100,7 +100,7 @@ class ApplicationBuilder(object):
 
         result = {}
 
-        for lambda_function in self._function_provider.get_all():
+        for lambda_function in self._functions_to_build:
 
             LOG.info("Building resource '%s'", lambda_function.name)
             result[lambda_function.name] = self._build_function(lambda_function.name,

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -20,6 +20,7 @@ LOG = logging.getLogger(__name__)
 
 
 class BuildIntegBase(TestCase):
+    template = "template.yaml"
 
     @classmethod
     def setUpClass(cls):
@@ -34,7 +35,7 @@ class BuildIntegBase(TestCase):
         cls.scratch_dir = str(Path(__file__).resolve().parent.joinpath("scratch"))
 
         cls.test_data_path = str(Path(integration_dir, "testdata", "buildcmd"))
-        cls.template_path = str(Path(cls.test_data_path, "template.yaml"))
+        cls.template_path = str(Path(cls.test_data_path, cls.template))
 
     def setUp(self):
 
@@ -61,9 +62,14 @@ class BuildIntegBase(TestCase):
         return command
 
     def get_command_list(self, build_dir=None, base_dir=None, manifest_path=None, use_container=None,
-                         parameter_overrides=None, mode=None):
+                         parameter_overrides=None, mode=None, function_identifier=None):
 
-        command_list = [self.cmd, "build", "-t", self.template_path]
+        command_list = [self.cmd, "build"]
+
+        if function_identifier:
+            command_list += [function_identifier]
+
+        command_list += ["-t", self.template_path]
 
         if parameter_overrides:
             command_list += ["--parameter-overrides", self._make_parameter_override_arg(parameter_overrides)]

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -86,7 +86,6 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
                                        function_logical_id)
 
         all_artifacts = set(os.listdir(str(resource_artifact_dir)))
-        print(all_artifacts)
         actual_files = all_artifacts.intersection(expected_files)
         self.assertEquals(actual_files, expected_files)
 
@@ -413,7 +412,7 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
                                        "jinja2",
                                        'requirements.txt'}
 
-    def test_fucntion_not_found(self):
+    def test_function_not_found(self):
         overrides = {"Runtime": 'python3.7', "CodeUri": "Python", "Handler": "main.handler"}
         cmdlist = self.get_command_list(parameter_overrides=overrides,
                                         function_identifier="FunctionNotInTemplate")
@@ -476,7 +475,6 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
                                        function_logical_id)
 
         all_artifacts = set(os.listdir(str(resource_artifact_dir)))
-        print(all_artifacts)
         actual_files = all_artifacts.intersection(expected_files)
         self.assertEquals(actual_files, expected_files)
 

--- a/tests/integration/testdata/buildcmd/many-functions-template.yaml
+++ b/tests/integration/testdata/buildcmd/many-functions-template.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameteres:
+  Runtime:
+    Type: String
+  CodeUri:
+    Type: String
+  Handler:
+    Type: String
+
+Resources:
+
+  FunctionOne:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: !Ref Handler
+      Runtime: !Ref Runtime
+      CodeUri: !Ref CodeUri
+      Timeout: 600
+
+  FunctionTwo:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: !Ref Handler
+      Runtime: !Ref Runtime
+      CodeUri: !Ref CodeUri
+      Timeout: 600

--- a/tests/unit/commands/buildcmd/test_build_context.py
+++ b/tests/unit/commands/buildcmd/test_build_context.py
@@ -15,11 +15,14 @@ class TestBuildContext__enter__(TestCase):
                                 get_template_data_mock):
 
         template_dict = get_template_data_mock.return_value = "template dict"
-        funcprovider = SamFunctionProviderMock.return_value = "funcprovider"
+        func_provider_mock = Mock()
+        func_provider_mock.get.return_value = "function to build"
+        funcprovider = SamFunctionProviderMock.return_value = func_provider_mock
         base_dir = pathlib_mock.Path.return_value.resolve.return_value.parent = "basedir"
         container_mgr_mock = ContainerManagerMock.return_value = Mock()
 
-        context = BuildContext("template_file",
+        context = BuildContext("function_identifier",
+                               "template_file",
                                None,  # No base dir is provided
                                "build_dir",
                                manifest_path="manifest_path",
@@ -46,6 +49,7 @@ class TestBuildContext__enter__(TestCase):
         self.assertEquals(context.output_template_path, os.path.join(build_dir_result, "template.yaml"))
         self.assertEquals(context.manifest_path_override, os.path.abspath("manifest_path"))
         self.assertEqual(context.mode, "buildmode")
+        self.assertEquals(context.functions_to_build, ["function to build"])
 
         get_template_data_mock.assert_called_once_with("template_file")
         SamFunctionProviderMock.assert_called_once_with(template_dict, "overrides")
@@ -53,6 +57,58 @@ class TestBuildContext__enter__(TestCase):
         setup_build_dir_mock.assert_called_with("build_dir", True)
         ContainerManagerMock.assert_called_once_with(docker_network_id="network",
                                                      skip_pull_image=True)
+        func_provider_mock.get.assert_called_once_with("function_identifier")
+
+    @patch("samcli.commands.build.build_context.get_template_data")
+    @patch("samcli.commands.build.build_context.SamFunctionProvider")
+    @patch("samcli.commands.build.build_context.pathlib")
+    @patch("samcli.commands.build.build_context.ContainerManager")
+    def test_must_return_many_functions_to_build(self, ContainerManagerMock, pathlib_mock, SamFunctionProviderMock,
+                                                 get_template_data_mock):
+        template_dict = get_template_data_mock.return_value = "template dict"
+        func_provider_mock = Mock()
+        func_provider_mock.get_all.return_value = ["function to build", "and another function"]
+        funcprovider = SamFunctionProviderMock.return_value = func_provider_mock
+        base_dir = pathlib_mock.Path.return_value.resolve.return_value.parent = "basedir"
+        container_mgr_mock = ContainerManagerMock.return_value = Mock()
+
+        context = BuildContext(None,
+                               "template_file",
+                               None,  # No base dir is provided
+                               "build_dir",
+                               manifest_path="manifest_path",
+                               clean=True,
+                               use_container=True,
+                               docker_network="network",
+                               parameter_overrides="overrides",
+                               skip_pull_image=True,
+                               mode="buildmode")
+        setup_build_dir_mock = Mock()
+        build_dir_result = setup_build_dir_mock.return_value = "my/new/build/dir"
+        context._setup_build_dir = setup_build_dir_mock
+
+        # call the enter method
+        result = context.__enter__()
+
+        self.assertEquals(result, context)  # __enter__ must return self
+        self.assertEquals(context.template_dict, template_dict)
+        self.assertEquals(context.function_provider, funcprovider)
+        self.assertEquals(context.base_dir, base_dir)
+        self.assertEquals(context.container_manager, container_mgr_mock)
+        self.assertEquals(context.build_dir, build_dir_result)
+        self.assertEquals(context.use_container, True)
+        self.assertEquals(context.output_template_path, os.path.join(build_dir_result, "template.yaml"))
+        self.assertEquals(context.manifest_path_override, os.path.abspath("manifest_path"))
+        self.assertEqual(context.mode, "buildmode")
+        self.assertEquals(context.functions_to_build, ["function to build", "and another function"])
+
+        get_template_data_mock.assert_called_once_with("template_file")
+        SamFunctionProviderMock.assert_called_once_with(template_dict, "overrides")
+        pathlib_mock.Path.assert_called_once_with("template_file")
+        setup_build_dir_mock.assert_called_with("build_dir", True)
+        ContainerManagerMock.assert_called_once_with(docker_network_id="network",
+                                                     skip_pull_image=True)
+        func_provider_mock.get_all.assert_called_once()
 
 
 class TestBuildContext_setup_build_dir(TestCase):

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -14,29 +14,27 @@ from samcli.lib.build.app_builder import ApplicationBuilder,\
 class TestApplicationBuilder_build(TestCase):
 
     def setUp(self):
-        self.mock_func_provider = Mock()
-        self.builder = ApplicationBuilder(self.mock_func_provider,
+        self.func1 = Mock()
+        self.func2 = Mock()
+        self.builder = ApplicationBuilder([self.func1, self.func2],
                                           "builddir",
                                           "basedir")
 
     def test_must_iterate_on_functions(self):
-        func1 = Mock()
-        func2 = Mock()
         build_function_mock = Mock()
 
-        self.mock_func_provider.get_all.return_value = [func1, func2]
         self.builder._build_function = build_function_mock
 
         result = self.builder.build()
 
         self.assertEquals(result, {
-            func1.name: build_function_mock.return_value,
-            func2.name: build_function_mock.return_value,
+            self.func1.name: build_function_mock.return_value,
+            self.func2.name: build_function_mock.return_value,
         })
 
         build_function_mock.assert_has_calls([
-            call(func1.name, func1.codeuri, func1.runtime),
-            call(func2.name, func2.codeuri, func2.runtime),
+            call(self.func1.name, self.func1.codeuri, self.func1.runtime),
+            call(self.func2.name, self.func2.codeuri, self.func2.runtime),
         ], any_order=False)
 
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

### Description of changes:
This enables a customer to build a single function similar to how they would invoke a single function. To build a single function, you can pass the LogicalID to the command `sam build <MyLogicalId>`. If the LogicalID is omitted, the command will behave exactly how it does not and build the whole template.

### Concerns on approach:
This change enables a customer (or IDE) to quickly build a single function for faster test cycles. This could result in a deployment to of source code instead of built code, if the customer only builds one of the n number of functions in the template and then does a package and deploy. With this change, customers will need to still use `sam build` without the logicalId before package and deploying. This could create more customer confusion in the short term.

### Checklist:

- [x] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
