### PR TITLE
fix: options endpoint does not invoke lambda (#1434)

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -173,7 +173,7 @@ class LocalApigwService(BaseLocalService):
         cors_headers = Cors.cors_to_headers(self.api.cors)
 
         method, _ = self.get_request_methods_endpoints(request)
-        if method == "OPTIONS":
+        if method == "OPTIONS" and method not in route.methods:
             headers = Headers(cors_headers)
             return self.service_response("", headers, 200)
 


### PR DESCRIPTION
*Issue #, if available:* #1434

*Description of changes:* PR #1242 introduced a bug that means lambdas do not get called for OPTIONS requests, even if configured.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
