### PR TITLE
fix: upgrade requests to 2.22.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,6 @@ docker>=3.3.0
 dateparser~=0.7
 python-dateutil~=2.6
 pathlib2~=2.3.2; python_version<"3.4"
-requests==2.20.1
+requests==2.22.0
 serverlessrepo==0.1.8
 aws_lambda_builders==0.3.0

--- a/tests/functional/local/apigw/test_local_apigw_service.py
+++ b/tests/functional/local/apigw/test_local_apigw_service.py
@@ -630,8 +630,46 @@ def make_service(list_of_routes, function_provider, cwd):
 
 def make_service_response(port, method, scheme, resourcePath, resolvedResourcePath, pathParameters=None,
                           body=None, headers=None, queryParams=None, isBase64Encoded=False):
-    response_str = '{"httpMethod": "GET", "body": null, "resource": "/something/{event}", "requestContext": {"resourceId": "123456", "apiId": "1234567890", "resourcePath": "/something/{event}", "httpMethod": "GET", "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef", "accountId": "123456789012", "stage": "prod", "identity": {"apiKey": null, "userArn": null, "cognitoAuthenticationType": null, "caller": null, "userAgent": "Custom User Agent String", "user": null, "cognitoIdentityPoolId": null, "cognitoAuthenticationProvider": null, "sourceIp": "127.0.0.1", "accountId": null}, "extendedRequestId": null, "path": "/something/{event}"}, "queryStringParameters": null, "headers": {"Host": "0.0.0.0:33651", "User-Agent": "python-requests/2.20.1", "Accept-Encoding": "gzip, deflate", "Accept": "*/*", "Connection": "keep-alive"}, "pathParameters": {"event": "event1"}, "stageVariables": null, "path": "/something/event1", "isBase64Encoded": false}' # NOQA
-    response = json.loads(response_str)
+    response = {
+        "httpMethod": "GET",
+        "body": None,
+        "resource": "/something/{event}",
+        "requestContext": {
+            "resourceId": "123456",
+            "apiId": "1234567890",
+            "resourcePath": "/something/{event}",
+            "httpMethod": "GET",
+            "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+            "accountId": "123456789012",
+            "stage": "prod",
+            "identity": {
+                "apiKey": None,
+                "userArn": None,
+                "cognitoAuthenticationType": None,
+                "caller": None,
+                "userAgent": "Custom User Agent String",
+                "user": None,
+                "cognitoIdentityPoolId": None,
+                "cognitoAuthenticationProvider": None,
+                "sourceIp": "127.0.0.1",
+                "accountId": None
+            },
+            "extendedRequestId": None,
+            "path": "/something/{event}"
+        },
+        "queryStringParameters": None,
+        "headers": {
+            "Host": "0.0.0.0:33651",
+            "User-Agent": "python-requests/{}".format(requests.__version__),
+            "Accept-Encoding": "gzip, deflate",
+            "Accept": "*/*",
+            "Connection": "keep-alive"
+        },
+        "pathParameters": {"event": "event1"},
+        "stageVariables": None,
+        "path": "/something/event1",
+        "isBase64Encoded": False
+    }
 
     if body:
         response["body"] = body


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
- Bump requests from 2.20.0 to 2.22.0
- Update `make_service_response` for readability and dynamic inclusion of requests' version number

Upgrading requests to 2.22 lifts the upper bound of urllib3 to <1.26.  urllib3 1.25 includes fixes for the following vulnerabilities [CVE-2019-9740](https://nvd.nist.gov/vuln/detail/CVE-2019-9740) and [CVE-2019-112369](https://nvd.nist.gov/vuln/detail/CVE-2019-11236) which were also backported to the 1.24 series (included in release 1.24.3).

urllib3 1.25.2+ includes also other improvements like certificate validation, TLSv1.3 support, Brotli support, ….  See https://github.com/urllib3/urllib3/blob/1.25.3/CHANGES.rst

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
