### PR TITLE
feat(perf): Improve load time of help text

### DIFF
--- a/requirements/isolated.txt
+++ b/requirements/isolated.txt
@@ -11,7 +11,7 @@ chevron==0.13.1
 Click==7.0
 cookiecutter==1.6.0
 dateparser==0.7.2
-docker==4.0.2
+docker==4.1.0
 docutils==0.15.2
 Flask==1.0.4
 future==0.17.1

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -6,17 +6,11 @@ import os
 import logging
 import click
 
-from samcli.commands.exceptions import UserException
-from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands._utils.options import template_option_without_build, docker_common_options, \
     parameter_override_option
-from samcli.commands.build.build_context import BuildContext
-from samcli.lib.build.app_builder import ApplicationBuilder, BuildError, UnsupportedBuilderLibraryVersionError, \
-    ContainerBuildNotSupported
-from samcli.lib.build.workflow_config import UnsupportedRuntimeException
-from samcli.local.lambdafn.exceptions import FunctionNotFound
-from samcli.commands._utils.template import move_template
+from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.lib.telemetry.metrics import track_command
+
 
 LOG = logging.getLogger(__name__)
 
@@ -105,7 +99,7 @@ def cli(ctx,
            skip_pull_image, parameter_overrides, mode)  # pragma: no cover
 
 
