### PR TITLE
fix: py2 warning message to be deprecated instead

### DIFF
--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -25,9 +25,9 @@ _SAM_CLI_COMMAND_PACKAGES = [
 ]
 
 DEPRECATION_NOTICE = (
-    "Warning : AWS SAM CLI will no longer support "
-    "installations on Python 2.7 starting on October 1st, 2019."
-    " Install AWS SAM CLI via https://docs.aws.amazon.com/serverless-application-model/"
+    "Deprecated : AWS SAM CLI no longer supports "
+    "installations on Python 2.7. "
+    "Install AWS SAM CLI via https://docs.aws.amazon.com/serverless-application-model/"
     "latest/developerguide/serverless-sam-cli-install.html for continued support with new versions. \n"
 )
 
@@ -70,7 +70,7 @@ class BaseCommand(click.MultiCommand):
         self._commands = BaseCommand._set_commands(cmd_packages)
 
         if sys.version_info.major == 2:
-            click.secho(DEPRECATION_NOTICE, fg="yellow", err=True)
+            click.secho(DEPRECATION_NOTICE, fg="red", err=True)
 
     @staticmethod
     def _set_commands(package_names):


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/1273

*Description of changes:*

Change message from warning to deprecation notice.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
