### PR TITLE
fix: Inline data that was defined with AWS::Include

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,4 +17,4 @@ backports.tempfile==1.0
 pytest-xdist==1.20.0
 pytest-forked==1.0.2
 pytest-timeout==1.3.3
-pytest-rerunfailures==7.0
+pytest-rerunfailures==5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,3 +17,4 @@ backports.tempfile==1.0
 pytest-xdist==1.20.0
 pytest-forked==1.0.2
 pytest-timeout==1.3.3
+pytest-rerunfailures==7.0

--- a/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
+++ b/samcli/lib/intrinsic_resolver/intrinsic_property_resolver.py
@@ -22,6 +22,7 @@ from samcli.lib.intrinsic_resolver.invalid_intrinsic_validation import (
     verify_all_list_intrinsic_type,
 )
 from samcli.lib.intrinsic_resolver.invalid_intrinsic_exception import InvalidIntrinsicException, InvalidSymbolException
+from samcli.commands._utils.template import get_template_data
 
 LOG = logging.getLogger(__name__)
 
@@ -562,7 +563,9 @@ class IntrinsicResolver(object):
         )
 
         location = self.intrinsic_property_resolver(parameters.get("Location"), ignore_errors)
-        return location
+        location_data = get_template_data(location)
+
+        return location_data
 
     def handle_fn_import_value(self, intrinsic_value, ignore_errors):
         """

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -991,3 +991,16 @@ class TestServerlessApiGateway(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+
+
+class TestSwaggerIncludedFromSeparateFile(StartApiIntegBaseClass):
+    template_path = "/testdata/start_api/template-with-included-swagger.yaml"
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    def test_swagger_was_tranformed_and_api_is_reachable(self):
+        response = requests.patch(self.url + "/anyandall")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -19,6 +19,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_same_endpoint(self):
         """
@@ -44,6 +45,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
             self.assertEqual(result.status_code, 200)
             self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_different_endpoints(self):
         """
@@ -83,6 +85,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_invalid_http_verb_for_endpoint(self):
         response = requests.get(self.url + "/id", timeout=300)
@@ -90,6 +93,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {"message": "Missing Authentication Token"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_invalid_response_from_lambda(self):
         response = requests.get(self.url + "/invalidresponsereturned", timeout=300)
@@ -97,6 +101,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_invalid_json_response_from_lambda(self):
         response = requests.get(self.url + "/invalidresponsehash", timeout=300)
@@ -104,6 +109,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_timeout(self):
         pass
@@ -122,6 +128,7 @@ class TestService(StartApiIntegBaseClass):
     def test_static_directory(self):
         pass
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_calling_proxy_endpoint(self):
         response = requests.get(self.url + "/proxypath/this/is/some/path", timeout=300)
@@ -129,6 +136,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_implicit_api(self):
         """
@@ -139,6 +147,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_implicit_api(self):
         """
@@ -149,6 +158,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_implicit_api(self):
         """
@@ -159,6 +169,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_implicit_api(self):
         """
@@ -168,6 +179,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_implicit_api(self):
         """
@@ -178,6 +190,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_implicit_api(self):
         """
@@ -187,6 +200,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_implicit_api(self):
         """
@@ -205,6 +219,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
@@ -215,6 +230,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
@@ -225,6 +241,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
@@ -235,6 +252,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
@@ -244,6 +262,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
@@ -254,6 +273,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
@@ -263,6 +283,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
@@ -273,6 +294,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/nofunctionfound", timeout=300)
@@ -280,6 +302,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_with_no_api_event_is_reachable(self):
         response = requests.get(self.url + "/functionwithnoapievent", timeout=300)
@@ -287,6 +310,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/nonserverlessfunction", timeout=300)
@@ -294,6 +318,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
         """
@@ -308,6 +333,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
         """
@@ -329,6 +355,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
@@ -339,6 +366,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
@@ -349,6 +377,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
@@ -359,6 +388,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
@@ -368,6 +398,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
@@ -378,6 +409,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
@@ -387,6 +419,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
@@ -397,6 +430,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/nofunctionfound", timeout=300)
@@ -404,6 +438,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/nonserverlessfunction", timeout=300)
@@ -411,6 +446,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
         """
@@ -425,6 +461,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
         """
