### PR TITLE
Add OSError Handler to GlobalConfig

### DIFF
--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -47,7 +47,6 @@ class GlobalConfig(object):
             # Internal Environment variable to customize SAM CLI App Dir. Currently used only by integ tests.
             app_dir = os.getenv("__SAM_CLI_APP_DIR")
             self._config_dir = Path(app_dir) if app_dir else Path(click.get_app_dir('AWS SAM', force_posix=True))
-
         return Path(self._config_dir)
 
     @property
@@ -76,7 +75,7 @@ class GlobalConfig(object):
         try:
             self._installation_id = self._get_or_set_uuid(INSTALLATION_ID_KEY)
             return self._installation_id
-        except (ValueError, IOError):
+        except (ValueError, IOError, OSError):
             return None
 
     @property
@@ -112,7 +111,7 @@ class GlobalConfig(object):
         try:
             self._telemetry_enabled = self._get_value(TELEMETRY_ENABLED_KEY)
             return self._telemetry_enabled
-        except (ValueError, IOError) as ex:
+        except (ValueError, IOError, OSError) as ex:
             LOG.debug("Error when retrieving telemetry_enabled flag", exc_info=ex)
             return False
 
@@ -164,6 +163,10 @@ class GlobalConfig(object):
             return self._set_json_cfg(cfg_path, key, value, json_body)
 
     def _create_dir(self):
+        """
+        Creates configuration directory if it does not already exist, otherwise does nothing.
+        May raise an OSError if we do not have permissions to create the directory.
+        """
         self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     def _get_config_file_path(self, filename):

--- a/tests/unit/cli/test_global_config.py
+++ b/tests/unit/cli/test_global_config.py
@@ -19,6 +19,16 @@ class TestGlobalConfig(TestCase):
             installation_id = gc.installation_id
             self.assertIsNone(installation_id)
 
+    def test_unable_to_create_dir(self):
+        m = mock_open()
+        m.side_effect = OSError("Permission DENIED")
+        gc = GlobalConfig()
+        with patch('samcli.cli.global_config.Path.mkdir', m):
+            installation_id = gc.installation_id
+            self.assertIsNone(installation_id)
+            telemetry_enabled = gc.telemetry_enabled
+            self.assertFalse(telemetry_enabled)
+
     def test_setter_cannot_open_path(self):
         m = mock_open()
         m.side_effect = IOError("fail")


### PR DESCRIPTION
*Issue #, if available:* Resolves #1313

*Description of changes:* Handle OSError when creating the config directory.

*Checklist:* make pr passing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
