### PR TITLE
fix: More robust connections to telemetry backend

### DIFF
--- a/samcli/lib/telemetry/telemetry.py
+++ b/samcli/lib/telemetry/telemetry.py
@@ -78,7 +78,7 @@ class Telemetry(object):
         payload = {"metrics": [metric]}
         LOG.debug("Sending Telemetry: %s", payload)
 
-        timeout_ms = 2000 if wait_for_response else 1  # 2 seconds to wait for response or 1ms
+        timeout_ms = 2000 if wait_for_response else 100  # 2 seconds to wait for response or 100ms
 
         timeout = (2,  # connection timeout. Always set to 2 seconds
                    timeout_ms / 1000.0  # Read timeout. Tweaked based on input.
@@ -86,8 +86,9 @@ class Telemetry(object):
         try:
             r = requests.post(self._url, json=payload, timeout=timeout)
             LOG.debug("Telemetry response: %d", r.status_code)
-        except requests.exceptions.Timeout as ex:
-            # Expected if request times out. Just print debug log and ignore the exception.
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as ex:
+            # Expected if request times out OR cannot connect to the backend (offline).
+            # Just print debug log and ignore the exception.
             LOG.debug(str(ex))
 
     def _add_common_metric_attributes(self, attrs):

--- a/tests/integration/telemetry/integ_base.py
+++ b/tests/integration/telemetry/integ_base.py
@@ -54,14 +54,17 @@ class IntegBase(TestCase):
 
         return command
 
-    def run_cmd(self, stdin_data=""):
+    def run_cmd(self, stdin_data="", optout_envvar_value=None):
         # Any command will work for this test suite
         cmd_list = [self.cmd, "local", "generate-event", "s3", "put"]
 
         env = os.environ.copy()
 
-        # remove the envvar which usually is set in Travis. This interferes with tests.
+        # remove the envvar which usually is set in Travis. This interferes with tests
         env.pop("SAM_CLI_TELEMETRY", None)
+        if optout_envvar_value:
+            # But if the caller explicitly asked us to opt-out via EnvVar, then set it here
+            env["SAM_CLI_TELEMETRY"] = optout_envvar_value
 
         env["__SAM_CLI_APP_DIR"] = self.config_dir
         env["__SAM_CLI_TELEMETRY_ENDPOINT_URL"] = "{}/metrics".format(TELEMETRY_ENDPOINT_URL)

--- a/tests/integration/telemetry/test_telemetry_contract.py
+++ b/tests/integration/telemetry/test_telemetry_contract.py
@@ -1,0 +1,73 @@
+
+from .integ_base import IntegBase, TelemetryServer
+
+
+class TestTelemetryContract(IntegBase):
+    """
+    Validates the basic tenets/contract Telemetry module needs to adhere to
+    """
+
+    def test_must_not_send_metrics_if_disabled_using_envvar(self):
+        """
+        No metrics should be sent if "Enabled via Config file but Disabled via Envvar"
+        """
+        # Enable it via configuration file
+        self.set_config(telemetry_enabled=True)
+
+        with TelemetryServer() as server:
+            # Start the CLI, but opt-out of Telemetry using env var
+            process = self.run_cmd(optout_envvar_value="0")
+            (_, stderrdata) = process.communicate()
+            retcode = process.poll()
+            self.assertEquals(retcode, 0, "Command should successfully complete")
+            all_requests = server.get_all_requests()
+            self.assertEquals(0, len(all_requests), "No metrics should be sent")
+
+            # Now run again without the Env Var Opt out
+            process = self.run_cmd()
+            (_, stderrdata) = process.communicate()
+            retcode = process.poll()
+            self.assertEquals(retcode, 0, "Command should successfully complete")
+            all_requests = server.get_all_requests()
+            self.assertEquals(1, len(all_requests), "Command run metric should be sent")
+
+    def test_must_send_metrics_if_enabled_via_envvar(self):
+        """
+        Metrics should be sent if "Disabled via config file but Enabled via Envvar"
+        """
+        # Disable it via configuration file
+        self.set_config(telemetry_enabled=False)
+
+        with TelemetryServer() as server:
+            # Run without any envvar.Should not publish metrics
+            process = self.run_cmd()
+            (_, stderrdata) = process.communicate()
+            retcode = process.poll()
+            self.assertEquals(retcode, 0, "Command should successfully complete")
+            all_requests = server.get_all_requests()
+            self.assertEquals(0, len(all_requests), "No metric should be sent")
+
+            # Opt-in via env var
+            process = self.run_cmd(optout_envvar_value="1")
+            (_, stderrdata) = process.communicate()
+            retcode = process.poll()
+            self.assertEquals(retcode, 0, "Command should successfully complete")
+            all_requests = server.get_all_requests()
+            self.assertEquals(1, len(all_requests), "Command run metric must be sent")
+
+    def test_must_not_crash_when_offline(self):
+        """
+        Must not crash the process if internet is not available
+        """
+        self.set_config(telemetry_enabled=True)
+
+        # DO NOT START Telemetry Server here.
+        # Try to run the command without it.
+
+        # Start the CLI
+        process = self.run_cmd()
+
+        (_, stderrdata) = process.communicate()
+
+        retcode = process.poll()
+        self.assertEquals(retcode, 0, "Command should successfully complete")


### PR DESCRIPTION
- Increase read timeout to 100ms. Backend needs a bit more time than 1ms to reliably receive & process data
- Don't crash if offline
- Integration tests to validate offline behavior & opt-in/opt-out behavior

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
