### PR TITLE
Fix Ruby Integ Test

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -189,7 +189,7 @@ class TestBuildCommand_RubyFunctions(BuildIntegBase):
 
     EXPECTED_FILES_GLOBAL_MANIFEST = set()
     EXPECTED_FILES_PROJECT_MANIFEST = {"app.rb"}
-    EXPECTED_RUBY_GEM = "httparty"
+    EXPECTED_RUBY_GEM = "aws-record"
 
     FUNCTION_LOGICAL_ID = "Function"
 

--- a/tests/integration/testdata/buildcmd/Ruby/Gemfile
+++ b/tests/integration/testdata/buildcmd/Ruby/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "httparty"
+gem "aws-record", "~> 2"


### PR DESCRIPTION
The `httparty` gem has native extensions, and can fail to build on Windows, which is causing integ test failures. Changed to a new gem which should be much more platform-agnostic to build.

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
