### PR TITLE
fix: sam commands in lifecycle app order in help command

### DIFF
--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -5,21 +5,24 @@ Base classes that implement the CLI framework
 import logging
 import importlib
 import sys
+from collections import OrderedDict
+
 import click
 
 logger = logging.getLogger(__name__)
 
-# Commands that are bundled with the CLI by default
-_SAM_CLI_COMMAND_PACKAGES = {
-    "samcli.commands.local.local",
-    "samcli.commands.validate.validate",
+# Commands that are bundled with the CLI by default in app life-cycle order.
+
+_SAM_CLI_COMMAND_PACKAGES = [
     "samcli.commands.init",
-    "samcli.commands.deploy",
-    "samcli.commands.package",
-    "samcli.commands.logs",
+    "samcli.commands.validate.validate",
     "samcli.commands.build",
+    "samcli.commands.local.local",
+    "samcli.commands.package",
+    "samcli.commands.deploy",
+    "samcli.commands.logs",
     "samcli.commands.publish"
-}
+]
 
 DEPRECATION_NOTICE = (
     "Warning : AWS SAM CLI will no longer support "
@@ -79,7 +82,7 @@ class BaseCommand(click.MultiCommand):
         :return: Dictionary with command name as key and the package name as value.
         """
 
-        commands = {}
+        commands = OrderedDict()
 
         for pkg_name in package_names:
             cmd_name = pkg_name.split('.')[-1]

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -17,7 +17,9 @@ from samcli.lib.telemetry.metrics import track_command
 LOG = logging.getLogger(__name__)
 
 
-@click.command(context_settings=dict(help_option_names=[u'-h', u'--help']))
+@click.command("init",
+               short_help="Init an AWS SAM application.",
+               context_settings=dict(help_option_names=[u'-h', u'--help']))
 @click.option('-l', '--location', help="Template location (git, mercurial, http(s), zip, path)")
 @click.option('-r', '--runtime', type=click.Choice(INIT_RUNTIMES), default=DEFAULT_RUNTIME,
               help="Lambda Runtime of your app")


### PR DESCRIPTION
- fix init so that it displays short help content
- display commands in lifecycle order

```
~/aws_sam_cli_WS/aws-sam-cli❯ sam --help                                                                                              
Usage: sam [OPTIONS] COMMAND [ARGS]...

  AWS Serverless Application Model (SAM) CLI

  The AWS Serverless Application Model extends AWS CloudFormation to provide
  a simplified way of defining the Amazon API Gateway APIs, AWS Lambda
  functions, and Amazon DynamoDB tables needed by your serverless
  application. You can find more in-depth guide about the SAM specification
  here: https://github.com/awslabs/serverless-application-model.

Options:
  --debug    Turn on debug logging to print debug message generated by SAM
             CLI.
  --version  Show the version and exit.
  --info
  --help     Show this message and exit.

Commands:
  init      Init an AWS SAM application.
  validate  Validate an AWS SAM template.
  build     Build your Lambda function code
  local     Run your Serverless application locally for quick development &...
  package   Package an AWS SAM application. This is an alias for 'aws
            cloudformation package'.
  deploy    Deploy an AWS SAM application. This is an alias for 'aws
            cloudformation deploy'.
  logs      Fetch logs for a function
  publish   Publish a packaged AWS SAM template to the AWS Serverless
            Application Repository.
```


- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [X] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
