### PR TITLE
Pin Pyyaml to 5.1 since theres pyyaml vulnerability in 3.12

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ click~=6.7
 enum34~=1.1.6; python_version<"3.4"
 Flask~=1.0.2
 boto3~=1.9, >=1.9.56
-PyYAML~=3.12
+PyYAML~=5.1.2
 cookiecutter~=1.6.0
 aws-sam-translator==1.10.0
 docker~=3.7.0


### PR DESCRIPTION
*Description of changes:*

- Pin PyYaml to 5.1 since a vulnerability was found in 3.12.
- Details: https://nvd.nist.gov/vuln/detail/CVE-2017-18342
```
1 pyyaml vulnerability found in requirements.txt 5 minutes ago
Remediation
Upgrade pyyaml to version 4.2b1 or later. For example:

pyyaml>=4.2b1
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2017-18342 More information
high severity
Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
