### PR TITLE
(feat) Add --persist-containers flag to start-api

### DIFF
--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -81,6 +81,10 @@ def invoke_common_options(f):
     invoke_options = [
         template_click_option(),
 
+        click.option("--persist-containers/--no-persist-containers",
+                     default=False,
+                     help="Persist lambda containers between invocations"),
+
         click.option('--env-vars', '-n',
                      type=click.Path(exists=True),
                      help="JSON file containing values for Lambda function's environment variables."),

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -41,9 +41,6 @@ and point SAM to the directory or file containing build artifacts.
               default="public",
               help="Any static assets (e.g. CSS/Javascript/HTML) files located in this directory "
                    "will be presented at /")
-@click.option("--persist-containers/--no-persist-containers",
-              default=False,
-              help="Persist lambda containers between invocations")
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options  # pylint: disable=R0914
@@ -51,10 +48,10 @@ and point SAM to the directory or file containing build artifacts.
 @track_command
 def cli(ctx,
         # start-api Specific Options
-        host, port, static_dir, persist_containers,
+        host, port, static_dir,
 
         # Common Options for Lambda Invoke
-        template, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
+        template, persist_containers, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
         docker_network, log_file, layer_cache_basedir, skip_pull_image, force_image_build, parameter_overrides):
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
@@ -63,7 +60,7 @@ def cli(ctx,
            parameter_overrides)  # pragma: no cover
 
 
-def do_cli(ctx, host, port, static_dir, persist_containers, template, env_vars, debug_port,  # pylint: disable=R0914
+def do_cli(ctx, host, port, static_dir, template, persist_containers, env_vars, debug_port,  # pylint: disable=R0914
            debug_args, debugger_path, docker_volume_basedir, docker_network, log_file, layer_cache_basedir,
            skip_pull_image, force_image_build, parameter_overrides):
     """

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -41,6 +41,9 @@ and point SAM to the directory or file containing build artifacts.
               default="public",
               help="Any static assets (e.g. CSS/Javascript/HTML) files located in this directory "
                    "will be presented at /")
+@click.option("--persist-containers/--no-persist-containers",
+              default=False,
+              help="Persist lambda containers between invocations")
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options  # pylint: disable=R0914
@@ -48,21 +51,21 @@ and point SAM to the directory or file containing build artifacts.
 @track_command
 def cli(ctx,
         # start-api Specific Options
-        host, port, static_dir,
+        host, port, static_dir, persist_containers,
 
         # Common Options for Lambda Invoke
         template, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
         docker_network, log_file, layer_cache_basedir, skip_pull_image, force_image_build, parameter_overrides):
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_args, debugger_path,
+    do_cli(ctx, host, port, static_dir, persist_containers, template, env_vars, debug_port, debug_args, debugger_path,
            docker_volume_basedir, docker_network, log_file, layer_cache_basedir, skip_pull_image, force_image_build,
            parameter_overrides)  # pragma: no cover
 
 
-def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_args,  # pylint: disable=R0914
-           debugger_path, docker_volume_basedir, docker_network, log_file, layer_cache_basedir, skip_pull_image,
-           force_image_build, parameter_overrides):
+def do_cli(ctx, host, port, static_dir, persist_containers, template, env_vars, debug_port,  # pylint: disable=R0914
+           debug_args, debugger_path, docker_volume_basedir, docker_network, log_file, layer_cache_basedir,
+           skip_pull_image, force_image_build, parameter_overrides):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
@@ -87,7 +90,8 @@ def do_cli(ctx, host, port, static_dir, template, env_vars, debug_port, debug_ar
                            layer_cache_basedir=layer_cache_basedir,
                            force_image_build=force_image_build,
                            aws_region=ctx.region,
-                           aws_profile=ctx.profile) as invoke_context:
+                           aws_profile=ctx.profile,
+                           persist_containers=persist_containers) as invoke_context:
 
             service = LocalApiService(lambda_invoke_context=invoke_context,
                                       port=port,

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -65,17 +65,17 @@ def cli(ctx,  # pylint: disable=R0914
         host, port,
 
         # Common Options for Lambda Invoke
-        template, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
+        template, persist_containers, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
         docker_network, log_file, layer_cache_basedir, skip_pull_image, force_image_build,
         parameter_overrides):  # pylint: disable=R0914
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(ctx, host, port, template, env_vars, debug_port, debug_args, debugger_path, docker_volume_basedir,
-           docker_network, log_file, layer_cache_basedir, skip_pull_image, force_image_build,
+    do_cli(ctx, host, port, template, persist_containers, env_vars, debug_port, debug_args, debugger_path,
+           docker_volume_basedir, docker_network, log_file, layer_cache_basedir, skip_pull_image, force_image_build,
            parameter_overrides)  # pragma: no cover
 
 
-def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylint: disable=R0914
+def do_cli(ctx, host, port, template, persist_containers, env_vars, debug_port, debug_args,  # pylint: disable=R0914
            debugger_path, docker_volume_basedir, docker_network, log_file, layer_cache_basedir, skip_pull_image,
            force_image_build, parameter_overrides):
     """
@@ -102,7 +102,8 @@ def do_cli(ctx, host, port, template, env_vars, debug_port, debug_args,  # pylin
                            layer_cache_basedir=layer_cache_basedir,
                            force_image_build=force_image_build,
                            aws_region=ctx.region,
-                           aws_profile=ctx.profile) as invoke_context:
+                           aws_profile=ctx.profile,
+                           persist_containers=persist_containers) as invoke_context:
 
             service = LocalLambdaService(lambda_invoke_context=invoke_context,
                                          port=port,

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -39,6 +39,7 @@ class LambdaContainer(Container):
                  image_builder,
                  memory_mb=128,
                  env_vars=None,
+                 entrypoint=None,
                  debug_options=None):
         """
         Initializes the class
@@ -69,7 +70,6 @@ class LambdaContainer(Container):
 
         image = LambdaContainer._get_image(image_builder, runtime, layers)
         ports = LambdaContainer._get_exposed_ports(debug_options)
-        entry = LambdaContainer._get_entry_point(runtime, debug_options)
         additional_options = LambdaContainer._get_additional_options(runtime, debug_options)
         additional_volumes = LambdaContainer._get_additional_volumes(debug_options)
         cmd = [handler]
@@ -80,7 +80,7 @@ class LambdaContainer(Container):
                                               code_dir,
                                               memory_limit_mb=memory_mb,
                                               exposed_ports=ports,
-                                              entrypoint=entry,
+                                              entrypoint=entrypoint,
                                               env_vars=env_vars,
                                               container_opts=additional_options,
                                               additional_volumes=additional_volumes)
@@ -161,7 +161,7 @@ class LambdaContainer(Container):
         return image_builder.build(runtime, layers)
 
     @staticmethod
-    def _get_entry_point(runtime, debug_options=None):  # pylint: disable=too-many-branches
+    def get_debug_entry_point(runtime, debug_options=None):
         """
         Returns the entry point for the container. The default value for the entry point is already configured in the
         Dockerfile. We override this default specifically when enabling debugging. The overridden entry point includes

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -211,7 +211,8 @@ class TestInvokeContext_local_lambda_runner(TestCase):
                                      debugger_path="path-to-debugger",
                                      debug_args='args',
                                      aws_profile="profile",
