### PR TITLE
fix: fix unit tests so that they pass on windows

### DIFF
--- a/tests/unit/commands/local/lib/swagger/test_reader.py
+++ b/tests/unit/commands/local/lib/swagger/test_reader.py
@@ -184,7 +184,7 @@ class TestSamSwaggerReader_download_swagger(TestCase):
         expected = "parsed result"
         yaml_parse_mock.return_value = expected
 
-        with tempfile.NamedTemporaryFile(mode='w') as fp:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as fp:
             filepath = fp.name
 
             json.dump(data, fp)
@@ -205,7 +205,7 @@ class TestSamSwaggerReader_download_swagger(TestCase):
         expected = "parsed result"
         yaml_parse_mock.return_value = expected
 
-        with tempfile.NamedTemporaryFile(mode='w') as fp:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as fp:
             filepath = fp.name
 
             json.dump(data, fp)

--- a/tests/unit/commands/local/lib/test_sam_api_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_api_provider.py
@@ -471,7 +471,7 @@ class TestSamApiProviderWithExplicitApis(TestCase):
         assertCountEqual(self, self.input_apis, provider.apis)
 
     def test_with_swagger_as_local_file(self):
-        with tempfile.NamedTemporaryFile(mode='w') as fp:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as fp:
             filename = fp.name
 
             swagger = make_swagger(self.input_apis)

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -6,6 +6,12 @@ import json
 from unittest import TestCase
 from mock import Mock, call, patch
 
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+
 from samcli.lib.build.app_builder import ApplicationBuilder,\
     UnsupportedBuilderLibraryVersionError, BuildError, \
     LambdaBuilderError, ContainerBuildNotSupported
@@ -131,9 +137,9 @@ class TestApplicationBuilder_build_function(TestCase):
 
         self.builder._build_function_in_process = Mock()
 
-        code_dir = "/base/dir/path/to/source"
-        artifacts_dir = "/build/dir/function_name"
-        manifest_path = os.path.join(code_dir, config_mock.manifest_name)
+        code_dir = str(Path("/base/dir/path/to/source").resolve())
+        artifacts_dir = str(Path("/build/dir/function_name"))
+        manifest_path = str(Path(os.path.join(code_dir, config_mock.manifest_name)).resolve())
 
         self.builder._build_function(function_name, codeuri, runtime)
 
@@ -159,9 +165,9 @@ class TestApplicationBuilder_build_function(TestCase):
 
         self.builder._build_function_on_container = Mock()
 
-        code_dir = "/base/dir/path/to/source"
-        artifacts_dir = "/build/dir/function_name"
-        manifest_path = os.path.join(code_dir, config_mock.manifest_name)
+        code_dir = str(Path("/base/dir/path/to/source").resolve())
+        artifacts_dir = str(Path("/build/dir/function_name"))
+        manifest_path = str(Path(os.path.join(code_dir, config_mock.manifest_name)).resolve())
 
         # Settting the container manager will make us use the container
         self.builder._container_manager = Mock()

--- a/tests/unit/lib/telemetry/test_metrics.py
+++ b/tests/unit/lib/telemetry/test_metrics.py
@@ -113,7 +113,7 @@ class TestTrackCommand(TestCase):
     @patch("samcli.lib.telemetry.metrics.Context")
     def test_must_record_function_duration(self, ContextMock):
         ContextMock.get_current_context.return_value = self.context_mock
-        sleep_duration = 0.001  # 1 millisecond
+        sleep_duration = 0.01  # 10 millisecond
 
         def real_fn():
             time.sleep(sleep_duration)
@@ -125,9 +125,10 @@ class TestTrackCommand(TestCase):
         args, kwargs = self.telemetry_instance.emit.call_args_list[0]
         metric_name, actual_attrs = args
         self.assertEquals("commandRun", metric_name)
-        self.assertGreater(actual_attrs["duration"],
-                           sleep_duration,
-                           "Measured duration must be in milliseconds and greater than the sleep duration")
+        self.assertGreaterEqual(actual_attrs["duration"],
+                                sleep_duration,
+                                "Measured duration must be in milliseconds and "
+                                "greater than equal to  the sleep duration")
 
     @patch("samcli.lib.telemetry.metrics.Context")
     def test_must_record_user_exception(self, ContextMock):

--- a/tests/unit/lib/utils/test_codeuri.py
+++ b/tests/unit/lib/utils/test_codeuri.py
@@ -2,6 +2,11 @@ import os
 from unittest import TestCase
 from parameterized import parameterized
 
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
 from samcli.lib.utils.codeuri import resolve_code_path
 
 
