### PR TITLE
fix: Use explicit memory settings for Java cookie cutters

### DIFF
--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-java-gradle/{{cookiecutter.project_name}}/template.yaml
@@ -17,6 +17,7 @@ Resources:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
       Runtime: java8
+      MemorySize: 512
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE

--- a/samcli/local/init/templates/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/local/init/templates/cookiecutter-aws-sam-hello-java-maven/{{cookiecutter.project_name}}/template.yaml
@@ -17,6 +17,7 @@ Resources:
       CodeUri: HelloWorldFunction
       Handler: helloworld.App::handleRequest
       Runtime: java8
+      MemorySize: 512
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
           PARAM1: VALUE


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sam-cli/issues/1158

*Description of changes:*
- Use explicit memory settings for Java cookie cutters
  - MemorySize of 128MB is barely sufficient for JVM Lambdas

*Checklist:*

- [-] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [-] Write unit tests
- [-] Write/update functional tests
- [-] Write/update integration tests
- [x] `make pr` passes
- [-] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
