### PR TITLE
Local support for response multiValueHeaders

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -5,8 +5,9 @@ import logging
 import base64
 
 from flask import Flask, request
+from werkzeug.datastructures import Headers
 
-from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser, CaseInsensitiveDict
+from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser
 from samcli.lib.utils.stream_writer import StreamWriter
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from samcli.local.events.api_event import ContextIdentity, RequestContext, ApiGatewayLambdaEvent
@@ -207,7 +208,7 @@ class LocalApigwService(BaseLocalService):
             raise TypeError("Lambda returned %{s} instead of dict", type(json_output))
 
         status_code = json_output.get("statusCode") or 200
-        headers = CaseInsensitiveDict(json_output.get("headers") or {})
+        headers = Headers(json_output.get("headers") or {})
         body = json_output.get("body") or "no data"
         is_base_64_encoded = json_output.get("isBase64Encoded") or False
 

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -285,8 +285,7 @@ class LocalApigwService(BaseLocalService):
         Merge multiValueHeaders headers with headers
 
         * If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
-        * If the same key-value pair is specified in both, only the values from multiValueHeaders will
-        * appear in the merged list.
+        * If the same key-value pair is specified in both, the value will only appear once.
 
         Parameters
         ----------
@@ -301,14 +300,15 @@ class LocalApigwService(BaseLocalService):
 
         """
 
-        processed_headers = Headers(headers)
+        processed_headers = Headers(multi_headers)
 
-        # Multi-value headers completely replace any single-value
-        # headers, so remove any key collisions then extend
-        for header in multi_headers:
-            processed_headers.remove(header)
+        for header in headers:
+            # Prevent duplication of values when the key-value pair exists in both
+            # headers and multi_headers, but preserve order from multi_headers
+            if header in multi_headers and headers[header] in multi_headers[header]:
+                continue
 
-        processed_headers.extend(multi_headers)
+            processed_headers.add(header, headers[header])
 
         return processed_headers
 

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -7,7 +7,7 @@ import io
 from flask import Flask, request
 
 from samcli.lib.utils.stream_writer import StreamWriter
-from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser, CaseInsensitiveDict
+from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 from .lambda_error_responses import LambdaErrorResponses
 
@@ -92,7 +92,7 @@ class LocalLambdaInvokeService(BaseLocalService):
             LOG.debug("Query parameters are in the request but not supported")
             return LambdaErrorResponses.invalid_request_content("Query Parameters are not supported")
 
-        request_headers = CaseInsensitiveDict(flask_request.headers)
+        request_headers = flask_request.headers
 
         log_type = request_headers.get('X-Amz-Log-Type', 'None')
         if log_type != 'None':

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -69,7 +69,7 @@ class BaseLocalService(object):
         Constructs a Flask Response from the body, headers, and status_code.
 
         :param str body: Response body as a string
-        :param dict headers: headers for the response
+        :param werkzeug.datastructures.Headers headers: headers for the response
         :param int status_code: status_code for response
         :return: Flask Response
         """

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -9,23 +9,6 @@ from flask import Response
 LOG = logging.getLogger(__name__)
 
 
-class CaseInsensitiveDict(dict):
-    """
-    Implement a simple case insensitive dictionary for storing headers. To preserve the original
-    case of the given Header (e.g. X-FooBar-Fizz) this only touches the get and contains magic
-    methods rather than implementing a __setitem__ where we normalize the case of the headers.
-    """
-
-    def __getitem__(self, key):
-        matches = [v for k, v in self.items() if k.lower() == key.lower()]
-        if not matches:
-            raise KeyError(key)
-        return matches[0]
-
-    def __contains__(self, key):
-        return key.lower() in [k.lower() for k in self.keys()]
-
-
 class BaseLocalService(object):
 
     def __init__(self, is_debugging, port, host):

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -310,7 +310,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
         self.assertEquals(response.status_code, 200)
         self.assertEquals(response.headers.get("Content-Type"), "text/plain")
-        self.assertEquals(response.headers.get("MyCustomHeader"), 'Value1, Value2')
+        self.assertEquals(response.headers.get("MyCustomHeader"), 'Value1, Value2, Custom')
 
     def test_binary_response(self):
         """

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -298,6 +298,20 @@ class TestServiceResponses(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    def test_multiple_headers_response(self):
+        response = requests.get(self.url + "/multipleheaders")
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.headers.get("Content-Type"), "text/plain")
+        self.assertEquals(response.headers.get("MyCustomHeader"), 'Value1, Value2')
+
+    def test_multiple_headers_overrides_headers_response(self):
+        response = requests.get(self.url + "/multipleheadersoverridesheaders")
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.headers.get("Content-Type"), "text/plain")
+        self.assertEquals(response.headers.get("MyCustomHeader"), 'Value1, Value2')
+
     def test_binary_response(self):
         """
         Binary data is returned correctly

--- a/tests/integration/testdata/start_api/main.py
+++ b/tests/integration/testdata/start_api/main.py
@@ -89,3 +89,21 @@ def echo_base64_event_body(event, context):
         },
         "isBase64Encoded": event["isBase64Encoded"]
     }
