### PR TITLE
Adds SageMaker Ground Truth Lambda events

### DIFF
--- a/samcli/commands/local/lib/generated_sample_events/event-mapping.json
+++ b/samcli/commands/local/lib/generated_sample_events/event-mapping.json
@@ -863,13 +863,10 @@
         "account-id": {
           "default": "123456789012"
         },
-        "bucket": {
-          "default": "sagemakerexample"
+        "source-ref": {
+          "default": "s3://sagemakerexample/object_to_annotate.jpg"
         },
-	"data_object_key": {
-          "default": "object_to_annotate.jpg"
-	},
-	"labeling_job_name": {
+	"labeling-job-name": {
           "default": "example-job"
 	}
       }
@@ -887,19 +884,19 @@
         "account-id": {
           "default": "123456789012"
         },
-	"labeling_job_name": {
+	"labeling-job-name": {
           "default": "example-job"
 	},
-	"label_attribute_name": {
+	"label-attribute-name": {
           "default": "example-attribute"
 	},
-        "bucket": {
-          "default": "sagemakerexample"
+        "s3-output-path": {
+          "default": "s3://sagemakerexample/output"
         },
-	"execution_role": {
+	"execution-role": {
           "default": "sagemaker-role"
 	},
-	"iteration_object_timestamp": {
+	"iteration-object-timestamp": {
           "default": "iteration-1/0/2019-09-06_18:35:03"
 	}
       }

--- a/samcli/commands/local/lib/generated_sample_events/event-mapping.json
+++ b/samcli/commands/local/lib/generated_sample_events/event-mapping.json
@@ -849,6 +849,62 @@
       }
     }
   },
+  "sagemaker": {
+    "ground-truth-pre-human": {
+      "filename": "PreHumanTask",
+      "help": "Generates a SageMaker Ground Truth PreHumanTask request",
+      "tags": {
+        "region": {
+          "default": "us-east-1"
+        },
+        "partition": {
+          "default": "aws"
+        },
+        "account-id": {
+          "default": "123456789012"
+        },
+        "bucket": {
+          "default": "sagemakerexample"
+        },
+	"data_object_key": {
+          "default": "object_to_annotate.jpg"
+	},
+	"labeling_job_name": {
+          "default": "example-job"
+	}
+      }
+    },
+    "ground-truth-annotation-consolidation": {
+      "filename": "AnnotationConsolidation",
+      "help": "Generates a SageMaker Ground Truth AnnotationConsolidation request",
+      "tags": {
+        "region": {
+          "default": "us-east-1"
+        },
+        "partition": {
+          "default": "aws"
+        },
+        "account-id": {
+          "default": "123456789012"
+        },
+	"labeling_job_name": {
+          "default": "example-job"
+	},
+	"label_attribute_name": {
+          "default": "example-attribute"
+	},
+        "bucket": {
+          "default": "sagemakerexample"
+        },
+	"execution_role": {
+          "default": "sagemaker-role"
+	},
+	"iteration_object_timestamp": {
+          "default": "iteration-1/0/2019-09-06_18:35:03"
+	}
+      }
+    }
+  },
   "ses": {
     "email-receiving": {
       "filename": "SesEmailReceiving",

--- a/samcli/commands/local/lib/generated_sample_events/events/sagemaker/AnnotationConsolidation.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/sagemaker/AnnotationConsolidation.json
@@ -1,0 +1,9 @@
+{
+    "version": "2018-10-16",
+    "labelingJobArn": "arn:{{{partition}}}:sagemaker:{{{region}}}:{{{account_id}}}:labeling-job/{{{labeling_job_name}}}",
+    "labelAttributeName": "{{{label_attribute_name}}}",
+    "roleArn" : "aws:{{{partition}}}:iam::{{account_id}}:role/{{{execution_role}}}",
+    "payload": {
+        "s3Uri": "s3://{{{bucket}}}/{{{labeling_job_name}}}/annotations/worker_response/{{{iteration_object_timestamp}}}.json"
+    }
+ }

--- a/samcli/commands/local/lib/generated_sample_events/events/sagemaker/AnnotationConsolidation.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/sagemaker/AnnotationConsolidation.json
@@ -4,6 +4,6 @@
     "labelAttributeName": "{{{label_attribute_name}}}",
     "roleArn" : "aws:{{{partition}}}:iam::{{account_id}}:role/{{{execution_role}}}",
     "payload": {
-        "s3Uri": "s3://{{{bucket}}}/{{{labeling_job_name}}}/annotations/worker_response/{{{iteration_object_timestamp}}}.json"
+        "s3Uri": "{{{s3_output_path}}}/{{{labeling_job_name}}}/annotations/worker_response/{{{iteration_object_timestamp}}}.json"
     }
  }

--- a/samcli/commands/local/lib/generated_sample_events/events/sagemaker/PreHumanTask.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/sagemaker/PreHumanTask.json
@@ -2,6 +2,6 @@
     "version": "2018-10-16",
     "labelingJobArn": "arn:{{{partition}}}:sagemaker:{{{region}}}:{{{account_id}}}:labeling-job/{{{labeling_job_name}}}",
     "dataObject" : {
-        "source-ref": "s3://{{{bucket}}}/{{{data_object_key}}}"
+        "source-ref": "{{{source_ref}}}"
     }
 }

--- a/samcli/commands/local/lib/generated_sample_events/events/sagemaker/PreHumanTask.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/sagemaker/PreHumanTask.json
@@ -1,0 +1,7 @@
+{
+    "version": "2018-10-16",
+    "labelingJobArn": "arn:{{{partition}}}:sagemaker:{{{region}}}:{{{account_id}}}:labeling-job/{{{labeling_job_name}}}",
+    "dataObject" : {
+        "source-ref": "s3://{{{bucket}}}/{{{data_object_key}}}"
+    }
+}


### PR DESCRIPTION
*Description of changes:*

Adds events for Lambda functions for SageMaker Ground Truth for these Lambda functions in the [CreateLabelingJob operation](https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateLabelingJob.html):

1. PreHumanTask
2. AnnotationConsolidation

*Checklist:*

- [n/a] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [n/a] Write unit tests
- [n/a] Write/update functional tests
- [n/a] Write/update integration tests
- [x] `make pr` passes
- [n/a] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
