### PR TITLE
Loosen requests version bounds

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,6 @@ docker~=4.0
 dateparser~=0.7
 python-dateutil~=2.6
 pathlib2~=2.3.2; python_version<"3.4"
-requests==2.22.0
+requests~=2.22
 serverlessrepo==0.1.9
 aws_lambda_builders==0.3.0


### PR DESCRIPTION
*Issue #, if available:*
Nope

*Description of changes:*
Use compatible versions of requests instead of pinning. Requests respects SemVer according to https://2.python-requests.org/en/master/dev/philosophy/#semantic-versioning , so there's no need to pin to a specific version. Anything in the >=2.22,<3 range should be compatible.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