@@ -450,6 +487,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_multiple_headers_response(self):
         response = requests.get(self.url + "/multipleheaders", timeout=300)
@@ -458,6 +496,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
         self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_multiple_headers_overrides_headers_response(self):
         response = requests.get(self.url + "/multipleheadersoverridesheaders", timeout=300)
@@ -466,6 +505,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
         self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2, Custom")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
         """
@@ -479,6 +519,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, expected)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_header_content_type(self):
         """
@@ -490,6 +531,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.content.decode("utf-8"), "no data")
         self.assertEqual(response.headers.get("Content-Type"), "application/json")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_status_code(self):
         """
@@ -501,6 +543,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_string_status_code(self):
         """
@@ -510,6 +553,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_body(self):
         """
@@ -520,6 +564,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "no data")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_writing_to_stdout(self):
         response = requests.get(self.url + "/writetostdout", timeout=300)
@@ -527,6 +572,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_writing_to_stderr(self):
         response = requests.get(self.url + "/writetostderr", timeout=300)
@@ -534,6 +580,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_integer_body(self):
         response = requests.get(self.url + "/echo_integer_body", timeout=300)
@@ -553,6 +600,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
         """
@@ -567,6 +615,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_form_data(self):
         """
@@ -586,6 +635,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded")
         self.assertEqual(response_data.get("body"), "key=value")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_to_an_endpoint_with_two_different_handlers(self):
         response = requests.get(self.url + "/echoeventbody", timeout=300)
@@ -596,6 +646,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("handler"), "echo_event_handler_2")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_multi_value_headers(self):
         response = requests.get(
@@ -613,6 +664,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
             response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded, image/gif"
         )
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_query_params(self):
         """
@@ -627,6 +679,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("queryStringParameters"), {"key": "value"})
         self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value"]})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_list_of_query_params(self):
         """
@@ -641,6 +694,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("queryStringParameters"), {"key": "value2"})
         self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value", "value2"]})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_path_params(self):
         """
@@ -654,6 +708,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("pathParameters"), {"id": "4"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_many_path_params(self):
         """
@@ -667,6 +722,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("pathParameters"), {"id": "4", "user": "jacob"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_forward_headers_are_added_to_event(self):
         """
@@ -692,6 +748,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_stage_name(self):
         response = requests.get(self.url + "/echoeventbody", timeout=300)
@@ -702,6 +759,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Prod")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_global_stage_variables(self):
         response = requests.get(self.url + "/echoeventbody", timeout=300)
@@ -723,6 +781,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_swagger_stage_name(self):
         response = requests.get(self.url + "/echoeventbody", timeout=300)
@@ -732,6 +791,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
         response_data = response.json()
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "dev")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_swagger_stage_variable(self):
         response = requests.get(self.url + "/echoeventbody", timeout=300)
@@ -753,6 +813,7 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_cors_swagger_options(self):
         """
@@ -778,6 +839,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_cors_global(self):
         """
@@ -791,6 +853,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), ",".join(sorted(Route.ANY_HTTP_METHODS)))
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), None)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_cors_global_get(self):
         """
@@ -817,6 +880,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_stage_name(self):
         response = requests.get(self.url + "/echoeventbody", timeout=300)
@@ -826,6 +890,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
         response_data = response.json()
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Dev")
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_global_stage_variables(self):
         response = requests.get(self.url + "/echoeventbody", timeout=300)
@@ -844,6 +909,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
@@ -854,6 +920,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
@@ -864,6 +931,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
@@ -874,6 +942,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
@@ -883,6 +952,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
@@ -893,6 +963,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
@@ -902,6 +973,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
@@ -912,6 +984,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/root/nofunctionfound", timeout=300)
@@ -919,6 +992,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/root/nonserverlessfunction", timeout=300)
@@ -926,6 +1000,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
         """
@@ -940,6 +1015,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
         """
@@ -953,6 +1029,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, expected)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_proxy_response(self):
         """