-                                     aws_region="region")
+                                     aws_region="region",
+                                     persist_containers=False)
 
     @patch("samcli.commands.local.cli_common.invoke_context.LambdaImage")
     @patch("samcli.commands.local.cli_common.invoke_context.LayerDownloader")
@@ -254,7 +255,7 @@ class TestInvokeContext_local_lambda_runner(TestCase):
             result = self.context.local_lambda_runner
             self.assertEquals(result, runner_mock)
 
-            LambdaRuntimeMock.assert_called_with(container_manager_mock, image_mock)
+            LambdaRuntimeMock.assert_called_with(container_manager_mock, image_mock, persist_container=False)
             lambda_image_patch.assert_called_once_with(download_mock, True, True)
             LocalLambdaMock.assert_called_with(local_runtime=runtime_mock,
                                                function_provider=ANY,

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -40,6 +40,7 @@ class TestCli(TestCase):
         self.host = "host"
         self.port = 123
         self.static_dir = "staticdir"
+        self.persist_containers = False
 
     @patch("samcli.commands.local.start_api.cli.InvokeContext")
     @patch("samcli.commands.local.start_api.cli.LocalApiService")
@@ -68,7 +69,8 @@ class TestCli(TestCase):
                                                layer_cache_basedir=self.layer_cache_basedir,
                                                force_image_build=self.force_image_build,
                                                aws_region=self.region_name,
-                                               aws_profile=self.profile)
+                                               aws_profile=self.profile,
+                                               persist_containers=False)
 
         local_api_service_mock.assert_called_with(lambda_invoke_context=context_mock,
                                                   port=self.port,
@@ -132,6 +134,7 @@ class TestCli(TestCase):
                       host=self.host,
                       port=self.port,
                       static_dir=self.static_dir,
+                      persist_containers=self.persist_containers,
                       template=self.template,
                       env_vars=self.env_vars,
                       debug_port=self.debug_port,

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -49,7 +49,8 @@ class TestCli(TestCase):
 
         self.call_cli()
 
-        invoke_context_mock.assert_called_with(template_file=self.template,
+        invoke_context_mock.assert_called_with(persist_containers=False,
+                                               template_file=self.template,
                                                function_identifier=None,
                                                env_vars_file=self.env_vars,
                                                docker_volume_basedir=self.docker_volume_basedir,
@@ -107,6 +108,7 @@ class TestCli(TestCase):
                          host=self.host,
                          port=self.port,
                          template=self.template,
+                         persist_containers=False,
                          env_vars=self.env_vars,
                          debug_port=self.debug_port,
                          debug_args=self.debug_args,


### PR DESCRIPTION
There's still some work to do for this, e.g. Design doc(?), more tests, and documentation

I want to see if this is something that would be considered to be merged before I spend too much time on it

There exists a PR already for a similar feature (https://github.com/awslabs/aws-sam-cli/pull/1305), however this has much better performance (roughly 0.2s per invocation, whereas using docker start instead was between 0.5 and 1.5s for me)

*Issue #, if available:*
#239 

*Description of changes:*
Adds `--persist-containers` as a flag to start api.

This causes lambda containers to stay running (with `sleep infinity`) the whole time, and lambdas are invoked by calling `exec` on the containers with the lambda handler. This means we only pay the container startup cost once (the first time the lambda is run), instead of at every request. Anecdotally this lowers runtime of a hello world lambda from ~3s to ~0.2s.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
