### PR TITLE
Try relpath first, if failed use the user specified path

### DIFF
--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -158,8 +158,8 @@ def do_cli(function_identifier,  # pylint: disable=too-many-locals
 
             click.secho("\nBuild Succeeded", fg="green")
 
-            msg = gen_success_msg(os.path.relpath(ctx.build_dir),
-                                  os.path.relpath(ctx.output_template_path),
+            msg = gen_success_msg(os.path.abspath(ctx.build_dir),
+                                  os.path.abspath(ctx.output_template_path),
                                   os.path.abspath(ctx.build_dir) == os.path.abspath(DEFAULT_BUILD_DIR))
 
             click.secho(msg, fg="yellow")

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -158,8 +158,19 @@ def do_cli(function_identifier,  # pylint: disable=too-many-locals
 
             click.secho("\nBuild Succeeded", fg="green")
 
-            msg = gen_success_msg(os.path.abspath(ctx.build_dir),
-                                  os.path.abspath(ctx.output_template_path),
+            # try to use relpath so the command is easier to understand, however,
+            # under Windows, when SAM and (build_dir or output_template_path) are
+            # on different drive, relpath() fails.
+            try:
+                build_dir = os.path.relpath(ctx.build_dir)
+                output_template_path = os.path.relpath(ctx.output_template_path)
+            except ValueError:
+                LOG.debug("Failed to retrieve relpath - using abspath instead")
+                build_dir = os.path.abspath(ctx.build_dir)
+                output_template_path = os.path.abspath(ctx.output_template_path)
+
+            msg = gen_success_msg(build_dir,
+                                  output_template_path,
                                   os.path.abspath(ctx.build_dir) == os.path.abspath(DEFAULT_BUILD_DIR))
 
             click.secho(msg, fg="yellow")

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -162,15 +162,15 @@ def do_cli(function_identifier,  # pylint: disable=too-many-locals
             # under Windows, when SAM and (build_dir or output_template_path) are
             # on different drive, relpath() fails.
             try:
-                build_dir = os.path.relpath(ctx.build_dir)
-                output_template_path = os.path.relpath(ctx.output_template_path)
+                build_dir_in_success_message = os.path.relpath(ctx.build_dir)
+                output_template_path_in_success_message = os.path.relpath(ctx.output_template_path)
             except ValueError:
-                LOG.debug("Failed to retrieve relpath - using abspath instead")
-                build_dir = os.path.abspath(ctx.build_dir)
-                output_template_path = os.path.abspath(ctx.output_template_path)
+                LOG.debug("Failed to retrieve relpath - using the specified path as-is instead")
+                build_dir_in_success_message = ctx.build_dir
+                output_template_path_in_success_message = ctx.output_template_path
 
-            msg = gen_success_msg(build_dir,
-                                  output_template_path,
+            msg = gen_success_msg(build_dir_in_success_message,
+                                  output_template_path_in_success_message,
                                   os.path.abspath(ctx.build_dir) == os.path.abspath(DEFAULT_BUILD_DIR))
 
             click.secho(msg, fg="yellow")


### PR DESCRIPTION
For compatibility with Windows. relpath() fails when the specified path is on a different drive.

*Issue #, if available:* #1336

*Description of changes:* use abspath() instead of relpath(), so cli command succeeds even when running on windows where sam and build_dir/template are located on different drive.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