@@ -52,7 +57,7 @@ class TestLocalLambda_get_code_path(TestCase):
         expected = os.path.normpath(os.path.join(self.cwd, codeuri))
 
         actual = resolve_code_path(self.cwd, codeuri)
-        self.assertEquals(expected, actual)
+        self.assertEquals(str(Path(expected).resolve()), actual)
         self.assertTrue(os.path.isabs(actual), "Result must be an absolute path")
 
     @parameterized.expand([

--- a/tests/unit/local/docker/test_lambda_build_container.py
+++ b/tests/unit/local/docker/test_lambda_build_container.py
@@ -54,10 +54,10 @@ class TestLambdaBuildContainer_init(TestCase):
         self.assertEquals(container._entrypoint, entry)
         self.assertEquals(container._cmd, [])
         self.assertEquals(container._working_dir, container_dirs["source_dir"])
-        self.assertEquals(container._host_dir, "/foo/source")
+        self.assertEquals(container._host_dir, str(pathlib.Path("/foo/source").resolve()))
         self.assertEquals(container._env_vars, {"LAMBDA_BUILDERS_LOG_LEVEL": "log-level"})
         self.assertEquals(container._additional_volumes, {
-            "/bar": {
+            str(pathlib.Path("/bar").resolve()): {
                 "bind": container_dirs["manifest_dir"],
                 "mode": "ro"
             }
@@ -71,7 +71,8 @@ class TestLambdaBuildContainer_init(TestCase):
         make_request_mock.assert_called_once()
         get_entrypoint_mock.assert_called_once_with(request)
         get_image_mock.assert_called_once_with("runtime")
-        get_container_dirs_mock.assert_called_once_with("/foo/source", "/bar")
+        get_container_dirs_mock.assert_called_once_with(str(pathlib.Path("/foo/source").resolve()),
+                                                        str(pathlib.Path("/bar").resolve()))
 
 
 class TestLambdaBuildContainer_make_request(TestCase):

--- a/tests/unit/local/lambdafn/test_zip.py
+++ b/tests/unit/local/lambdafn/test_zip.py
@@ -1,19 +1,24 @@
+import os
+import platform
+import shutil
 import stat
 import zipfile
-import os
-import shutil
-from unittest import TestCase
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile, mkdtemp
-from mock import Mock, patch
+from unittest import TestCase
+from unittest import skipIf
 
+from mock import Mock, patch
 from nose_parameterized import parameterized, param
 
 from samcli.local.lambdafn.zip import unzip, unzip_from_uri, _override_permissions
 
+# On Windows, permissions do not match 1:1 with permissions on Unix systems.
+SKIP_UNZIP_PERMISSION_TESTS = platform.system() == 'Windows'
 
+
+@skipIf(SKIP_UNZIP_PERMISSION_TESTS, "Skip UnZip Permissions tests in Windows only")
 class TestUnzipWithPermissions(TestCase):
-
     files_with_permissions = {
         "folder1/1.txt": 0o644,
         "folder1/2.txt": 0o777,

--- a/tests/unit/local/layers/test_download_layers.py
+++ b/tests/unit/local/layers/test_download_layers.py
@@ -2,6 +2,11 @@ from unittest import TestCase
 from mock import patch, Mock, call
 
 from botocore.exceptions import NoCredentialsError, ClientError
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
 
 from samcli.local.layers.layer_downloader import LayerDownloader
 from samcli.commands.local.cli_common.user_exceptions import CredentialsRequired, ResourceNotFound
@@ -55,7 +60,7 @@ class TestDownloadLayers(TestCase):
 
         actual = download_layers.download(layer_mock)
 
-        self.assertEquals(actual.codeuri, '/home/layer1')
+        self.assertEquals(actual.codeuri, str(Path('/home/layer1').resolve()))
 
         create_cache_patch.assert_called_once_with("/home")
 
@@ -99,13 +104,13 @@ class TestDownloadLayers(TestCase):
 
         actual = download_layers.download(layer_mock)
 
-        self.assertEquals(actual.codeuri, "/home/layer1")
+        self.assertEquals(actual.codeuri, str(Path("/home/layer1").resolve()))
 
         create_cache_patch.assert_called_once_with("/home")
         fetch_layer_uri_patch.assert_called_once_with(layer_mock)
         unzip_from_uri_patch.assert_called_once_with("layer/uri",
-                                                     '/home/layer1.zip',
-                                                     unzip_output_dir='/home/layer1',
+                                                     str(Path('/home/layer1.zip').resolve()),
+                                                     unzip_output_dir=str(Path('/home/layer1').resolve()),
                                                      progressbar_label="Downloading arn:layer:layer1")
 
     def test_layer_is_cached(self):


### PR DESCRIPTION
first pass at getting unit tests to pass on windows (with Appveyor)

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
