### PR TITLE
generate sample events for amazon connect

### DIFF
--- a/samcli/commands/local/lib/generated_sample_events/event-mapping.json
+++ b/samcli/commands/local/lib/generated_sample_events/event-mapping.json
@@ -478,6 +478,29 @@
       }
     }
   },
+  "connect": {
+    "contact-flow-event": {
+      "filename": "ConnectContactFlowEvent",
+      "help": "Generates an Amazon Connect Contact Flow Event",
+      "tags": {
+        "region": {
+          "default": "us-east-1"
+        },
+        "partition": {
+          "default": "aws"
+        },
+        "account-id": {
+          "default": "123456789012"
+        },
+        "contact-id": {
+          "default": "5ca32fbd-8f92-46af-92a5-6b0f970f0efe"
+        },
+        "phone-number": {
+          "default": "+11234567890"
+        }
+      }
+    }
+  },
   "dynamodb": {
     "update": {
       "filename": "DynamoDBUpdate",

--- a/samcli/commands/local/lib/generated_sample_events/events/connect/ConnectContactFlowEvent.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/connect/ConnectContactFlowEvent.json
@@ -1,0 +1,33 @@
+{
+  "Name": "ContactFlowEvent",
+  "Details": {
+    "ContactData": {
+      "Attributes": {},
+      "Channel": "VOICE",
+      "ContactId": "{{{contact_id}}}",
+      "CustomerEndpoint": {
+        "Address": "{{{phone_number}}}",
+        "Type": "TELEPHONE_NUMBER"
+      },
+      "InitialContactId": "{{{contact_id}}}",
+      "InitiationMethod": "API",
+      "InstanceARN": "arn:{{{partition}}}:connect:{{{region}}}:{{{account_id}}}:instance/9308c2a1-9bc6-4cea-8290-6c0b4a6d38fa",
+      "MediaStreams": {
+        "Customer": {
+          "Audio": {
+            "StartFragmentNumber": "91343852333181432392682062622220590765191907586",
+            "StartTimestamp": "1565781909613",
+            "StreamARN": "arn:{{{partition}}}:kinesisvideo:{{{region}}}:{{{account_id}}}:stream/connect-contact-a3d73b84-ce0e-479a-a9dc-5637c9d30ac9/1565272947806"
+          }
+        }
+      },
+      "PreviousContactId": "{{{contact_id}}}",
+      "Queue": null,
+      "SystemEndpoint": {
+        "Address": "{{{phone_number}}}",
+        "Type": "TELEPHONE_NUMBER"
+      }
+    },
+    "Parameters": {}
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Amazon Connect users have the option to use AWS Lambda functions to augment their contact flows. Many users for Amazon Connect are unfamiliar with Lambda and other AWS tools. A sample event template would make it simple for them to test the behavior of their functions.

Modified `events.json` and added `events/connect/ConnectContactFlowEvent.json`


*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [*] `make pr` passes
- [*] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
