### PR TITLE
fix(invoke/build): Allow AmazonLinux1803 Layer and fail when AmazonLinux1703 Layer is provided

### DIFF
--- a/samcli/commands/local/lib/sam_function_provider.py
+++ b/samcli/commands/local/lib/sam_function_provider.py
@@ -5,6 +5,7 @@ Class that provides functions from a given SAM template
 import logging
 import six
 
+from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
 from .exceptions import InvalidLayerReference
 from .provider import FunctionProvider, Function, LayerVersion
 from .sam_base_provider import SamBaseProvider
@@ -238,6 +239,14 @@ class SamFunctionProvider(FunctionProvider):
         """
         layers = []
         for layer in list_of_layers:
+            if layer == 'arn:aws:lambda:::awslayer:AmazonLinux1803':
+                LOG.debug('Skipped arn:aws:lambda:::awslayer:AmazonLinux1803 as the containers are AmazonLinux1803')
+                continue
+
+            if layer == 'arn:aws:lambda:::awslayer:AmazonLinux1703':
+                raise InvalidLayerVersionArn('Building and invoking locally only supports AmazonLinux1803. See '
+                                             'https://aws.amazon.com/blogs/compute/upcoming-updates-to-the-aws-lambda-execution-environment/ for more detials.')  # noqa: E501
+
             # If the layer is a string, assume it is the arn
             if isinstance(layer, six.string_types):
                 layers.append(LayerVersion(layer, None))

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -118,11 +118,9 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
     FUNCTION_LOGICAL_ID = "Function"
 
     @parameterized.expand([
-        ("nodejs4.3", False),
         ("nodejs6.10", False),
         ("nodejs8.10", False),
         ("nodejs10.x", False),
-        ("nodejs4.3", "use_container"),
         ("nodejs6.10", "use_container"),
         ("nodejs8.10", "use_container"),
         ("nodejs10.x", "use_container")


### PR DESCRIPTION
DockerLambda only supports one version of a container. Recently this was updated to AmazonLinux1803
but (at the time of writing) the Lambda Service is still using AmazonLinux1703. Given that, SAM CLI
will now fail if the arn:aws:lambda:::awslayer:AmazonLinux1703 Layer Arn is provided. If
arn:aws:lambda:::awslayer:AmazonLinux1803 Layer Arn is provided, we simply ignore it when reading
the Layer Definition on a Function. This scenerios happen in both build and invoke related commands.

*Issue #, if available:*
N/A

*Description of changes:*
See git commit above.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
