### PR TITLE
fix: default to nodejs10.x on init

### DIFF
--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 @click.command(context_settings=dict(help_option_names=[u'-h', u'--help']))
 @click.option('-l', '--location', help="Template location (git, mercurial, http(s), zip, path)")
-@click.option('-r', '--runtime', type=click.Choice(INIT_RUNTIMES), default="nodejs8.10",
+@click.option('-r', '--runtime', type=click.Choice(INIT_RUNTIMES), default="nodejs10.x",
               help="Lambda Runtime of your app")
 @click.option('-d', '--dependency-manager', type=click.Choice(SUPPORTED_DEP_MANAGERS), default=None,
               help="Dependency manager of your Lambda runtime", required=False)

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -8,7 +8,7 @@ import click
 
 from samcli.cli.main import pass_context, common_options
 from samcli.commands.exceptions import UserException
-from samcli.local.common.runtime_template import INIT_RUNTIMES, SUPPORTED_DEP_MANAGERS
+from samcli.local.common.runtime_template import INIT_RUNTIMES, SUPPORTED_DEP_MANAGERS, DEFAULT_RUNTIME
 from samcli.local.init import generate_project
 from samcli.local.init.exceptions import GenerateProjectFailedError
 
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 @click.command(context_settings=dict(help_option_names=[u'-h', u'--help']))
 @click.option('-l', '--location', help="Template location (git, mercurial, http(s), zip, path)")
-@click.option('-r', '--runtime', type=click.Choice(INIT_RUNTIMES), default="nodejs10.x",
+@click.option('-r', '--runtime', type=click.Choice(INIT_RUNTIMES), default=DEFAULT_RUNTIME,
               help="Lambda Runtime of your app")
 @click.option('-d', '--dependency-manager', type=click.Choice(SUPPORTED_DEP_MANAGERS), default=None,
               help="Dependency manager of your Lambda runtime", required=False)

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -13,10 +13,12 @@ except ImportError:
 _init_path = str(pathlib.Path(os.path.dirname(__file__)).parent)
 _templates = os.path.join(_init_path, 'init', 'templates')
 
+
+# Note(TheSriram): The ordering of the runtimes list per language is based on the latest to oldest.
 RUNTIME_DEP_TEMPLATE_MAPPING = {
     "python": [
         {
-            "runtimes": ["python2.7", "python3.6", "python3.7"],
+            "runtimes": ["python3.7", "python3.6", "python2.7"],
             "dependency_manager": "pip",
             "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-python"),
             "build": True
@@ -46,7 +48,7 @@ RUNTIME_DEP_TEMPLATE_MAPPING = {
     ],
     "dotnet": [
         {
-            "runtimes": ["dotnetcore", "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1"],
+            "runtimes": ["dotnetcore2.1", "dotnetcore2.0", "dotnetcore1.0", "dotnetcore"],
             "dependency_manager": "cli-package",
             "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
             "build": True

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -32,7 +32,7 @@ RUNTIME_DEP_TEMPLATE_MAPPING = {
     ],
     "nodejs": [
         {
-            "runtimes": ["nodejs8.10", "nodejs10.x"],
+            "runtimes": ["nodejs10.x", "nodejs8.10"],
             "dependency_manager": "npm",
             "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-nodejs"),
             "build": True
@@ -81,3 +81,6 @@ SUPPORTED_DEP_MANAGERS = set([c['dependency_manager'] for c in list(
 RUNTIMES = set(itertools.chain(*[c['runtimes'] for c in list(
     itertools.chain(*(RUNTIME_DEP_TEMPLATE_MAPPING.values())))]))
 INIT_RUNTIMES = RUNTIMES.union(RUNTIME_DEP_TEMPLATE_MAPPING.keys())
+
+# NOTE(TheSriram): Default Runtime Choice when runtime is not chosen
+DEFAULT_RUNTIME = RUNTIME_DEP_TEMPLATE_MAPPING['nodejs'][0]['runtimes'][0]

--- a/samcli/local/init/__init__.py
+++ b/samcli/local/init/__init__.py
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 
 
 def generate_project(
-        location=None, runtime="nodejs", dependency_manager=None,
+        location=None, runtime="nodejs10.x", dependency_manager=None,
         output_dir=".", name='sam-sample-app', no_input=False):
     """Generates project using cookiecutter and options given
 
@@ -51,11 +51,9 @@ def generate_project(
 
     for mapping in list(itertools.chain(*(RUNTIME_DEP_TEMPLATE_MAPPING.values()))):
         if runtime in mapping['runtimes'] or any([r.startswith(runtime) for r in mapping['runtimes']]):
-            if not dependency_manager:
+            if not dependency_manager or dependency_manager == mapping['dependency_manager']:
                 template = mapping['init_location']
                 break
-            elif dependency_manager == mapping['dependency_manager']:
-                template = mapping['init_location']
 
     if not template:
         msg = "Lambda Runtime {} does not support dependency manager: {}".format(runtime, dependency_manager)


### PR DESCRIPTION
- `sam init -r node -d npm` now yeilds a sam template with `nodejs10.x` as
  runtime instead of `nodejs`

*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/1251

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [X] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