+
+
+def multiple_headers(event, context):
+    return {
+        "statusCode": 200,
+        "body": "hello",
+        "headers": {"Content-Type": "text/plain"},
+        "multiValueHeaders": {"MyCustomHeader": ['Value1', 'Value2']}
+    }
+
+
+def multiple_headers_overrides_headers(event, context):
+    return {
+        "statusCode": 200,
+        "body": "hello",
+        "headers": {"Content-Type": "text/plain", "MyCustomHeader": 'Custom'},
+        "multiValueHeaders": {"MyCustomHeader": ['Value1', 'Value2']}
+    }

--- a/tests/integration/testdata/start_api/template.yaml
+++ b/tests/integration/testdata/start_api/template.yaml
@@ -229,3 +229,29 @@ Resources:
           Properties:
             Method: POST
             Path: /echobase64eventbody
+
+  MultipleHeadersResponseFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.multiple_headers
+      Runtime: python3.6
+      CodeUri: .
+      Events:
+        IdBasePath:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /multipleheaders
+
+  MultipleHeadersOverridesHeadersResponseFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.multiple_headers_overrides_headers
+      Runtime: python3.6
+      CodeUri: .
+      Events:
+        IdBasePath:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /multipleheadersoverridesheaders

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -4,6 +4,7 @@ import json
 import base64
 
 from parameterized import parameterized, param
+from werkzeug.datastructures import Headers
 
 from samcli.local.apigw.local_apigw_service import LocalApigwService, Route
 from samcli.local.lambdafn.exceptions import FunctionNotFound
@@ -307,7 +308,7 @@ class TestServiceParsingLambdaOutput(TestCase):
                                                                               flask_request=Mock())
 
         self.assertEquals(status_code, 200)
-        self.assertEquals(headers, {"Content-Type": "application/json"})
+        self.assertEquals(headers, Headers({"Content-Type": "application/json"}))
         self.assertEquals(body, '{"message":"Hello from Lambda"}')
 
     @patch('samcli.local.apigw.local_apigw_service.LocalApigwService._should_base64_decode_body')
@@ -326,7 +327,7 @@ class TestServiceParsingLambdaOutput(TestCase):
                                                                               flask_request=Mock())
 
         self.assertEquals(status_code, 200)
-        self.assertEquals(headers, {"Content-Type": "application/octet-stream"})
+        self.assertEquals(headers, Headers({"Content-Type": "application/octet-stream"}))
         self.assertEquals(body, binary_body)
 
     def test_status_code_not_int(self):
@@ -388,7 +389,7 @@ class TestServiceParsingLambdaOutput(TestCase):
                                                                               flask_request=Mock())
 
         self.assertEquals(status_code, 200)
-        self.assertEquals(headers, {"Content-Type": "application/json"})
+        self.assertEquals(headers, Headers({"Content-Type": "application/json"}))
         self.assertEquals(body, "no data")
 
 

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -3,7 +3,7 @@ from mock import Mock, patch
 
 from parameterized import parameterized, param
 
-from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser, CaseInsensitiveDict
+from samcli.local.services.base_local_service import BaseLocalService, LambdaOutputParser
 
 
 class TestLocalHostRunner(TestCase):
@@ -128,36 +128,3 @@ class TestLambdaOutputParser(TestCase):
     ])
     def test_is_lambda_error_response(self, input, exected_result):
         self.assertEquals(LambdaOutputParser.is_lambda_error_response(input), exected_result)
-
-
-class CaseInsensiveDict(TestCase):
-
-    def setUp(self):
-        self.data = CaseInsensitiveDict({
-            'Content-Type': 'text/html',
-            'Browser': 'APIGW',
-        })
-
-    def test_contains_lower(self):
-        self.assertTrue('content-type' in self.data)
-
-    def test_contains_title(self):
-        self.assertTrue('Content-Type' in self.data)
-
-    def test_contains_upper(self):
-        self.assertTrue('CONTENT-TYPE' in self.data)
-
-    def test_contains_browser_key(self):
-        self.assertTrue('Browser' in self.data)
-
-    def test_contains_not_in(self):
-        self.assertTrue('Dog-Food' not in self.data)
-
-    def test_setitem_found(self):
-        self.data['Browser'] = 'APIGW'
-
-        self.assertTrue(self.data['browser'])
-
-    def test_keyerror(self):
-        with self.assertRaises(KeyError):
-            self.data['does-not-exist']


### PR DESCRIPTION
*Issue #, if available:*

#830 

*Description of changes:*

This is a rework of #842 by @martysweet, which seems to have stalled. This PR uses Flask's built-in method of providing multiple header values, which makes it act like API GW. In particular, multi-value headers are folded into a comma-separated list *unless* it's `Set-Cookie` which is a special-case.

There's two parts to this PR. First drops `CaseInsensitiveDict` as it doesn't seem to be necessary. The `Headers` class in Flask is already case-insensitive and swapping in `Headers` in the test case for `CaseInsensitiveDict` passed the tests. There are some minor differences:

  * `Headers` isn't JSON serializable by default
  * `Headers` won't pass equality comparison with a dict
  * `Headers` raises `werkzeug.exceptions.BadRequestKeyError` (a subclass of `KeyError`) on bad key

Those could be addressed with a custom subclass of `Headers` if necessary, but at the moment all tests pass just fine.

The second commit is mostly the same as #842 but uses the default behavior of `Headers` to handle multi-value headers instead of manually merging them as a comma-separated list. This lets Flask do the special-case for `Set-Cookie`.

@martysweet, @jfuss, @everyonce, you guys want to take a look since you were active on #842?

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