@@ -970,6 +1047,7 @@ class TestCDKApiGateway(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_with_cdk(self):
         """
@@ -987,6 +1065,7 @@ class TestServerlessApiGateway(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_with_serverless(self):
         """
@@ -1004,6 +1083,8 @@ class TestSwaggerIncludedFromSeparateFile(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
     def test_swagger_was_tranformed_and_api_is_reachable(self):
         response = requests.patch(self.url + "/anyandall", timeout=300)
 

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -573,7 +573,10 @@ class TestServiceRequests(StartApiIntegBaseClass):
         Form-encoded data should be put into the Event to Lambda
         """
         response = requests.post(
-            self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded"}, data="key=value", timeout=300
+            self.url + "/echoeventbody",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data="key=value",
+            timeout=300,
         )
 
         self.assertEqual(response.status_code, 200)
@@ -596,7 +599,9 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_multi_value_headers(self):
         response = requests.get(
-            self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded, image/gif"}, timeout=300
+            self.url + "/echoeventbody",
+            headers={"Content-Type": "application/x-www-form-urlencoded, image/gif"},
+            timeout=300,
         )
 
         self.assertEqual(response.status_code, 200)

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -85,21 +85,21 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_invalid_http_verb_for_endpoint(self):
-        response = requests.get(self.url + "/id")
+        response = requests.get(self.url + "/id", timeout=300)
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {"message": "Missing Authentication Token"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_invalid_response_from_lambda(self):
-        response = requests.get(self.url + "/invalidresponsereturned")
+        response = requests.get(self.url + "/invalidresponsereturned", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_invalid_json_response_from_lambda(self):
-        response = requests.get(self.url + "/invalidresponsehash")
+        response = requests.get(self.url + "/invalidresponsehash", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
@@ -124,7 +124,7 @@ class TestService(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_calling_proxy_endpoint(self):
-        response = requests.get(self.url + "/proxypath/this/is/some/path")
+        response = requests.get(self.url + "/proxypath/this/is/some/path", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -134,7 +134,7 @@ class TestService(StartApiIntegBaseClass):
         """
         Get Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.get(self.url + "/anyandall")
+        response = requests.get(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -144,7 +144,7 @@ class TestService(StartApiIntegBaseClass):
         """
         Post Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.post(self.url + "/anyandall", json={})
+        response = requests.post(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -154,7 +154,7 @@ class TestService(StartApiIntegBaseClass):
         """
         Put Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.put(self.url + "/anyandall", json={})
+        response = requests.put(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -164,7 +164,7 @@ class TestService(StartApiIntegBaseClass):
         """
         Head Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.head(self.url + "/anyandall")
+        response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -173,7 +173,7 @@ class TestService(StartApiIntegBaseClass):
         """
         Delete Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.delete(self.url + "/anyandall")
+        response = requests.delete(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -183,7 +183,7 @@ class TestService(StartApiIntegBaseClass):
         """
         Options Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.options(self.url + "/anyandall")
+        response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -192,7 +192,7 @@ class TestService(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
         """
-        response = requests.patch(self.url + "/anyandall")
+        response = requests.patch(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -210,7 +210,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.get(self.url + "/anyandall")
+        response = requests.get(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -220,7 +220,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.post(self.url + "/anyandall", json={})
+        response = requests.post(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -230,7 +230,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.put(self.url + "/anyandall", json={})
+        response = requests.put(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -240,7 +240,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.head(self.url + "/anyandall")
+        response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -249,7 +249,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.delete(self.url + "/anyandall")
+        response = requests.delete(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -259,7 +259,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.options(self.url + "/anyandall")
+        response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -268,28 +268,28 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.patch(self.url + "/anyandall")
+        response = requests.patch(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_not_defined_in_template(self):
-        response = requests.get(self.url + "/nofunctionfound")
+        response = requests.get(self.url + "/nofunctionfound", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_with_no_api_event_is_reachable(self):
-        response = requests.get(self.url + "/functionwithnoapievent")
+        response = requests.get(self.url + "/functionwithnoapievent", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
-        response = requests.get(self.url + "/nonserverlessfunction")
+        response = requests.get(self.url + "/nonserverlessfunction", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -301,7 +301,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
-            self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data
+            self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
         )
 
         self.assertEqual(response.status_code, 200)
@@ -315,7 +315,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         """
         expected = self.get_binary_data(self.binary_data_file)
 
-        response = requests.get(self.url + "/base64response")
+        response = requests.get(self.url + "/base64response", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
@@ -334,7 +334,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.get(self.url + "/anyandall")
+        response = requests.get(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -344,7 +344,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.post(self.url + "/anyandall", json={})
+        response = requests.post(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -354,7 +354,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.put(self.url + "/anyandall", json={})
+        response = requests.put(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -364,7 +364,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.head(self.url + "/anyandall")
+        response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -373,7 +373,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.delete(self.url + "/anyandall")
+        response = requests.delete(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -383,7 +383,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.options(self.url + "/anyandall")
+        response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -392,21 +392,21 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.patch(self.url + "/anyandall")
+        response = requests.patch(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_not_defined_in_template(self):
-        response = requests.get(self.url + "/nofunctionfound")
+        response = requests.get(self.url + "/nofunctionfound", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
-        response = requests.get(self.url + "/nonserverlessfunction")
+        response = requests.get(self.url + "/nonserverlessfunction", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -418,7 +418,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
-            self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data
+            self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
         )
 
         self.assertEqual(response.status_code, 200)
@@ -432,7 +432,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         """
         expected = self.get_binary_data(self.binary_data_file)
 
-        response = requests.get(self.url + "/base64response")
+        response = requests.get(self.url + "/base64response", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
@@ -452,7 +452,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_multiple_headers_response(self):
-        response = requests.get(self.url + "/multipleheaders")
+        response = requests.get(self.url + "/multipleheaders", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
@@ -460,7 +460,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_multiple_headers_overrides_headers_response(self):
-        response = requests.get(self.url + "/multipleheadersoverridesheaders")
+        response = requests.get(self.url + "/multipleheadersoverridesheaders", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
@@ -473,7 +473,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         """
         expected = self.get_binary_data(self.binary_data_file)
 
-        response = requests.get(self.url + "/base64response")
+        response = requests.get(self.url + "/base64response", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
@@ -484,7 +484,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         """
         Test that if no ContentType is given the default is "application/json"
         """
-        response = requests.get(self.url + "/onlysetstatuscode")
+        response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "no data")
@@ -496,7 +496,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         Test that if no status_code is given, the status code is 200
         :return:
         """
-        response = requests.get(self.url + "/onlysetbody")
+        response = requests.get(self.url + "/onlysetbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -506,7 +506,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         """
         Test that an integer-string can be returned as the status code
         """
-        response = requests.get(self.url + "/stringstatuscode")
+        response = requests.get(self.url + "/stringstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -515,28 +515,28 @@ class TestServiceResponses(StartApiIntegBaseClass):
         """
         Test that if no body is given, the response is 'no data'
         """
-        response = requests.get(self.url + "/onlysetstatuscode")
+        response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "no data")
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_writing_to_stdout(self):
-        response = requests.get(self.url + "/writetostdout")
+        response = requests.get(self.url + "/writetostdout", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_writing_to_stderr(self):
-        response = requests.get(self.url + "/writetostderr")
+        response = requests.get(self.url + "/writetostderr", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_integer_body(self):
-        response = requests.get(self.url + "/echo_integer_body")
+        response = requests.get(self.url + "/echo_integer_body", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "42")
@@ -560,7 +560,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
-            self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data
+            self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
         )
 
         self.assertEqual(response.status_code, 200)
@@ -573,7 +573,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         Form-encoded data should be put into the Event to Lambda
         """
         response = requests.post(
-            self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded"}, data="key=value"
+            self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded"}, data="key=value", timeout=300
         )
 
         self.assertEqual(response.status_code, 200)
@@ -585,7 +585,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_to_an_endpoint_with_two_different_handlers(self):
-        response = requests.get(self.url + "/echoeventbody")
+        response = requests.get(self.url + "/echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -596,7 +596,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_multi_value_headers(self):
         response = requests.get(
-            self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded, image/gif"}
+            self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded, image/gif"}, timeout=300
         )
 
         self.assertEqual(response.status_code, 200)
@@ -613,7 +613,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         Query params given should be put into the Event to Lambda
         """
-        response = requests.get(self.url + "/id/4", params={"key": "value"})
+        response = requests.get(self.url + "/id/4", params={"key": "value"}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -627,7 +627,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         Query params given should be put into the Event to Lambda
         """
-        response = requests.get(self.url + "/id/4", params={"key": ["value", "value2"]})
+        response = requests.get(self.url + "/id/4", params={"key": ["value", "value2"]}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -641,7 +641,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         Path Parameters given should be put into the Event to Lambda
         """
-        response = requests.get(self.url + "/id/4")
+        response = requests.get(self.url + "/id/4", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -654,7 +654,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         Path Parameters given should be put into the Event to Lambda
         """
-        response = requests.get(self.url + "/id/4/user/jacob")
+        response = requests.get(self.url + "/id/4/user/jacob", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -667,7 +667,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         """
         Test the Forwarding Headers exist in the Api Event to Lambda
         """
-        response = requests.get(self.url + "/id/4")
+        response = requests.get(self.url + "/id/4", timeout=300)
 
         response_data = response.json()
 
@@ -689,7 +689,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_stage_name(self):
-        response = requests.get(self.url + "/echoeventbody")
+        response = requests.get(self.url + "/echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -699,7 +699,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_global_stage_variables(self):
-        response = requests.get(self.url + "/echoeventbody")
+        response = requests.get(self.url + "/echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -720,7 +720,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_swagger_stage_name(self):
-        response = requests.get(self.url + "/echoeventbody")
+        response = requests.get(self.url + "/echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -729,7 +729,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_swagger_stage_variable(self):
-        response = requests.get(self.url + "/echoeventbody")
+        response = requests.get(self.url + "/echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -753,7 +753,7 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
         """
         This tests that the Cors are added to option requests in the swagger template
         """
-        response = requests.options(self.url + "/echobase64eventbody")
+        response = requests.options(self.url + "/echobase64eventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -778,7 +778,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         """
         This tests that the Cors are added to options requests when the global property is set
         """
-        response = requests.options(self.url + "/echobase64eventbody")
+        response = requests.options(self.url + "/echobase64eventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
@@ -791,7 +791,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         """
         This tests that the Cors are added to post requests when the global property is set
         """
-        response = requests.get(self.url + "/onlysetstatuscode")
+        response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "no data")
@@ -814,7 +814,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_stage_name(self):
-        response = requests.get(self.url + "/echoeventbody")
+        response = requests.get(self.url + "/echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -823,7 +823,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_global_stage_variables(self):
-        response = requests.get(self.url + "/echoeventbody")
+        response = requests.get(self.url + "/echoeventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -844,7 +844,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.get(self.url + "/root/anyandall")
+        response = requests.get(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -854,7 +854,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.post(self.url + "/root/anyandall", json={})
+        response = requests.post(self.url + "/root/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -864,7 +864,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.put(self.url + "/root/anyandall", json={})
+        response = requests.put(self.url + "/root/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -874,7 +874,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.head(self.url + "/root/anyandall")
+        response = requests.head(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -883,7 +883,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.delete(self.url + "/root/anyandall")
+        response = requests.delete(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -893,7 +893,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.options(self.url + "/root/anyandall")
+        response = requests.options(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
 
@@ -902,21 +902,21 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.patch(self.url + "/root/anyandall")
+        response = requests.patch(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_function_not_defined_in_template(self):
-        response = requests.get(self.url + "/root/nofunctionfound")
+        response = requests.get(self.url + "/root/nofunctionfound", timeout=300)
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_lambda_function_resource_is_reachable(self):
-        response = requests.get(self.url + "/root/nonserverlessfunction")
+        response = requests.get(self.url + "/root/nonserverlessfunction", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -928,7 +928,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
-            self.url + "/root/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data
+            self.url + "/root/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
         )
 
         self.assertEqual(response.status_code, 200)
@@ -942,7 +942,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         expected = self.get_binary_data(self.binary_data_file)
 
-        response = requests.get(self.url + "/root/base64response")
+        response = requests.get(self.url + "/root/base64response", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
@@ -953,7 +953,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         """
         Binary data is returned correctly
         """
-        response = requests.get(self.url + "/root/v1/test")
+        response = requests.get(self.url + "/root/v1/test", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -970,7 +970,7 @@ class TestCDKApiGateway(StartApiIntegBaseClass):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.get(self.url + "/hello-world")
+        response = requests.get(self.url + "/hello-world", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -987,7 +987,7 @@ class TestServerlessApiGateway(StartApiIntegBaseClass):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
         """
-        response = requests.get(self.url + "/hello-world")
+        response = requests.get(self.url + "/hello-world", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
@@ -1000,7 +1000,7 @@ class TestSwaggerIncludedFromSeparateFile(StartApiIntegBaseClass):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
     def test_swagger_was_tranformed_and_api_is_reachable(self):
-        response = requests.patch(self.url + "/anyandall")
+        response = requests.patch(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})

--- a/tests/integration/testdata/start_api/swagger.yaml
+++ b/tests/integration/testdata/start_api/swagger.yaml
@@ -1,0 +1,13 @@
+swagger: "2.0"
+info:
+  title:
+    Ref: AWS::StackName
+paths:
+  "/anyandall":
+    x-amazon-apigateway-any-method:
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: aws_proxy
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyLambdaFunction.Arn}/invocations
+        responses: {}

--- a/tests/integration/testdata/start_api/template-with-included-swagger.yaml
+++ b/tests/integration/testdata/start_api/template-with-included-swagger.yaml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Api:
+    BinaryMediaTypes:
+      # These are equivalent to image/gif and image/png when deployed
+      - image~1png
+
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      Variables:
+        VarName: varValue
+      Cors:
+        AllowOrigin: "'*''"
+        AllowMethods: "'GET'"
+        AllowHeaders: "'origin, x-requested-with'"
+        MaxAge: "'510'"
+      DefinitionBody:
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: ./swagger.yaml
+
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.handler
+      Runtime: python3.6
+      CodeUri: .

--- a/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
+++ b/tests/unit/lib/intrinsic_resolver/test_intrinsic_resolver.py
@@ -8,6 +8,8 @@ except ImportError:
     from pathlib2 import Path
 from unittest import TestCase
 
+from mock import patch
+
 from parameterized import parameterized
 
 from samcli.lib.intrinsic_resolver.intrinsic_property_resolver import IntrinsicResolver
@@ -302,9 +304,12 @@ class TestFnTransform(TestCase):
             template={}, symbol_resolver=IntrinsicsSymbolTable(logical_id_translator=logical_id_translator)
         )
 
-    def test_basic_fn_transform(self):
+    @patch("samcli.lib.intrinsic_resolver.intrinsic_property_resolver.get_template_data")
+    def test_basic_fn_transform(self, get_template_data_patch):
         intrinsic = {"Fn::Transform": {"Name": "AWS::Include", "Parameters": {"Location": "test"}}}
+        get_template_data_patch.return_value = {"data": "test"}
         self.resolver.intrinsic_property_resolver(intrinsic, True)
+        get_template_data_patch.assert_called_once_with("test")
 
     def test_fn_transform_unsupported_macro(self):
         intrinsic = {"Fn::Transform": {"Name": "UNKNOWN", "Parameters": {"Location": "test"}}}


### PR DESCRIPTION
*Issue #, if available:*
#1418 and possibly all of #1427 (haven't tested with that yet)

*Description of changes:*

`Fn::Transform` with `AWS::Include` allows for inlining data that is found in a separate file. The current implementation only took the value from the `Parameter.Location`, which is breaks `start-api`. This PR will take the value of `Parameter.Location` and try to load the local file and return that as the value of the `Fn::Transform`. If the file is not a valid local file, the `Fn::Transform` is left alone (say if the value is an s3 Uri). Our other code paths already handle these cases, so no special logic is needed, but we can expand this in the future to do all the right things.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
