### PR TITLE
Fix typo in test name

### DIFF
--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -130,7 +130,7 @@ class TestLambdaOutputParser(TestCase):
         self.assertEquals(LambdaOutputParser.is_lambda_error_response(input), exected_result)
 
 
-class CaseInsensiveDict(TestCase):
+class TestCaseInsensitiveDict(TestCase):
 
     def setUp(self):
         self.data = CaseInsensitiveDict({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Test name had a typo, `CaseInsensiveDict`. Changed to `TestCaseInsensitiveDict` to avoid name collision with the correctly spelled `CaseInsensitiveDict`.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
