### PR TITLE
Docker proxy config

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -99,7 +99,9 @@ class Container(object):
                 }
             },
             # We are not running an interactive shell here.
-            "tty": False
+            "tty": False,
+            # Set proxy configuration from global Docker config file
+            "use_config_proxy": True
         }
 
         if self._container_opts:

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -3,8 +3,8 @@ Helper methods that aid with changing the mount path to unix style.
 """
 
 import os
-import posixpath
 import re
+import posixpath
 try:
     import pathlib
 except ImportError:

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -97,7 +97,8 @@ class TestContainer_create(TestCase):
                                                                      command=self.cmd,
                                                                      working_dir=self.working_dir,
                                                                      volumes=expected_volumes,
-                                                                     tty=False)
+                                                                     tty=False,
+                                                                     use_config_proxy=True)
         self.mock_docker_client.networks.get.assert_not_called()
 
     def test_must_create_container_including_all_optional_values(self):
@@ -141,6 +142,7 @@ class TestContainer_create(TestCase):
                                                                      working_dir=self.working_dir,
                                                                      volumes=expected_volumes,
                                                                      tty=False,
+                                                                     use_config_proxy=True,
                                                                      environment=self.env_vars,
                                                                      ports=self.exposed_ports,
                                                                      entrypoint=self.entrypoint,
@@ -206,6 +208,7 @@ class TestContainer_create(TestCase):
                                                                      working_dir=self.working_dir,
                                                                      volumes=translated_volumes,
                                                                      tty=False,
+                                                                     use_config_proxy=True,
                                                                      environment=self.env_vars,
                                                                      ports=self.exposed_ports,
                                                                      entrypoint=self.entrypoint,
@@ -250,6 +253,7 @@ class TestContainer_create(TestCase):
                                                                      command=self.cmd,
                                                                      working_dir=self.working_dir,
                                                                      tty=False,
+                                                                     use_config_proxy=True,
                                                                      volumes=expected_volumes
                                                                      )
 
@@ -292,6 +296,7 @@ class TestContainer_create(TestCase):
                                                                      command=self.cmd,
                                                                      working_dir=self.working_dir,
                                                                      tty=False,
+                                                                     use_config_proxy=True,
                                                                      volumes=expected_volumes,
                                                                      network_mode='host'
                                                                      )


### PR DESCRIPTION
*Issue #, if available:*

#913 

*Description of changes:*

This updates the docker create command to configure the proxy settings inside the docker container using global docker configuration file.  This will allow users who sit behind a proxy and have configured their proxy settings in docker to pass through their proxy for things such as dependency installation (Pip, etc.).

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
