### PR TITLE
Removed broken snapcraft.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Status](https://travis-ci.org/awslabs/aws-sam-cli.svg?branch=develop)
 ![GitHub-release](https://img.shields.io/github/release/awslabs/aws-sam-cli.svg)
 ![PyPI version](https://badge.fury.io/py/aws-sam-cli.svg)
 
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/aws-sam-cli)
-
 [Join the SAM developers channel (\#samdev) on
 Slack](https://join.slack.com/t/awsdevelopers/shared_invite/enQtMzg3NTc5OTM2MzcxLTdjYTdhYWE3OTQyYTU4Njk1ZWY4Y2ZjYjBhMTUxNGYzNDg5MWQ1ZTc5MTRlOGY0OTI4NTdlZTMwNmI5YTgwOGM/)
 to collaborate with fellow community members and the AWS SAM team.


### PR DESCRIPTION
The link appears to be broken. I also searched snapcraft for aws-sam-cli and aws-sam and the app isn't found.

Removing the link so people aren't confused. Alternatively, the package could be added but that would probably take more time to fix.

*Description of changes:*
Made install docs clearer.
