### PR TITLE
warning: deprecation warning message - Python 2.7

### DIFF
--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -21,8 +21,12 @@ _SAM_CLI_COMMAND_PACKAGES = {
     "samcli.commands.publish"
 }
 
-DEPRECATION_NOTICE = "Warning : AWS SAM CLI will no longer support " \
-                     "installations on Python 2.7 starting on October 1st, 2019. \n"
+DEPRECATION_NOTICE = (
+    "Warning : AWS SAM CLI will no longer support "
+    "installations on Python 2.7 starting on October 1st, 2019."
+    " Install AWS SAM CLI via https://docs.aws.amazon.com/serverless-application-model/"
+    "latest/developerguide/serverless-sam-cli-install.html for continued support with new versions. \n"
+)
 
 
 class BaseCommand(click.MultiCommand):

--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -4,6 +4,7 @@ Base classes that implement the CLI framework
 
 import logging
 import importlib
+import sys
 import click
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,9 @@ _SAM_CLI_COMMAND_PACKAGES = {
     "samcli.commands.build",
     "samcli.commands.publish"
 }
+
+DEPRECATION_NOTICE = "Warning : AWS SAM CLI will no longer support " \
+                     "installations on Python 2.7 starting on October 1st, 2019. \n"
 
 
 class BaseCommand(click.MultiCommand):
@@ -57,6 +61,9 @@ class BaseCommand(click.MultiCommand):
 
         self._commands = {}
         self._commands = BaseCommand._set_commands(cmd_packages)
+
+        if sys.version_info.major == 2:
+            click.secho(DEPRECATION_NOTICE, fg="yellow", err=True)
 
     @staticmethod
     def _set_commands(package_names):

--- a/tests/integration/deprecation/test_deprecation_warning.py
+++ b/tests/integration/deprecation/test_deprecation_warning.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import sys
+
+from unittest import TestCase
+
+from samcli.cli.command import DEPRECATION_NOTICE
+
+
+class TestPy2DeprecationWarning(TestCase):
+
+    def base_command(self):
+        command = "sam"
+        if os.getenv("SAM_CLI_DEV"):
+            command = "samdev"
+
+        return command
+
+    def run_cmd(self):
+        # Checking with base command to see if warning is present if running in python2
+        cmd_list = [self.base_command()]
+        process = subprocess.Popen(cmd_list, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return process
+
+    def test_print_deprecation_warning_if_py2(self):
+        process = self.run_cmd()
+        (stdoutdata, stderrdata) = process.communicate()
+
+        # Deprecation notice should be part of the command output if running in python 2
+        if sys.version_info.major == 2:
+            self.assertIn(DEPRECATION_NOTICE, stderrdata.decode())


### PR DESCRIPTION
- if AWS SAM CLI is installed under python2.7 environment, there is a
  warning which says that AWS SAM CLI will no longer be installable
  under python2.7 from October 1st 2019.

*Issue #, if available:*

* https://github.com/awslabs/aws-sam-cli/issues/1273

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