-def do_cli(function_identifier,  # pylint: disable=too-many-locals
+def do_cli(function_identifier,  # pylint: disable=too-many-locals, too-many-statements
            template,
            base_dir,
            build_dir,
@@ -119,6 +113,15 @@ def do_cli(function_identifier,  # pylint: disable=too-many-locals
     """
     Implementation of the ``cli`` method
     """
+
+    from samcli.commands.exceptions import UserException
+
+    from samcli.commands.build.build_context import BuildContext
+    from samcli.lib.build.app_builder import ApplicationBuilder, BuildError, UnsupportedBuilderLibraryVersionError, \
+        ContainerBuildNotSupported
+    from samcli.lib.build.workflow_config import UnsupportedRuntimeException
+    from samcli.local.lambdafn.exceptions import FunctionNotFound
+    from samcli.commands._utils.template import move_template
 
     LOG.debug("'build' command is called")
 

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -7,12 +7,8 @@ import logging
 import click
 
 from samcli.cli.main import pass_context, common_options
-from samcli.commands.exceptions import UserException
-from samcli.local.common.runtime_template import INIT_RUNTIMES, SUPPORTED_DEP_MANAGERS, DEFAULT_RUNTIME
-from samcli.local.init import generate_project
-from samcli.local.init.exceptions import GenerateProjectFailedError
 from samcli.lib.telemetry.metrics import track_command
-
+from samcli.local.common.runtime_template import INIT_RUNTIMES, SUPPORTED_DEP_MANAGERS, DEFAULT_RUNTIME
 
 LOG = logging.getLogger(__name__)
 
@@ -95,6 +91,10 @@ def do_cli(ctx, location, runtime, dependency_manager, output_dir, name, no_inpu
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
+    from samcli.commands.exceptions import UserException
+    from samcli.local.init import generate_project
+    from samcli.local.init.exceptions import GenerateProjectFailedError
+
     LOG.debug("Init command")
     click.secho("[+] Initializing project structure...", fg="green")
 

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -7,14 +7,6 @@ import click
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands.local.cli_common.options import invoke_common_options
-from samcli.commands.exceptions import UserException
-from samcli.commands.local.lib.exceptions import InvalidLayerReference
-from samcli.commands.local.cli_common.invoke_context import InvokeContext
-from samcli.local.lambdafn.exceptions import FunctionNotFound
-from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
-from samcli.local.docker.manager import DockerImagePullFailedException
-from samcli.local.docker.lambda_debug_entrypoint import DebuggingNotSupported
 from samcli.lib.telemetry.metrics import track_command
 
 
@@ -112,6 +104,15 @@ def do_cli(  # pylint: disable=R0914
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
+
+    from samcli.commands.exceptions import UserException
+    from samcli.commands.local.lib.exceptions import InvalidLayerReference
+    from samcli.commands.local.cli_common.invoke_context import InvokeContext
+    from samcli.local.lambdafn.exceptions import FunctionNotFound
+    from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+    from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
+    from samcli.local.docker.manager import DockerImagePullFailedException
+    from samcli.local.docker.lambda_debug_entrypoint import DebuggingNotSupported
 
     LOG.debug("local invoke command is called")
 

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -7,13 +7,6 @@ import click
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands.local.cli_common.options import invoke_common_options, service_common_options
-from samcli.commands.local.cli_common.invoke_context import InvokeContext
-from samcli.commands.local.lib.exceptions import NoApisDefined, InvalidLayerReference
-from samcli.commands.exceptions import UserException
-from samcli.commands.local.lib.local_api_service import LocalApiService
-from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
-from samcli.local.docker.lambda_debug_entrypoint import DebuggingNotSupported
 from samcli.lib.telemetry.metrics import track_command
 
 
@@ -113,6 +106,14 @@ def do_cli(  # pylint: disable=R0914
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
+
+    from samcli.commands.local.cli_common.invoke_context import InvokeContext
+    from samcli.commands.local.lib.exceptions import NoApisDefined, InvalidLayerReference
+    from samcli.commands.exceptions import UserException
+    from samcli.commands.local.lib.local_api_service import LocalApiService
+    from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+    from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
+    from samcli.local.docker.lambda_debug_entrypoint import DebuggingNotSupported
 
     LOG.debug("local start-api command is called")
 

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -7,13 +7,6 @@ import click
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands.local.cli_common.options import invoke_common_options, service_common_options
-from samcli.commands.local.cli_common.invoke_context import InvokeContext
-from samcli.commands.local.cli_common.user_exceptions import UserException
-from samcli.commands.local.lib.exceptions import InvalidLayerReference
-from samcli.commands.local.lib.local_lambda_service import LocalLambdaService
-from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
-from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
-from samcli.local.docker.lambda_debug_entrypoint import DebuggingNotSupported
 from samcli.lib.telemetry.metrics import track_command
 
 
@@ -122,6 +115,14 @@ def do_cli(  # pylint: disable=R0914
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
+
+    from samcli.commands.local.cli_common.invoke_context import InvokeContext
+    from samcli.commands.local.cli_common.user_exceptions import UserException
+    from samcli.commands.local.lib.exceptions import InvalidLayerReference
+    from samcli.commands.local.lib.local_lambda_service import LocalLambdaService
+    from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
+    from samcli.commands.local.lib.exceptions import OverridesNotWellDefinedError
+    from samcli.local.docker.lambda_debug_entrypoint import DebuggingNotSupported
 
     LOG.debug("local start_lambda command is called")
 

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -7,7 +7,6 @@ import click
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.lib.telemetry.metrics import track_command
-from .logs_context import LogsCommandContext
 
 LOG = logging.getLogger(__name__)
 
@@ -84,6 +83,7 @@ def do_cli(function_name, stack_name, filter_pattern, tailing, start_time, end_t
     """
     Implementation of the ``cli`` method
     """
+    from .logs_context import LogsCommandContext
 
     LOG.debug("'logs' command is called")
 

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -5,16 +5,12 @@ import logging
 
 import click
 import boto3
-from serverlessrepo import publish_application
-from serverlessrepo.publish import CREATE_APPLICATION
-from serverlessrepo.parser import METADATA, SERVERLESS_REPO_APPLICATION
-from serverlessrepo.exceptions import ServerlessRepoError, InvalidS3UriError
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands._utils.options import template_common_option
 from samcli.commands._utils.template import get_template_data
-from samcli.commands.exceptions import UserException
 from samcli.lib.telemetry.metrics import track_command
+from serverlessrepo.publish import CREATE_APPLICATION
 
 LOG = logging.getLogger(__name__)
 
@@ -58,6 +54,13 @@ def cli(ctx, template, semantic_version):
 
 def do_cli(ctx, template, semantic_version):
     """Publish the application based on command line inputs."""
+
+    from serverlessrepo import publish_application
+    from serverlessrepo.parser import METADATA, SERVERLESS_REPO_APPLICATION
+    from serverlessrepo.exceptions import ServerlessRepoError, InvalidS3UriError
+
+    from samcli.commands.exceptions import UserException
+
     try:
         template_data = get_template_data(template)
     except ValueError as ex:

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -6,16 +6,10 @@ import os
 import boto3
 from botocore.exceptions import NoCredentialsError
 import click
-from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
 
-from samcli.commands.exceptions import UserException
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands._utils.options import template_option_without_build
-from samcli.commands.local.cli_common.user_exceptions import InvalidSamTemplateException, SamTemplateNotFoundException
-from samcli.yamlhelper import yaml_parse
 from samcli.lib.telemetry.metrics import track_command
-from .lib.exceptions import InvalidSamDocumentException
-from .lib.sam_template_validator import SamTemplateValidator
 
 
 @click.command("validate", short_help="Validate an AWS SAM template.")
@@ -35,6 +29,12 @@ def do_cli(ctx, template):
     """
     Implementation of the ``cli`` method, just separated out for unit testing purposes
     """
+    from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
+
+    from samcli.commands.exceptions import UserException
+    from samcli.commands.local.cli_common.user_exceptions import InvalidSamTemplateException
+    from .lib.exceptions import InvalidSamDocumentException
+    from .lib.sam_template_validator import SamTemplateValidator
 
     sam_template = _read_sam_file(template)
 
@@ -54,12 +54,16 @@ def do_cli(ctx, template):
 
 def _read_sam_file(template):
     """
-    Reads the file (json and yaml supported) provided and returns the dictionary representation of the file.
+        Reads the file (json and yaml supported) provided and returns the dictionary representation of the file.
 
-    :param str template: Path to the template file
-    :return dict: Dictionary representing the SAM Template
-    :raises: SamTemplateNotFoundException when the template file does not exist
+        :param str template: Path to the template file
+        :return dict: Dictionary representing the SAM Template
+        :raises: SamTemplateNotFoundException when the template file does not exist
     """
+
+    from samcli.commands.local.cli_common.user_exceptions import SamTemplateNotFoundException
+    from samcli.yamlhelper import yaml_parse
+
     if not os.path.exists(template):
         click.secho("SAM Template Not Found", bg="red")
         raise SamTemplateNotFoundException("Template at {} is not found".format(template))

--- a/tests/unit/commands/buildcmd/test_command.py
+++ b/tests/unit/commands/buildcmd/test_command.py
@@ -13,9 +13,9 @@ from samcli.local.lambdafn.exceptions import FunctionNotFound
 
 
 class TestDoCli(TestCase):
-    @patch("samcli.commands.build.command.BuildContext")
-    @patch("samcli.commands.build.command.ApplicationBuilder")
-    @patch("samcli.commands.build.command.move_template")
+    @patch("samcli.commands.build.build_context.BuildContext")
+    @patch("samcli.lib.build.app_builder.ApplicationBuilder")
+    @patch("samcli.commands._utils.template.move_template")
     @patch("samcli.commands.build.command.os")
     def test_must_succeed_build(self, os_mock, move_template_mock, ApplicationBuilderMock, BuildContextMock):
 
@@ -63,8 +63,8 @@ class TestDoCli(TestCase):
             (UnsupportedBuilderLibraryVersionError(container_name="name", error_msg="msg"),),
         ]
     )
-    @patch("samcli.commands.build.command.BuildContext")
-    @patch("samcli.commands.build.command.ApplicationBuilder")
+    @patch("samcli.commands.build.build_context.BuildContext")
+    @patch("samcli.lib.build.app_builder.ApplicationBuilder")
     def test_must_catch_known_exceptions(self, exception, ApplicationBuilderMock, BuildContextMock):
 
         ctx_mock = Mock()
@@ -91,8 +91,8 @@ class TestDoCli(TestCase):
 
         self.assertEqual(str(ctx.exception), str(exception))
 
-    @patch("samcli.commands.build.command.BuildContext")
-    @patch("samcli.commands.build.command.ApplicationBuilder")
+    @patch("samcli.commands.build.build_context.BuildContext")
+    @patch("samcli.lib.build.app_builder.ApplicationBuilder")
     def test_must_catch_function_not_found_exception(self, ApplicationBuilderMock, BuildContextMock):
         ctx_mock = Mock()
         BuildContextMock.return_value.__enter__ = Mock()

--- a/tests/unit/commands/init/test_cli.py
+++ b/tests/unit/commands/init/test_cli.py
@@ -16,7 +16,7 @@ class TestCli(TestCase):
         self.name = "testing project"
         self.no_input = False
 
-    @patch("samcli.commands.init.generate_project")
+    @patch("samcli.local.init.generate_project")
     def test_init_cli(self, generate_project_patch):
         # GIVEN generate_project successfully created a project
         # WHEN a project name has been passed
@@ -35,7 +35,7 @@ class TestCli(TestCase):
             self.location, self.runtime, self.dependency_manager, self.output_dir, self.name, self.no_input
         )
 
-    @patch("samcli.commands.init.generate_project")
+    @patch("samcli.local.init.generate_project")
     def test_init_cli_generate_project_fails(self, generate_project_patch):
 
         # GIVEN generate_project fails to create a project

--- a/tests/unit/commands/local/invoke/test_cli.py
+++ b/tests/unit/commands/local/invoke/test_cli.py
@@ -39,7 +39,7 @@ class TestCli(TestCase):
         self.region_name = "region"
         self.profile = "profile"
 
-    @patch("samcli.commands.local.invoke.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_cli_must_setup_context_and_invoke(self, get_event_mock, InvokeContextMock):
         event_data = "data"
@@ -95,7 +95,7 @@ class TestCli(TestCase):
         )
         get_event_mock.assert_called_with(self.eventfile)
 
-    @patch("samcli.commands.local.invoke.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_cli_must_invoke_with_no_event(self, get_event_mock, InvokeContextMock):
         self.no_event = True
@@ -149,7 +149,7 @@ class TestCli(TestCase):
         )
         get_event_mock.assert_not_called()
 
-    @patch("samcli.commands.local.invoke.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_no_event_and_event(self, get_event_mock, InvokeContextMock):
         self.no_event = True
@@ -188,7 +188,7 @@ class TestCli(TestCase):
             param(DockerImagePullFailedException("Failed to pull image"), "Failed to pull image"),
         ]
     )
-    @patch("samcli.commands.local.invoke.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_function_not_found(
         self, side_effect_exception, expected_exectpion_message, get_event_mock, InvokeContextMock
@@ -240,7 +240,7 @@ class TestCli(TestCase):
             (DebuggingNotSupported("Debugging not supported"), "Debugging not supported"),
         ]
     )
-    @patch("samcli.commands.local.invoke.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_invalid_sam_template(
         self, exeception_to_raise, execption_message, get_event_mock, InvokeContextMock
@@ -278,7 +278,7 @@ class TestCli(TestCase):
         msg = str(ex_ctx.exception)
         self.assertEqual(msg, execption_message)
 
-    @patch("samcli.commands.local.invoke.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     @patch("samcli.commands.local.invoke.cli._get_event")
     def test_must_raise_user_exception_on_invalid_env_vars(self, get_event_mock, InvokeContextMock):
         event_data = "data"

--- a/tests/unit/commands/local/start_api/test_cli.py
+++ b/tests/unit/commands/local/start_api/test_cli.py
@@ -40,8 +40,8 @@ class TestCli(TestCase):
         self.port = 123
         self.static_dir = "staticdir"
 
-    @patch("samcli.commands.local.start_api.cli.InvokeContext")
-    @patch("samcli.commands.local.start_api.cli.LocalApiService")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
+    @patch("samcli.commands.local.lib.local_api_service.LocalApiService")
     def test_cli_must_setup_context_and_start_service(self, local_api_service_mock, invoke_context_mock):
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
@@ -76,8 +76,8 @@ class TestCli(TestCase):
 
         service_mock.start.assert_called_with()
 
-    @patch("samcli.commands.local.start_api.cli.InvokeContext")
-    @patch("samcli.commands.local.start_api.cli.LocalApiService")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
+    @patch("samcli.commands.local.lib.local_api_service.LocalApiService")
     def test_must_raise_if_no_api_defined(self, local_api_service_mock, invoke_context_mock):
 
         # Mock the __enter__ method to return a object inside a context manager
@@ -105,7 +105,7 @@ class TestCli(TestCase):
             (DebuggingNotSupported("Debugging not supported"), "Debugging not supported"),
         ]
     )
-    @patch("samcli.commands.local.start_api.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     def test_must_raise_user_exception_on_invalid_sam_template(
         self, exeception_to_raise, execption_message, invoke_context_mock
     ):
@@ -119,7 +119,7 @@ class TestCli(TestCase):
         expected = execption_message
         self.assertEqual(msg, expected)
 
-    @patch("samcli.commands.local.start_api.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     def test_must_raise_user_exception_on_invalid_env_vars(self, invoke_context_mock):
         invoke_context_mock.side_effect = OverridesNotWellDefinedError("bad env vars")
 

--- a/tests/unit/commands/local/start_lambda/test_cli.py
+++ b/tests/unit/commands/local/start_lambda/test_cli.py
@@ -35,8 +35,8 @@ class TestCli(TestCase):
         self.host = "host"
         self.port = 123
 
-    @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
-    @patch("samcli.commands.local.start_lambda.cli.LocalLambdaService")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
+    @patch("samcli.commands.local.lib.local_lambda_service.LocalLambdaService")
     def test_cli_must_setup_context_and_start_service(self, local_lambda_service_mock, invoke_context_mock):
         # Mock the __enter__ method to return a object inside a context manager
         context_mock = Mock()
@@ -79,7 +79,7 @@ class TestCli(TestCase):
             (DebuggingNotSupported("Debugging not supported"), "Debugging not supported"),
         ]
     )
-    @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     def test_must_raise_user_exception_on_invalid_sam_template(
         self, exeception_to_raise, execption_message, invoke_context_mock
     ):
@@ -92,7 +92,7 @@ class TestCli(TestCase):
         expected = execption_message
         self.assertEqual(msg, expected)
 
-    @patch("samcli.commands.local.start_lambda.cli.InvokeContext")
+    @patch("samcli.commands.local.cli_common.invoke_context.InvokeContext")
     def test_must_raise_user_exception_on_invalid_env_vars(self, invoke_context_mock):
         invoke_context_mock.side_effect = OverridesNotWellDefinedError("bad env vars")
 

--- a/tests/unit/commands/logs/test_command.py
+++ b/tests/unit/commands/logs/test_command.py
@@ -14,7 +14,7 @@ class TestLogsCliCommand(TestCase):
         self.end_time = "end"
 
     @patch("samcli.commands.logs.command.click")
-    @patch("samcli.commands.logs.command.LogsCommandContext")
+    @patch("samcli.commands.logs.logs_context.LogsCommandContext")
     def test_without_tail(self, LogsCommandContextMock, click_mock):
         tailing = False
         events_iterable = [1, 2, 3]
@@ -48,7 +48,7 @@ class TestLogsCliCommand(TestCase):
         click_mock.echo.assert_has_calls([call(v, nl=False) for v in formatted_events])
 
     @patch("samcli.commands.logs.command.click")
-    @patch("samcli.commands.logs.command.LogsCommandContext")
+    @patch("samcli.commands.logs.logs_context.LogsCommandContext")
     def test_with_tailing(self, LogsCommandContextMock, click_mock):
         tailing = True
         events_iterable = [1, 2, 3]

--- a/tests/unit/commands/publish/test_command.py
+++ b/tests/unit/commands/publish/test_command.py
@@ -34,7 +34,7 @@ class TestCli(TestCase):
         click_mock.secho.assert_called_with("Publish Failed", fg="red")
 
     @patch("samcli.commands.publish.command.get_template_data", Mock(return_value={}))
-    @patch("samcli.commands.publish.command.publish_application")
+    @patch("serverlessrepo.publish_application")
     @patch("samcli.commands.publish.command.click")
     def test_must_raise_if_serverlessrepo_error(self, click_mock, publish_application_mock):
         publish_application_mock.side_effect = ServerlessRepoError()
@@ -44,7 +44,7 @@ class TestCli(TestCase):
         click_mock.secho.assert_called_with("Publish Failed", fg="red")
 
     @patch("samcli.commands.publish.command.get_template_data", Mock(return_value={}))
-    @patch("samcli.commands.publish.command.publish_application")
+    @patch("serverlessrepo.publish_application")
     @patch("samcli.commands.publish.command.click")
     def test_must_raise_if_invalid_S3_uri_error(self, click_mock, publish_application_mock):
         publish_application_mock.side_effect = InvalidS3UriError(message="")
@@ -56,7 +56,7 @@ class TestCli(TestCase):
         click_mock.secho.assert_called_with("Publish Failed", fg="red")
 
     @patch("samcli.commands.publish.command.get_template_data", Mock(return_value={}))
-    @patch("samcli.commands.publish.command.publish_application")
+    @patch("serverlessrepo.publish_application")
     @patch("samcli.commands.publish.command.click")
     def test_must_succeed_to_create_application(self, click_mock, publish_application_mock):
         publish_application_mock.return_value = {
@@ -78,7 +78,7 @@ class TestCli(TestCase):
         )
 
     @patch("samcli.commands.publish.command.get_template_data", Mock(return_value={}))
-    @patch("samcli.commands.publish.command.publish_application")
+    @patch("serverlessrepo.publish_application")
     @patch("samcli.commands.publish.command.click")
     def test_must_succeed_to_update_application(self, click_mock, publish_application_mock):
         publish_application_mock.return_value = {
@@ -100,7 +100,7 @@ class TestCli(TestCase):
         )
 
     @patch("samcli.commands.publish.command.get_template_data", Mock(return_value={}))
-    @patch("samcli.commands.publish.command.publish_application")
+    @patch("serverlessrepo.publish_application")
     @patch("samcli.commands.publish.command.boto3")
     @patch("samcli.commands.publish.command.click")
     def test_print_console_link_if_context_region_not_set(self, click_mock, boto3_mock, publish_application_mock):
@@ -120,7 +120,7 @@ class TestCli(TestCase):
         click_mock.secho.assert_called_with(expected_link, fg="yellow")
 
     @patch("samcli.commands.publish.command.get_template_data")
-    @patch("samcli.commands.publish.command.publish_application")
+    @patch("serverlessrepo.publish_application")
     def test_must_use_template_semantic_version(self, publish_application_mock, get_template_data_mock):
         template_data = {METADATA: {SERVERLESS_REPO_APPLICATION: {SEMANTIC_VERSION: "0.1"}}}
         get_template_data_mock.return_value = template_data
@@ -129,7 +129,7 @@ class TestCli(TestCase):
         publish_application_mock.assert_called_with(template_data)
 
     @patch("samcli.commands.publish.command.get_template_data")
-    @patch("samcli.commands.publish.command.publish_application")
+    @patch("serverlessrepo.publish_application")
     def test_must_override_template_semantic_version(self, publish_application_mock, get_template_data_mock):
         template_data = {METADATA: {SERVERLESS_REPO_APPLICATION: {SEMANTIC_VERSION: "0.1"}}}
         get_template_data_mock.return_value = template_data

--- a/tests/unit/commands/validate/test_cli.py
+++ b/tests/unit/commands/validate/test_cli.py
@@ -20,7 +20,7 @@ class TestValidateCli(TestCase):
         with self.assertRaises(SamTemplateNotFoundException):
             _read_sam_file(template_path)
 
-    @patch("samcli.commands.validate.validate.yaml_parse")
+    @patch("samcli.yamlhelper.yaml_parse")
     @patch("samcli.commands.validate.validate.click")
     @patch("samcli.commands.validate.validate.os.path.exists")
     def test_file_parsed(self, path_exists_patch, click_patch, yaml_parse_patch):
@@ -34,7 +34,7 @@ class TestValidateCli(TestCase):
 
         self.assertEqual(actual_template, {"a": "b"})
 
-    @patch("samcli.commands.validate.validate.SamTemplateValidator")
+    @patch("samcli.commands.validate.lib.sam_template_validator.SamTemplateValidator")
     @patch("samcli.commands.validate.validate.click")
     @patch("samcli.commands.validate.validate._read_sam_file")
     def test_template_fails_validation(self, read_sam_file_patch, click_patch, template_valiadator):
@@ -48,7 +48,7 @@ class TestValidateCli(TestCase):
         with self.assertRaises(InvalidSamTemplateException):
             do_cli(ctx=None, template=template_path)
 
-    @patch("samcli.commands.validate.validate.SamTemplateValidator")
+    @patch("samcli.commands.validate.lib.sam_template_validator.SamTemplateValidator")
     @patch("samcli.commands.validate.validate.click")
     @patch("samcli.commands.validate.validate._read_sam_file")
     def test_no_credentials_provided(self, read_sam_file_patch, click_patch, template_valiadator):
@@ -62,7 +62,7 @@ class TestValidateCli(TestCase):
         with self.assertRaises(UserException):
             do_cli(ctx=None, template=template_path)
 
-    @patch("samcli.commands.validate.validate.SamTemplateValidator")
+    @patch("samcli.commands.validate.lib.sam_template_validator.SamTemplateValidator")
     @patch("samcli.commands.validate.validate.click")
     @patch("samcli.commands.validate.validate._read_sam_file")
     def test_template_passes_validation(self, read_sam_file_patch, click_patch, template_valiadator):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

`sam --help` is a very slow operation. Testing on my machine took about ~1.25s. Comparing this the `sam build --help`, help text was displayed in ~.7s. The main reason for this is due to how python loads modules and click. In order for click to know the help text of each command, click calls `list_commands` and then `get_command` for each command in the list. Our `get_command` implementation will then import the command module and return the `cli` method. This means a `sam --help` will end up loading the entire `samcli` module (or very close to it), while `sam build --help` will only load the 'build' related modules. 

This PR moves, most, of the command module loading from the global package/module scope (file), to specific methods. This reduces both `sam --help` and `sam build --help` to .63s and .6s respectfully, a roughly 50% reduction on `sam --help`. 

There could be better ways to lazy load these modules but not currently aware. Since this only moves the imports of some modules to the call of `cli` method, execution of the commands won't be impacted. This is due to the same loading that was being done in the global scope is now just done a function execution instead. This does not change how we load any of the 'library' code within the cli, only the parts of the code base that are the entry point for a given command (ones annotated with parameters/options/etc).

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
