### PR TITLE
fix: add timeouts on docker local-invoke, start-api and start-lambda integration tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,18 +25,43 @@ for:
         - image: Visual Studio 2017
 
     install:
+      - "SET PATH=%PYTHON_HOME%;%PATH%"
+      - "echo %PYTHON_HOME%"
+      - "echo %PATH%"
+      - "python --version"
       # Upgrade setuptools, wheel and virtualenv
       - "python -m pip install --upgrade setuptools wheel virtualenv"
 
       # Create new virtual environment and activate it
       - "rm -rf venv"
       - "python -m virtualenv venv"
-      - "venv/Scripts/activate"
+      - "venv\\Scripts\\activate"
 
+    build_script:
+      # Activate virtualenv again on windows
+      - "venv\\Scripts\\activate"
+      - "python -c \"import sys; print(sys.executable)\""
+      - "pip install -e \".[dev]\""
+
+    test_script:
+      # Activate virtualenv again on windows
+      - "venv\\Scripts\\activate"
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit"
+      - "pylint --rcfile .pylintrc samcli"
+
+      # Runs only in Linux
+      - sh: "pytest -vv tests/integration"
+      - sh: "/tmp/black --check setup.py tests samcli scripts"
+      - sh: "python scripts/check-isolated-needs-update.py"
+
+      # Smoke tests run in parallel - it runs on both Linux & Windows
+      # Presence of the RUN_SMOKE envvar will run the smoke tests
+      - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
   - 
     matrix:
       only:
         - image: Ubuntu
+
     install:
       - sh: "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"
       - sh: "PATH=$JAVA_HOME/bin:$PATH"
@@ -53,67 +78,30 @@ for:
       - sh: "wget -O /tmp/black https://github.com/python/black/releases/download/19.3b0/black"
       - sh: "chmod +x /tmp/black"
       - sh: "/tmp/black --version"
+
+    build_script:
+      - "python -c \"import sys; print(sys.executable)\""
+      - "pip install -e \".[dev]\""
+
+    test_script:
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit"
+      - "pylint --rcfile .pylintrc samcli"
+
+      # Runs only in Linux
+      - sh: "pytest -vv tests/integration"
+      - sh: "/tmp/black --check setup.py tests samcli scripts"
+      - sh: "python scripts/check-isolated-needs-update.py"
+
+      # Smoke tests run in parallel - it runs on both Linux & Windows
+      # Presence of the RUN_SMOKE envvar will run the smoke tests
+      - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
   
   - 
     matrix:
       only:
         - ONLY_SMOKE: 1
+
     test_script:
       # Smoke tests run in parallel
-      - "venv/Scripts/activate"
-      - "pytest -n 4 -vv tests/smoke"
-
-  -
-    matrix:
-      only:
-        - image: Visual Studio 2017
-    build_script:
-      - "python -c \"import sys; print(sys.executable)\""
-      - "pip install -e \".[dev]\""
-
-  -
-    matrix:
-      only:
-        - image: Ubuntu
-    build_script:
-      # Activate virtualenv again on windows
-      - "venv\\Scripts\\activate"
-      - "python -c \"import sys; print(sys.executable)\""
-      - "pip install -e \".[dev]\""
-
-  -
-    matrix:
-      only:
-        - image: Ubuntu
-    test_script:
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit"
-      - "pylint --rcfile .pylintrc samcli"
-
-      # Runs only in Linux
-      - sh: "pytest -vv tests/integration"
-      - sh: "/tmp/black --check setup.py tests samcli scripts"
-      - sh: "python scripts/check-isolated-needs-update.py"
-
-      # Smoke tests run in parallel - it runs on both Linux & Windows
-      # Presence of the RUN_SMOKE envvar will run the smoke tests
-      - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
-
-  -
-    matrix:
-      only:
-        - image: Visual Studio 2017
-    test_script:
-      # Activate virtualenv again on windows
-      - "venv\\Scripts\\activate"
-      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit"
-      - "pylint --rcfile .pylintrc samcli"
-
-      # Runs only in Linux
-      - sh: "pytest -vv tests/integration"
-      - sh: "/tmp/black --check setup.py tests samcli scripts"
-      - sh: "python scripts/check-isolated-needs-update.py"
-
-      # Smoke tests run in parallel - it runs on both Linux & Windows
-      # Presence of the RUN_SMOKE envvar will run the smoke tests
-      - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
-
+      - sh: "venv/Scripts/activate"
+      - sh: "pytest -n 4 -vv tests/smoke"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,9 @@ for:
 
       # Smoke tests run in parallel - it runs on both Linux & Windows
       # Presence of the RUN_SMOKE envvar will run the smoke tests
-      - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
+      # Note: temporarily removing as with current dependencies we require syslog on windows
+      # which is not present on stdlib.
+      # - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
   - 
     matrix:
       only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
  
   matrix:
 
-    - PYTHON_HOME: "C:\\Python27-x64"
-      PYTHON_VERSION: '2.7.16'
-      PYTHON_ARCH: '32'
-
     - PYTHON_HOME: "C:\\Python36-x64"
       PYTHON_VERSION: '3.6.8'
       PYTHON_ARCH: '64'
@@ -64,23 +60,60 @@ for:
         - ONLY_SMOKE: 1
     test_script:
       # Smoke tests run in parallel
+      - "venv/Scripts/activate"
       - "pytest -n 4 -vv tests/smoke"
 
-build_script:
-  - "python -c \"import sys; print(sys.executable)\""
+  -
+    matrix:
+      only:
+        - image: Visual Studio 2017
+    build_script:
+      - "python -c \"import sys; print(sys.executable)\""
+      - "pip install -e \".[dev]\""
 
-  # Actually install SAM CLI's dependencies
-  - "pip install -e \".[dev]\""
+  -
+    matrix:
+      only:
+        - image: Ubuntu
+    build_script:
+      # Activate virtualenv again on windows
+      - "venv\\Scripts\\activate"
+      - "python -c \"import sys; print(sys.executable)\""
+      - "pip install -e \".[dev]\""
 
-test_script:
-    - "pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit"
-    - "pylint --rcfile .pylintrc samcli"
+  -
+    matrix:
+      only:
+        - image: Ubuntu
+    test_script:
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit"
+      - "pylint --rcfile .pylintrc samcli"
 
-    # Runs only in Linux
-    - sh: "pytest -vv tests/integration"
-    - sh: "/tmp/black --check setup.py tests samcli scripts"
-    - sh: "python scripts/check-isolated-needs-update.py"
+      # Runs only in Linux
+      - sh: "pytest -vv tests/integration"
+      - sh: "/tmp/black --check setup.py tests samcli scripts"
+      - sh: "python scripts/check-isolated-needs-update.py"
 
-    # Smoke tests run in parallel - it runs on both Linux & Windows
-    # Presence of the RUN_SMOKE envvar will run the smoke tests
-    - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
+      # Smoke tests run in parallel - it runs on both Linux & Windows
+      # Presence of the RUN_SMOKE envvar will run the smoke tests
+      - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
+
+  -
+    matrix:
+      only:
+        - image: Visual Studio 2017
+    test_script:
+      # Activate virtualenv again on windows
+      - "venv\\Scripts\\activate"
+      - "pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit"
+      - "pylint --rcfile .pylintrc samcli"
+
+      # Runs only in Linux
+      - sh: "pytest -vv tests/integration"
+      - sh: "/tmp/black --check setup.py tests samcli scripts"
+      - sh: "python scripts/check-isolated-needs-update.py"
+
+      # Smoke tests run in parallel - it runs on both Linux & Windows
+      # Presence of the RUN_SMOKE envvar will run the smoke tests
+      - ps: "If ($env:RUN_SMOKE) {pytest -n 4 -vv tests/smoke}"
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,13 +1,13 @@
 coverage==4.3.4
-tox==2.2.1
 pytest-cov==2.4.0
 # astroid > 2.0.4 is not compatible with pylint1.7
 astroid>=1.5.8,<2.1.0
 pylint==1.7.2
 
 # Test requirements
-pytest==3.1.0
-py==1.4.33
+pytest==3.6.0
+py==1.5.1
+pluggy==0.6.0
 mock==2.0.0
 parameterized==0.6.1
 pathlib2==2.3.2; python_version<"3.4"
@@ -16,3 +16,4 @@ futures==3.2.0; python_version<"3.2.3"
 backports.tempfile==1.0
 pytest-xdist==1.20.0
 pytest-forked==1.0.2
+pytest-timeout==1.3.3

--- a/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
+++ b/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
@@ -5,6 +5,7 @@ import tempfile
 
 from subprocess import Popen, PIPE
 from nose_parameterized import parameterized, param
+import pytest
 
 from tests.integration.local.invoke.invoke_integ_base import InvokeIntegBase
 
@@ -30,6 +31,7 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
     def tearDown(self):
         os.remove(self.events_file_path)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     @parameterized.expand([param("Go1xFunction"), param("Java8Function")])
     def test_runtime_zip(self, function_name):
         command_list = self.get_command_list(
@@ -43,6 +45,7 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello World"')
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_custom_provided_runtime(self):
         command_list = self.get_command_list(
             "CustomBashFunction", template_path=self.template_path, event_path=self.events_file_path

--- a/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
+++ b/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
@@ -31,7 +31,7 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
     def tearDown(self):
         os.remove(self.events_file_path)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     @parameterized.expand([param("Go1xFunction"), param("Java8Function")])
     def test_runtime_zip(self, function_name):
         command_list = self.get_command_list(
@@ -45,7 +45,7 @@ class TestWithDifferentLambdaRuntimeZips(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello World"')
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_custom_provided_runtime(self):
         command_list = self.get_command_list(
             "CustomBashFunction", template_path=self.template_path, event_path=self.events_file_path

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -8,7 +8,7 @@ from unittest import skipIf
 from nose_parameterized import parameterized
 from subprocess import Popen, PIPE
 from timeit import default_timer as timer
-
+import pytest
 import docker
 
 from tests.integration.local.invoke.layer_utils import LayerUtils
@@ -28,6 +28,7 @@ except ImportError:
 class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
     template = Path("template.yml")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_returncode_is_zero(self):
         command_list = self.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
@@ -38,6 +39,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(return_code, 0)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_function_with_metadata(self):
         command_list = self.get_command_list("FunctionWithMetadata", template_path=self.template_path, no_event=True)
 
@@ -47,6 +49,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello World in a different dir"')
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_returns_execpted_results(self):
         command_list = self.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
@@ -57,6 +60,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_of_lambda_function(self):
         command_list = self.get_command_list(
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
@@ -67,6 +71,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     @parameterized.expand([("TimeoutFunction"), ("TimeoutFunctionWithParameter")])
     def test_invoke_with_timeout_set(self, function_name):
         command_list = self.get_command_list(
@@ -93,6 +98,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             msg="The return statement in the LambdaFunction " "should never return leading to an empty string",
         )
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_env_vars(self):
         command_list = self.get_command_list(
             "EchoCustomEnvVarFunction",
@@ -106,6 +112,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"MyVar"')
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_when_function_writes_stdout(self):
         command_list = self.get_command_list(
             "WriteToStdoutFunction", template_path=self.template_path, event_path=self.event_path
@@ -120,6 +127,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertIn("Docker Lambda is writing to stdout", process_stderr.decode("utf-8"))
         self.assertIn("wrote to stdout", process_stdout.decode("utf-8"))
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_when_function_writes_stderr(self):
         command_list = self.get_command_list(
             "WriteToStderrFunction", template_path=self.template_path, event_path=self.event_path
@@ -132,6 +140,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertIn("Docker Lambda is writing to stderr", process_stderr.decode("utf-8"))
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_returns_expected_result_when_no_event_given(self):
         command_list = self.get_command_list("EchoEventFunction", template_path=self.template_path)
         command_list.append("--no-event")
@@ -142,6 +151,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(return_code, 0)
         self.assertEqual("{}", process_stdout.decode("utf-8"))
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_raises_exception_with_noargs_and_event(self):
         command_list = self.get_command_list(
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
@@ -154,6 +164,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         error_output = process_stderr.decode("utf-8")
         self.assertIn("no_event and event cannot be used together. Please provide only one.", error_output)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_env_using_parameters(self):
         command_list = self.get_command_list(
             "EchoEnvWithParameters",
@@ -180,6 +191,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(environ["Timeout"], "100")
         self.assertEqual(environ["MyRuntimeVersion"], "v0")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_env_using_parameters_with_custom_region(self):
         custom_region = "my-custom-region"
 
@@ -194,6 +206,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(environ["Region"], custom_region)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_env_with_aws_creds(self):
         custom_region = "my-custom-region"
         key = "key"
@@ -222,6 +235,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], secret)
         self.assertEqual(environ["AWS_SESSION_TOKEN"], session)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_docker_network_of_host(self):
         command_list = self.get_command_list(
             "HelloWorldServerlessFunction",
@@ -235,6 +249,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(return_code, 0)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     @skipIf(IS_WINDOWS, "The test hangs on Windows due to trying to attach to a non-existing network")
     def test_invoke_with_docker_network_of_host_in_env_var(self):
         command_list = self.get_command_list(
@@ -250,6 +265,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertIn('Not Found ("network non-existing-network not found")', process_stderr.decode("utf-8"))
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_sam_template_file_env_var_set(self):
         command_list = self.get_command_list("HelloWorldFunctionInNonDefaultTemplate", event_path=self.event_path)
 
@@ -263,6 +279,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_skip_pull_image_in_env_var(self):
         docker.from_env().api.pull("lambci/lambda:python3.6")
 
@@ -288,6 +305,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
     def tearDown(self):
         shutil.rmtree(self.config_dir, ignore_errors=True)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_existing_env_variables_precedence_over_profiles(self):
         profile = "default"
         custom_config = self._create_config_file(profile)
@@ -322,6 +340,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], "priority_secret_key_id")
         self.assertEqual(environ["AWS_SESSION_TOKEN"], "priority_secret_token")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_default_profile_with_custom_configs(self):
         profile = "default"
         custom_config = self._create_config_file(profile)
@@ -353,6 +372,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], "shhhhhthisisasecret")
         self.assertEqual(environ["AWS_SESSION_TOKEN"], "sessiontoken")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_custom_profile_with_custom_configs(self):
         custom_config = self._create_config_file("custom")
         custom_cred = self._create_cred_file("custom")
@@ -383,6 +403,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], "shhhhhthisisasecret")
         self.assertEqual(environ["AWS_SESSION_TOKEN"], "sessiontoken")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_custom_profile_through_envrionment_variables(self):
         # When using a custom profile in a custom location, you need both the config
         # and credential file otherwise we fail to find a region or the profile (depending

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -28,7 +28,7 @@ except ImportError:
 class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
     template = Path("template.yml")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_returncode_is_zero(self):
         command_list = self.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
@@ -39,7 +39,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(return_code, 0)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_function_with_metadata(self):
         command_list = self.get_command_list("FunctionWithMetadata", template_path=self.template_path, no_event=True)
 
@@ -49,7 +49,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello World in a different dir"')
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_returns_execpted_results(self):
         command_list = self.get_command_list(
             "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
@@ -60,7 +60,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_of_lambda_function(self):
         command_list = self.get_command_list(
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
@@ -71,7 +71,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     @parameterized.expand([("TimeoutFunction"), ("TimeoutFunctionWithParameter")])
     def test_invoke_with_timeout_set(self, function_name):
         command_list = self.get_command_list(
@@ -98,7 +98,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
             msg="The return statement in the LambdaFunction " "should never return leading to an empty string",
         )
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_env_vars(self):
         command_list = self.get_command_list(
             "EchoCustomEnvVarFunction",
@@ -112,7 +112,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = b"".join(process.stdout.readlines()).strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"MyVar"')
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_when_function_writes_stdout(self):
         command_list = self.get_command_list(
             "WriteToStdoutFunction", template_path=self.template_path, event_path=self.event_path
@@ -127,7 +127,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertIn("Docker Lambda is writing to stdout", process_stderr.decode("utf-8"))
         self.assertIn("wrote to stdout", process_stdout.decode("utf-8"))
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_when_function_writes_stderr(self):
         command_list = self.get_command_list(
             "WriteToStderrFunction", template_path=self.template_path, event_path=self.event_path
@@ -140,7 +140,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertIn("Docker Lambda is writing to stderr", process_stderr.decode("utf-8"))
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_returns_expected_result_when_no_event_given(self):
         command_list = self.get_command_list("EchoEventFunction", template_path=self.template_path)
         command_list.append("--no-event")
@@ -151,7 +151,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(return_code, 0)
         self.assertEqual("{}", process_stdout.decode("utf-8"))
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_raises_exception_with_noargs_and_event(self):
         command_list = self.get_command_list(
             "HelloWorldLambdaFunction", template_path=self.template_path, event_path=self.event_path
@@ -164,7 +164,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         error_output = process_stderr.decode("utf-8")
         self.assertIn("no_event and event cannot be used together. Please provide only one.", error_output)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_env_using_parameters(self):
         command_list = self.get_command_list(
             "EchoEnvWithParameters",
@@ -191,7 +191,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(environ["Timeout"], "100")
         self.assertEqual(environ["MyRuntimeVersion"], "v0")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_env_using_parameters_with_custom_region(self):
         custom_region = "my-custom-region"
 
@@ -206,7 +206,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(environ["Region"], custom_region)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_env_with_aws_creds(self):
         custom_region = "my-custom-region"
         key = "key"
@@ -235,7 +235,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], secret)
         self.assertEqual(environ["AWS_SESSION_TOKEN"], session)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_docker_network_of_host(self):
         command_list = self.get_command_list(
             "HelloWorldServerlessFunction",
@@ -249,7 +249,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(return_code, 0)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     @skipIf(IS_WINDOWS, "The test hangs on Windows due to trying to attach to a non-existing network")
     def test_invoke_with_docker_network_of_host_in_env_var(self):
         command_list = self.get_command_list(
@@ -265,7 +265,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertIn('Not Found ("network non-existing-network not found")', process_stderr.decode("utf-8"))
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_sam_template_file_env_var_set(self):
         command_list = self.get_command_list("HelloWorldFunctionInNonDefaultTemplate", event_path=self.event_path)
 
@@ -279,7 +279,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_skip_pull_image_in_env_var(self):
         docker.from_env().api.pull("lambci/lambda:python3.6")
 
@@ -305,7 +305,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
     def tearDown(self):
         shutil.rmtree(self.config_dir, ignore_errors=True)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_existing_env_variables_precedence_over_profiles(self):
         profile = "default"
         custom_config = self._create_config_file(profile)
@@ -340,7 +340,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], "priority_secret_key_id")
         self.assertEqual(environ["AWS_SESSION_TOKEN"], "priority_secret_token")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_default_profile_with_custom_configs(self):
         profile = "default"
         custom_config = self._create_config_file(profile)
@@ -372,7 +372,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], "shhhhhthisisasecret")
         self.assertEqual(environ["AWS_SESSION_TOKEN"], "sessiontoken")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_custom_profile_with_custom_configs(self):
         custom_config = self._create_config_file("custom")
         custom_cred = self._create_cred_file("custom")
@@ -403,7 +403,7 @@ class TestUsingConfigFiles(InvokeIntegBase):
         self.assertEqual(environ["AWS_SECRET_ACCESS_KEY"], "shhhhhthisisasecret")
         self.assertEqual(environ["AWS_SESSION_TOKEN"], "sessiontoken")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_custom_profile_through_envrionment_variables(self):
         # When using a custom profile in a custom location, you need both the config
         # and credential file otherwise we fail to find a region or the profile (depending

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -2,6 +2,8 @@ import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import time
 
+import pytest
+
 from samcli.local.apigw.local_apigw_service import Route
 from .start_api_integ_base import StartApiIntegBaseClass
 
@@ -17,6 +19,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_same_endpoint(self):
         """
         Send two requests to the same path at the same time. This is to ensure we can handle
@@ -41,6 +44,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
             self.assertEqual(result.status_code, 200)
             self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_different_endpoints(self):
         """
         Send two requests to different paths at the same time. This is to ensure we can handle
@@ -79,24 +83,28 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invalid_http_verb_for_endpoint(self):
         response = requests.get(self.url + "/id")
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {"message": "Missing Authentication Token"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invalid_response_from_lambda(self):
         response = requests.get(self.url + "/invalidresponsereturned")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invalid_json_response_from_lambda(self):
         response = requests.get(self.url + "/invalidresponsehash")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_timeout(self):
         pass
 
@@ -114,12 +122,14 @@ class TestService(StartApiIntegBaseClass):
     def test_static_directory(self):
         pass
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_calling_proxy_endpoint(self):
         response = requests.get(self.url + "/proxypath/this/is/some/path")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_get_call_with_path_setup_with_any_implicit_api(self):
         """
         Get Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -129,6 +139,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_post_call_with_path_setup_with_any_implicit_api(self):
         """
         Post Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -138,6 +149,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_put_call_with_path_setup_with_any_implicit_api(self):
         """
         Put Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -147,6 +159,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_head_call_with_path_setup_with_any_implicit_api(self):
         """
         Head Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -155,6 +168,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_delete_call_with_path_setup_with_any_implicit_api(self):
         """
         Delete Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -164,6 +178,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_options_call_with_path_setup_with_any_implicit_api(self):
         """
         Options Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -172,6 +187,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_patch_call_with_path_setup_with_any_implicit_api(self):
         """
         Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -189,6 +205,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -198,6 +215,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
@@ -207,6 +225,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
@@ -216,6 +235,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
@@ -224,6 +244,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
@@ -233,6 +254,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
@@ -241,6 +263,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
@@ -250,24 +273,28 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/nofunctionfound")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_function_with_no_api_event_is_reachable(self):
         response = requests.get(self.url + "/functionwithnoapievent")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/nonserverlessfunction")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -281,6 +308,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -301,6 +329,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -310,6 +339,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
@@ -319,6 +349,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
@@ -328,6 +359,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
@@ -336,6 +368,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
@@ -345,6 +378,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
@@ -353,6 +387,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
@@ -362,18 +397,21 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/nofunctionfound")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/nonserverlessfunction")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -387,6 +425,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -411,6 +450,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_multiple_headers_response(self):
         response = requests.get(self.url + "/multipleheaders")
 
@@ -418,6 +458,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
         self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_multiple_headers_overrides_headers_response(self):
         response = requests.get(self.url + "/multipleheadersoverridesheaders")
 
@@ -425,6 +466,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
         self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2, Custom")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -437,6 +479,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, expected)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_default_header_content_type(self):
         """
         Test that if no ContentType is given the default is "application/json"
@@ -447,6 +490,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.content.decode("utf-8"), "no data")
         self.assertEqual(response.headers.get("Content-Type"), "application/json")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_default_status_code(self):
         """
         Test that if no status_code is given, the status code is 200
@@ -457,6 +501,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_string_status_code(self):
         """
         Test that an integer-string can be returned as the status code
@@ -465,6 +510,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_default_body(self):
         """
         Test that if no body is given, the response is 'no data'
@@ -474,18 +520,21 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "no data")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_function_writing_to_stdout(self):
         response = requests.get(self.url + "/writetostdout")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_function_writing_to_stderr(self):
         response = requests.get(self.url + "/writetostderr")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_integer_body(self):
         response = requests.get(self.url + "/echo_integer_body")
 
@@ -504,6 +553,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -517,6 +567,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_with_form_data(self):
         """
         Form-encoded data should be put into the Event to Lambda
@@ -532,6 +583,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded")
         self.assertEqual(response_data.get("body"), "key=value")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_to_an_endpoint_with_two_different_handlers(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -541,6 +593,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("handler"), "echo_event_handler_2")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_with_multi_value_headers(self):
         response = requests.get(
             self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded, image/gif"}
@@ -555,6 +608,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
             response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded, image/gif"
         )
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_with_query_params(self):
         """
         Query params given should be put into the Event to Lambda
@@ -568,6 +622,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("queryStringParameters"), {"key": "value"})
         self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value"]})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_with_list_of_query_params(self):
         """
         Query params given should be put into the Event to Lambda
@@ -581,6 +636,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("queryStringParameters"), {"key": "value2"})
         self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value", "value2"]})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_with_path_params(self):
         """
         Path Parameters given should be put into the Event to Lambda
@@ -593,6 +649,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("pathParameters"), {"id": "4"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_request_with_many_path_params(self):
         """
         Path Parameters given should be put into the Event to Lambda
@@ -605,6 +662,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("pathParameters"), {"id": "4", "user": "jacob"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_forward_headers_are_added_to_event(self):
         """
         Test the Forwarding Headers exist in the Api Event to Lambda
@@ -629,6 +687,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_default_stage_name(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -638,6 +697,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Prod")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_global_stage_variables(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -658,6 +718,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_swagger_stage_name(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -666,6 +727,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
         response_data = response.json()
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "dev")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_swagger_stage_variable(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -686,6 +748,7 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_cors_swagger_options(self):
         """
         This tests that the Cors are added to option requests in the swagger template
@@ -710,6 +773,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_cors_global(self):
         """
         This tests that the Cors are added to options requests when the global property is set
@@ -722,6 +786,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), ",".join(sorted(Route.ANY_HTTP_METHODS)))
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), None)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_cors_global_get(self):
         """
         This tests that the Cors are added to post requests when the global property is set
@@ -747,6 +812,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_default_stage_name(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -755,6 +821,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
         response_data = response.json()
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Dev")
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_global_stage_variables(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -772,6 +839,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -781,6 +849,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
@@ -790,6 +859,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
@@ -799,6 +869,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
@@ -807,6 +878,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
@@ -816,6 +888,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
@@ -824,6 +897,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
@@ -833,18 +907,21 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/root/nofunctionfound")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/root/nonserverlessfunction")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -858,6 +935,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -870,6 +948,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, expected)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_proxy_response(self):
         """
         Binary data is returned correctly
@@ -886,6 +965,7 @@ class TestCDKApiGateway(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_get_with_cdk(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -902,6 +982,7 @@ class TestServerlessApiGateway(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_get_with_serverless(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -19,7 +19,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_same_endpoint(self):
         """
         Send two requests to the same path at the same time. This is to ensure we can handle
@@ -44,7 +44,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
             self.assertEqual(result.status_code, 200)
             self.assertEqual(result.json(), {"message": "HelloWorld! I just slept and waking up."})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_different_endpoints(self):
         """
         Send two requests to different paths at the same time. This is to ensure we can handle
@@ -83,28 +83,28 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invalid_http_verb_for_endpoint(self):
         response = requests.get(self.url + "/id")
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {"message": "Missing Authentication Token"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invalid_response_from_lambda(self):
         response = requests.get(self.url + "/invalidresponsereturned")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invalid_json_response_from_lambda(self):
         response = requests.get(self.url + "/invalidresponsehash")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "Internal server error"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_timeout(self):
         pass
 
@@ -122,14 +122,14 @@ class TestService(StartApiIntegBaseClass):
     def test_static_directory(self):
         pass
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_calling_proxy_endpoint(self):
         response = requests.get(self.url + "/proxypath/this/is/some/path")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_get_call_with_path_setup_with_any_implicit_api(self):
         """
         Get Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -139,7 +139,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_post_call_with_path_setup_with_any_implicit_api(self):
         """
         Post Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -149,7 +149,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_put_call_with_path_setup_with_any_implicit_api(self):
         """
         Put Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -159,7 +159,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_head_call_with_path_setup_with_any_implicit_api(self):
         """
         Head Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -168,7 +168,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_delete_call_with_path_setup_with_any_implicit_api(self):
         """
         Delete Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -178,7 +178,7 @@ class TestService(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_options_call_with_path_setup_with_any_implicit_api(self):
         """
         Options Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -187,7 +187,7 @@ class TestService(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_patch_call_with_path_setup_with_any_implicit_api(self):
         """
         Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
@@ -205,7 +205,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -215,7 +215,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
@@ -225,7 +225,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
@@ -235,7 +235,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
@@ -244,7 +244,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
@@ -254,7 +254,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
@@ -263,7 +263,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
@@ -273,28 +273,28 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/nofunctionfound")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_function_with_no_api_event_is_reachable(self):
         response = requests.get(self.url + "/functionwithnoapievent")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/nonserverlessfunction")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -308,7 +308,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -329,7 +329,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -339,7 +339,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
@@ -349,7 +349,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
@@ -359,7 +359,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
@@ -368,7 +368,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
@@ -378,7 +378,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
@@ -387,7 +387,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
@@ -397,21 +397,21 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/nofunctionfound")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/nonserverlessfunction")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -425,7 +425,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -450,7 +450,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_multiple_headers_response(self):
         response = requests.get(self.url + "/multipleheaders")
 
@@ -458,7 +458,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
         self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_multiple_headers_overrides_headers_response(self):
         response = requests.get(self.url + "/multipleheadersoverridesheaders")
 
@@ -466,7 +466,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "text/plain")
         self.assertEqual(response.headers.get("MyCustomHeader"), "Value1, Value2, Custom")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -479,7 +479,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, expected)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_default_header_content_type(self):
         """
         Test that if no ContentType is given the default is "application/json"
@@ -490,7 +490,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.content.decode("utf-8"), "no data")
         self.assertEqual(response.headers.get("Content-Type"), "application/json")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_default_status_code(self):
         """
         Test that if no status_code is given, the status code is 200
@@ -501,7 +501,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_string_status_code(self):
         """
         Test that an integer-string can be returned as the status code
@@ -510,7 +510,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_default_body(self):
         """
         Test that if no body is given, the response is 'no data'
@@ -520,21 +520,21 @@ class TestServiceResponses(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode("utf-8"), "no data")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_function_writing_to_stdout(self):
         response = requests.get(self.url + "/writetostdout")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_function_writing_to_stderr(self):
         response = requests.get(self.url + "/writetostderr")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_integer_body(self):
         response = requests.get(self.url + "/echo_integer_body")
 
@@ -553,7 +553,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -567,7 +567,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_with_form_data(self):
         """
         Form-encoded data should be put into the Event to Lambda
@@ -583,7 +583,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded")
         self.assertEqual(response_data.get("body"), "key=value")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_to_an_endpoint_with_two_different_handlers(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -593,7 +593,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("handler"), "echo_event_handler_2")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_with_multi_value_headers(self):
         response = requests.get(
             self.url + "/echoeventbody", headers={"Content-Type": "application/x-www-form-urlencoded, image/gif"}
@@ -608,7 +608,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
             response_data.get("headers").get("Content-Type"), "application/x-www-form-urlencoded, image/gif"
         )
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_with_query_params(self):
         """
         Query params given should be put into the Event to Lambda
@@ -622,7 +622,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("queryStringParameters"), {"key": "value"})
         self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value"]})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_with_list_of_query_params(self):
         """
         Query params given should be put into the Event to Lambda
@@ -636,7 +636,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
         self.assertEqual(response_data.get("queryStringParameters"), {"key": "value2"})
         self.assertEqual(response_data.get("multiValueQueryStringParameters"), {"key": ["value", "value2"]})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_with_path_params(self):
         """
         Path Parameters given should be put into the Event to Lambda
@@ -649,7 +649,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("pathParameters"), {"id": "4"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_request_with_many_path_params(self):
         """
         Path Parameters given should be put into the Event to Lambda
@@ -662,7 +662,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("pathParameters"), {"id": "4", "user": "jacob"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_forward_headers_are_added_to_event(self):
         """
         Test the Forwarding Headers exist in the Api Event to Lambda
@@ -687,7 +687,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_default_stage_name(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -697,7 +697,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Prod")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_global_stage_variables(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -718,7 +718,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_swagger_stage_name(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -727,7 +727,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
         response_data = response.json()
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "dev")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_swagger_stage_variable(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -748,7 +748,7 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_cors_swagger_options(self):
         """
         This tests that the Cors are added to option requests in the swagger template
@@ -773,7 +773,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_cors_global(self):
         """
         This tests that the Cors are added to options requests when the global property is set
@@ -786,7 +786,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Access-Control-Allow-Methods"), ",".join(sorted(Route.ANY_HTTP_METHODS)))
         self.assertEqual(response.headers.get("Access-Control-Max-Age"), None)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_cors_global_get(self):
         """
         This tests that the Cors are added to post requests when the global property is set
@@ -812,7 +812,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_default_stage_name(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -821,7 +821,7 @@ class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
         response_data = response.json()
         self.assertEqual(response_data.get("requestContext", {}).get("stage"), "Dev")
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_global_stage_variables(self):
         response = requests.get(self.url + "/echoeventbody")
 
@@ -839,7 +839,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -849,7 +849,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
         """
         Post Request to a path that was defined as ANY in SAM through Swagger
@@ -859,7 +859,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
         """
         Put Request to a path that was defined as ANY in SAM through Swagger
@@ -869,7 +869,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
         """
         Head Request to a path that was defined as ANY in SAM through Swagger
@@ -878,7 +878,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
         """
         Delete Request to a path that was defined as ANY in SAM through Swagger
@@ -888,7 +888,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
         """
         Options Request to a path that was defined as ANY in SAM through Swagger
@@ -897,7 +897,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
         """
         Patch Request to a path that was defined as ANY in SAM through Swagger
@@ -907,21 +907,21 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_function_not_defined_in_template(self):
         response = requests.get(self.url + "/root/nofunctionfound")
 
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json(), {"message": "No function defined for resource method"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_lambda_function_resource_is_reachable(self):
         response = requests.get(self.url + "/root/nonserverlessfunction")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_request(self):
         """
         This tests that the service can accept and invoke a lambda when given binary data in a request
@@ -935,7 +935,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, input_data)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_binary_response(self):
         """
         Binary data is returned correctly
@@ -948,7 +948,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
         self.assertEqual(response.headers.get("Content-Type"), "image/gif")
         self.assertEqual(response.content, expected)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_proxy_response(self):
         """
         Binary data is returned correctly
@@ -965,7 +965,7 @@ class TestCDKApiGateway(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_get_with_cdk(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger
@@ -982,7 +982,7 @@ class TestServerlessApiGateway(StartApiIntegBaseClass):
     def setUp(self):
         self.url = "http://127.0.0.1:{}".format(self.port)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_get_with_serverless(self):
         """
         Get Request to a path that was defined as ANY in SAM through Swagger

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -25,7 +25,7 @@ class TestParallelRequests(StartLambdaIntegBaseClass):
             config=Config(signature_version=UNSIGNED, read_timeout=120, retries={"max_attempts": 0}),
         )
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_same_endpoint(self):
         """
         Send two requests to the same path at the same time. This is to ensure we can handle
@@ -64,7 +64,7 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
             config=Config(signature_version=UNSIGNED, read_timeout=120, retries={"max_attempts": 0}),
         )
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_non_json_data(self):
         expected_error_message = (
             "An error occurred (InvalidRequestContent) when calling the Invoke operation: "
@@ -76,7 +76,7 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
 
         self.assertEqual(str(error.exception), expected_error_message)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_log_type_not_None(self):
         expected_error_message = (
             "An error occurred (NotImplemented) when calling the Invoke operation: "
@@ -88,7 +88,7 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
 
         self.assertEqual(str(error.exception), expected_error_message)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_invocation_type_not_RequestResponse(self):
         expected_error_message = (
             "An error occurred (NotImplemented) when calling the Invoke operation: "
@@ -115,7 +115,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
             config=Config(signature_version=UNSIGNED, read_timeout=120, retries={"max_attempts": 0}),
         )
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_data(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction", Payload='"This is json data"')
 
@@ -123,7 +123,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_no_data(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction")
 
@@ -131,7 +131,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_log_type_None(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction", LogType="None")
 
@@ -139,7 +139,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_invocation_type_RequestResponse(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction", InvocationType="RequestResponse")
 
@@ -147,7 +147,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_lambda_function_raised_error(self):
         response = self.lambda_client.invoke(FunctionName="RaiseExceptionFunction", InvocationType="RequestResponse")
 
@@ -161,7 +161,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertEqual(response.get("FunctionError"), "Unhandled")
         self.assertEqual(response.get("StatusCode"), 200)
 
-    @pytest.mark.timeout(timeout=300, method='thread')
+    @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_function_timeout(self):
         """
         This behavior does not match the actually Lambda Service. For functions that timeout, data returned like the

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -1,6 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import time
 
+import pytest
+
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
@@ -23,6 +25,7 @@ class TestParallelRequests(StartLambdaIntegBaseClass):
             config=Config(signature_version=UNSIGNED, read_timeout=120, retries={"max_attempts": 0}),
         )
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_same_endpoint(self):
         """
         Send two requests to the same path at the same time. This is to ensure we can handle
@@ -61,6 +64,7 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
             config=Config(signature_version=UNSIGNED, read_timeout=120, retries={"max_attempts": 0}),
         )
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_non_json_data(self):
         expected_error_message = (
             "An error occurred (InvalidRequestContent) when calling the Invoke operation: "
@@ -72,6 +76,7 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
 
         self.assertEqual(str(error.exception), expected_error_message)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_log_type_not_None(self):
         expected_error_message = (
             "An error occurred (NotImplemented) when calling the Invoke operation: "
@@ -83,6 +88,7 @@ class TestLambdaServiceErrorCases(StartLambdaIntegBaseClass):
 
         self.assertEqual(str(error.exception), expected_error_message)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_invocation_type_not_RequestResponse(self):
         expected_error_message = (
             "An error occurred (NotImplemented) when calling the Invoke operation: "
@@ -109,6 +115,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
             config=Config(signature_version=UNSIGNED, read_timeout=120, retries={"max_attempts": 0}),
         )
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_data(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction", Payload='"This is json data"')
 
@@ -116,6 +123,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_no_data(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction")
 
@@ -123,6 +131,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_log_type_None(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction", LogType="None")
 
@@ -130,6 +139,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_invocation_type_RequestResponse(self):
         response = self.lambda_client.invoke(FunctionName="EchoEventFunction", InvocationType="RequestResponse")
 
@@ -137,6 +147,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_lambda_function_raised_error(self):
         response = self.lambda_client.invoke(FunctionName="RaiseExceptionFunction", InvocationType="RequestResponse")
 
@@ -150,6 +161,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         self.assertEqual(response.get("FunctionError"), "Unhandled")
         self.assertEqual(response.get("StatusCode"), 200)
 
+    @pytest.mark.timeout(timeout=300, method='thread')
     def test_invoke_with_function_timeout(self):
         """
         This behavior does not match the actually Lambda Service. For functions that timeout, data returned like the

--- a/tests/integration/testdata/invoke/layers/layer-template.yml
+++ b/tests/integration/testdata/invoke/layers/layer-template.yml
@@ -27,6 +27,7 @@ Resources:
       Handler: layer-main.one_layer_hanlder
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: LayerOneArn
 
@@ -37,6 +38,7 @@ Resources:
       Handler: layer-main.one_layer_hanlder
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: ChangedLayerArn
 
@@ -46,6 +48,7 @@ Resources:
       Handler: layer-main.custom_layer_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: MyCustomServerlessLayer
 
@@ -55,6 +58,7 @@ Resources:
       Handler: layer-main.custom_layer_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: MyCustomLambdaLayer
 
@@ -64,6 +68,7 @@ Resources:
       Handler: layer-main.one_layer_hanlder
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: LayerOneArn
         - Ref: LayerTwoArn
@@ -75,6 +80,7 @@ Resources:
       Handler: layer-main.one_layer_hanlder
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: LayerOneArn
 
@@ -84,6 +90,7 @@ Resources:
       Handler: layer-main.one_layer_hanlder
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: ChangedLayerArn
 #
@@ -93,6 +100,7 @@ Resources:
       Handler: layer-main.custom_layer_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: MyCustomServerlessLayer
 
@@ -102,6 +110,7 @@ Resources:
       Handler: layer-main.custom_layer_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: MyCustomLambdaLayer
 
@@ -111,6 +120,7 @@ Resources:
       Handler: layer-main.one_layer_hanlder
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: LayerOneArn
         - Ref: LayerTwoArn
@@ -121,6 +131,7 @@ Resources:
       Handler: layer-main.handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - Ref: NonExistentLayerArn
 
@@ -130,6 +141,7 @@ Resources:
       Handler: layer-main.handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Layers:
         - arn:aws:lambda:us-west-2:111111111101:layer:layerDoesNotExist:1
 

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -24,7 +24,7 @@ Resources:
     Properties:
       Handler: main.handler
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 600
 
   TimeoutFunction:
     Type: AWS::Serverless::Function
@@ -40,7 +40,7 @@ Resources:
       Handler: main.sleep_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 15
+      Timeout: 600
 
   EchoCustomEnvVarFunction:
     Type: AWS::Serverless::Function
@@ -51,7 +51,7 @@ Resources:
       Environment:
         Variables:
           CustomEnvVar: "MyVar"
-      Timeout: 20
+      Timeout: 600
 
   WriteToStderrFunction:
     Type: AWS::Serverless::Function
@@ -59,7 +59,7 @@ Resources:
       Handler: main.write_to_stderr
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 600
 
   WriteToStdoutFunction:
     Type: AWS::Serverless::Function
@@ -67,7 +67,7 @@ Resources:
       Handler: main.write_to_stdout
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 600
 
   EchoEventFunction:
     Type: AWS::Serverless::Function
@@ -75,7 +75,7 @@ Resources:
       Handler: main.echo_event
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 600
 
   RaiseExceptionFunction:
     Type: AWS::Serverless::Function
@@ -83,7 +83,7 @@ Resources:
       Handler: main.raise_exception
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 600
 
   TimeoutFunctionWithParameter:
     Type: AWS::Serverless::Function
@@ -99,7 +99,7 @@ Resources:
     Properties:
       Runtime: python3.6
       Handler: main.echo_hello_world
-      Timeout: 20
+      Timeout: 600
     Metadata:
       aws:asset:property: CodeUri
       aws:asset:path: ./different_code_location
@@ -110,7 +110,7 @@ Resources:
       Handler: main.env_var_echo_hanler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 600
       Environment:
         Variables:
           Region: !Ref "AWS::Region"

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -24,6 +24,7 @@ Resources:
     Properties:
       Handler: main.handler
       Runtime: python3.6
+      Timeout: 20
 
   TimeoutFunction:
     Type: AWS::Serverless::Function
@@ -50,6 +51,7 @@ Resources:
       Environment:
         Variables:
           CustomEnvVar: "MyVar"
+      Timeout: 20
 
   WriteToStderrFunction:
     Type: AWS::Serverless::Function
@@ -57,6 +59,7 @@ Resources:
       Handler: main.write_to_stderr
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   WriteToStdoutFunction:
     Type: AWS::Serverless::Function
@@ -64,6 +67,7 @@ Resources:
       Handler: main.write_to_stdout
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   EchoEventFunction:
     Type: AWS::Serverless::Function
@@ -71,6 +75,7 @@ Resources:
       Handler: main.echo_event
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   RaiseExceptionFunction:
     Type: AWS::Serverless::Function
@@ -78,6 +83,7 @@ Resources:
       Handler: main.raise_exception
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   TimeoutFunctionWithParameter:
     Type: AWS::Serverless::Function
@@ -93,6 +99,7 @@ Resources:
     Properties:
       Runtime: python3.6
       Handler: main.echo_hello_world
+      Timeout: 20
     Metadata:
       aws:asset:property: CodeUri
       aws:asset:path: ./different_code_location
@@ -103,6 +110,7 @@ Resources:
       Handler: main.env_var_echo_hanler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Environment:
         Variables:
           Region: !Ref "AWS::Region"

--- a/tests/integration/testdata/start_api/cdk-sample-output.yaml
+++ b/tests/integration/testdata/start_api/cdk-sample-output.yaml
@@ -26,7 +26,7 @@ Resources:
       Code: '.'
       Handler: main.handler
       Runtime: python3.6
-      Timeout: 0
+      Timeout: 600
 
   HelloHandlerApiPermissionANYAC4E141E:
     Type: AWS::Lambda::Permission

--- a/tests/integration/testdata/start_api/cdk-sample-output.yaml
+++ b/tests/integration/testdata/start_api/cdk-sample-output.yaml
@@ -26,6 +26,7 @@ Resources:
       Code: '.'
       Handler: main.handler
       Runtime: python3.6
+      Timeout: 20
 
   HelloHandlerApiPermissionANYAC4E141E:
     Type: AWS::Lambda::Permission

--- a/tests/integration/testdata/start_api/cdk-sample-output.yaml
+++ b/tests/integration/testdata/start_api/cdk-sample-output.yaml
@@ -26,7 +26,7 @@ Resources:
       Code: '.'
       Handler: main.handler
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
 
   HelloHandlerApiPermissionANYAC4E141E:
     Type: AWS::Lambda::Permission

--- a/tests/integration/testdata/start_api/methods-resources-api-template.yaml
+++ b/tests/integration/testdata/start_api/methods-resources-api-template.yaml
@@ -6,12 +6,14 @@ Resources:
       Code: "."
       Handler: main.base64_response
       Runtime: python3.6
+      Timeout: 20
     Type: AWS::Lambda::Function
   EchoBase64EventBodyFunction:
     Properties:
       Code: "."
       Handler: main.echo_base64_event_body
       Runtime: python3.6
+      Timeout: 20
     Type: AWS::Lambda::Function
 
   Dev:
@@ -27,6 +29,7 @@ Resources:
       Code: "."
       Handler: main.handler
       Runtime: python3.6
+      Timeout: 20
     Type: AWS::Lambda::Function
 
   TestApi:

--- a/tests/integration/testdata/start_api/methods-resources-api-template.yaml
+++ b/tests/integration/testdata/start_api/methods-resources-api-template.yaml
@@ -6,14 +6,14 @@ Resources:
       Code: "."
       Handler: main.base64_response
       Runtime: python3.6
-      Timeout: 0
+      Timeout: 600
     Type: AWS::Lambda::Function
   EchoBase64EventBodyFunction:
     Properties:
       Code: "."
       Handler: main.echo_base64_event_body
       Runtime: python3.6
-      Timeout: 0
+      Timeout: 600
     Type: AWS::Lambda::Function
 
   Dev:
@@ -29,7 +29,7 @@ Resources:
       Code: "."
       Handler: main.handler
       Runtime: python3.6
-      Timeout: 0
+      Timeout: 600
     Type: AWS::Lambda::Function
 
   TestApi:

--- a/tests/integration/testdata/start_api/methods-resources-api-template.yaml
+++ b/tests/integration/testdata/start_api/methods-resources-api-template.yaml
@@ -6,14 +6,14 @@ Resources:
       Code: "."
       Handler: main.base64_response
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
     Type: AWS::Lambda::Function
   EchoBase64EventBodyFunction:
     Properties:
       Code: "."
       Handler: main.echo_base64_event_body
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
     Type: AWS::Lambda::Function
 
   Dev:
@@ -29,7 +29,7 @@ Resources:
       Code: "."
       Handler: main.handler
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
     Type: AWS::Lambda::Function
 
   TestApi:

--- a/tests/integration/testdata/start_api/serverless-sample-output.yaml
+++ b/tests/integration/testdata/start_api/serverless-sample-output.yaml
@@ -60,7 +60,7 @@ Resources:
       FunctionName: serverless-hello-world-dev-helloWorld
       Handler: main.handler
       MemorySize: 1024
-      Timeout: 0
+      Timeout: 600
       Role:
         Fn::GetAtt:
           - IamRoleLambdaExecution

--- a/tests/integration/testdata/start_api/serverless-sample-output.yaml
+++ b/tests/integration/testdata/start_api/serverless-sample-output.yaml
@@ -60,6 +60,7 @@ Resources:
       FunctionName: serverless-hello-world-dev-helloWorld
       Handler: main.handler
       MemorySize: 1024
+      Timeout: 20
       Role:
         Fn::GetAtt:
           - IamRoleLambdaExecution

--- a/tests/integration/testdata/start_api/serverless-sample-output.yaml
+++ b/tests/integration/testdata/start_api/serverless-sample-output.yaml
@@ -60,7 +60,7 @@ Resources:
       FunctionName: serverless-hello-world-dev-helloWorld
       Handler: main.handler
       MemorySize: 1024
-      Timeout: 20
+      Timeout: 0
       Role:
         Fn::GetAtt:
           - IamRoleLambdaExecution

--- a/tests/integration/testdata/start_api/swagger-rest-api-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-rest-api-template.yaml
@@ -6,18 +6,21 @@ Resources:
       Code: "."
       Handler: main.base64_response
       Runtime: python3.6
+      Timeout: 20
     Type: AWS::Lambda::Function
   EchoBase64EventBodyFunction:
     Properties:
       Code: "."
       Handler: main.echo_base64_event_body
       Runtime: python3.6
+      Timeout: 20
     Type: AWS::Lambda::Function
   EchoEventBodyFunction:
     Properties:
       Code: "."
       Handler: main.echo_event_handler
       Runtime: python3.6
+      Timeout: 20
     Type: AWS::Lambda::Function
   MyApi:
     Properties:
@@ -86,4 +89,5 @@ Resources:
       Code: "."
       Handler: main.handler
       Runtime: python3.6
+      Timeout: 20
     Type: AWS::Lambda::Function

--- a/tests/integration/testdata/start_api/swagger-rest-api-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-rest-api-template.yaml
@@ -6,21 +6,21 @@ Resources:
       Code: "."
       Handler: main.base64_response
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
     Type: AWS::Lambda::Function
   EchoBase64EventBodyFunction:
     Properties:
       Code: "."
       Handler: main.echo_base64_event_body
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
     Type: AWS::Lambda::Function
   EchoEventBodyFunction:
     Properties:
       Code: "."
       Handler: main.echo_event_handler
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
     Type: AWS::Lambda::Function
   MyApi:
     Properties:
@@ -89,5 +89,5 @@ Resources:
       Code: "."
       Handler: main.handler
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
     Type: AWS::Lambda::Function

--- a/tests/integration/testdata/start_api/swagger-rest-api-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-rest-api-template.yaml
@@ -89,5 +89,5 @@ Resources:
       Code: "."
       Handler: main.handler
       Runtime: python3.6
-      Timeout: 0
+      Timeout: 600
     Type: AWS::Lambda::Function

--- a/tests/integration/testdata/start_api/swagger-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-template.yaml
@@ -89,7 +89,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         GetApi:
           Type: Api
@@ -105,7 +105,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
 
   MyNonServerlessLambdaFunction:
     Type: AWS::Lambda::Function
@@ -113,7 +113,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
 
   Base64ResponseFunction:
     Type: AWS::Serverless::Function
@@ -121,7 +121,7 @@ Resources:
       Handler: main.base64_response
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
 
   EchoBase64EventBodyFunction:
     Type: AWS::Serverless::Function
@@ -129,7 +129,7 @@ Resources:
       Handler: main.echo_base64_event_body
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
 
   EchoEventHandlerFunction:
     Type:  AWS::Serverless::Function
@@ -137,7 +137,7 @@ Resources:
       Handler: main.echo_event_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         GetApi:
           Type: Api

--- a/tests/integration/testdata/start_api/swagger-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-template.yaml
@@ -89,7 +89,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         GetApi:
           Type: Api
@@ -105,7 +105,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
 
   MyNonServerlessLambdaFunction:
     Type: AWS::Lambda::Function
@@ -113,7 +113,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
 
   Base64ResponseFunction:
     Type: AWS::Serverless::Function
@@ -121,7 +121,7 @@ Resources:
       Handler: main.base64_response
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
 
   EchoBase64EventBodyFunction:
     Type: AWS::Serverless::Function
@@ -129,7 +129,7 @@ Resources:
       Handler: main.echo_base64_event_body
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
 
   EchoEventHandlerFunction:
     Type:  AWS::Serverless::Function
@@ -137,7 +137,7 @@ Resources:
       Handler: main.echo_event_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         GetApi:
           Type: Api

--- a/tests/integration/testdata/start_api/swagger-template.yaml
+++ b/tests/integration/testdata/start_api/swagger-template.yaml
@@ -89,6 +89,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         GetApi:
           Type: Api
@@ -104,6 +105,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   MyNonServerlessLambdaFunction:
     Type: AWS::Lambda::Function
@@ -111,6 +113,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   Base64ResponseFunction:
     Type: AWS::Serverless::Function
@@ -118,6 +121,7 @@ Resources:
       Handler: main.base64_response
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   EchoBase64EventBodyFunction:
     Type: AWS::Serverless::Function
@@ -125,6 +129,7 @@ Resources:
       Handler: main.echo_base64_event_body
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
 
   EchoEventHandlerFunction:
     Type:  AWS::Serverless::Function
@@ -132,6 +137,7 @@ Resources:
       Handler: main.echo_event_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         GetApi:
           Type: Api

--- a/tests/integration/testdata/start_api/template.yaml
+++ b/tests/integration/testdata/start_api/template.yaml
@@ -153,7 +153,7 @@ Resources:
       Handler: main.sleep_10_sec_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 20
       Events:
         SleepPath:
           Type: Api
@@ -167,7 +167,7 @@ Resources:
       Handler: main.sleep_10_sec_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 20
       Events:
         SleepPath:
           Type: Api

--- a/tests/integration/testdata/start_api/template.yaml
+++ b/tests/integration/testdata/start_api/template.yaml
@@ -17,6 +17,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         IdBasePath:
           Type: Api
@@ -42,6 +43,7 @@ Resources:
       Handler: main.echo_event_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         PathWithPathParams:
           Type: Api
@@ -66,6 +68,7 @@ Resources:
     Properties:
       Handler: main.echo_event_handler_2
       Runtime: python3.6
+      Timeout: 20
       CodeUri: .
       Events:
         EchoEventBodyPath:
@@ -80,6 +83,7 @@ Resources:
       Handler: main.echo_integer_body
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         EchoEventBodyPath:
           Type: Api
@@ -93,6 +97,7 @@ Resources:
       Handler: main.content_type_setter_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         ContentTypeSetter:
           Type: Api
@@ -106,6 +111,7 @@ Resources:
       Handler: main.only_set_status_code_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         OnlySetStatusCodePath:
           Type: Api
@@ -119,6 +125,7 @@ Resources:
       Handler: main.only_set_body_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         OnlySetBodyPath:
           Type: Api
@@ -132,6 +139,7 @@ Resources:
       Handler: main.string_status_code_handler
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         StringStatusCodePath:
           Type: Api
@@ -173,6 +181,7 @@ Resources:
       Handler: main.write_to_stderr
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         WriteToStderrPath:
           Type: Api
@@ -186,6 +195,7 @@ Resources:
       Handler: main.write_to_stdout
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         WriteToStdoutPath:
           Type: Api
@@ -199,6 +209,7 @@ Resources:
       Handler: main.invalid_response_returned
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         InvalidResponseReturned:
           Type: Api
@@ -212,6 +223,7 @@ Resources:
       Handler: main.invalid_hash_response
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         InvalidResponseReturned:
           Type: Api
@@ -225,6 +237,7 @@ Resources:
       Handler: main.base64_response
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         Base64ResponsePath:
           Type: Api
@@ -238,6 +251,7 @@ Resources:
       Handler: main.echo_base64_event_body
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         EchoBase64EventBodyPath:
           Type: Api
@@ -251,6 +265,7 @@ Resources:
       Handler: main.multiple_headers
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         IdBasePath:
           Type: Api
@@ -264,6 +279,7 @@ Resources:
       Handler: main.multiple_headers_overrides_headers
       Runtime: python3.6
       CodeUri: .
+      Timeout: 20
       Events:
         IdBasePath:
           Type: Api

--- a/tests/integration/testdata/start_api/template.yaml
+++ b/tests/integration/testdata/start_api/template.yaml
@@ -17,7 +17,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         IdBasePath:
           Type: Api
@@ -43,7 +43,7 @@ Resources:
       Handler: main.echo_event_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         PathWithPathParams:
           Type: Api
@@ -68,7 +68,7 @@ Resources:
     Properties:
       Handler: main.echo_event_handler_2
       Runtime: python3.6
-      Timeout: 20
+      Timeout: 0
       CodeUri: .
       Events:
         EchoEventBodyPath:
@@ -83,7 +83,7 @@ Resources:
       Handler: main.echo_integer_body
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         EchoEventBodyPath:
           Type: Api
@@ -97,7 +97,7 @@ Resources:
       Handler: main.content_type_setter_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         ContentTypeSetter:
           Type: Api
@@ -111,7 +111,7 @@ Resources:
       Handler: main.only_set_status_code_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         OnlySetStatusCodePath:
           Type: Api
@@ -125,7 +125,7 @@ Resources:
       Handler: main.only_set_body_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         OnlySetBodyPath:
           Type: Api
@@ -139,7 +139,7 @@ Resources:
       Handler: main.string_status_code_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         StringStatusCodePath:
           Type: Api
@@ -153,7 +153,7 @@ Resources:
       Handler: main.sleep_10_sec_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         SleepPath:
           Type: Api
@@ -167,7 +167,7 @@ Resources:
       Handler: main.sleep_10_sec_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         SleepPath:
           Type: Api
@@ -181,7 +181,7 @@ Resources:
       Handler: main.write_to_stderr
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         WriteToStderrPath:
           Type: Api
@@ -195,7 +195,7 @@ Resources:
       Handler: main.write_to_stdout
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         WriteToStdoutPath:
           Type: Api
@@ -209,7 +209,7 @@ Resources:
       Handler: main.invalid_response_returned
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         InvalidResponseReturned:
           Type: Api
@@ -223,7 +223,7 @@ Resources:
       Handler: main.invalid_hash_response
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         InvalidResponseReturned:
           Type: Api
@@ -237,7 +237,7 @@ Resources:
       Handler: main.base64_response
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         Base64ResponsePath:
           Type: Api
@@ -251,7 +251,7 @@ Resources:
       Handler: main.echo_base64_event_body
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         EchoBase64EventBodyPath:
           Type: Api
@@ -265,7 +265,7 @@ Resources:
       Handler: main.multiple_headers
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         IdBasePath:
           Type: Api
@@ -279,7 +279,7 @@ Resources:
       Handler: main.multiple_headers_overrides_headers
       Runtime: python3.6
       CodeUri: .
-      Timeout: 20
+      Timeout: 0
       Events:
         IdBasePath:
           Type: Api

--- a/tests/integration/testdata/start_api/template.yaml
+++ b/tests/integration/testdata/start_api/template.yaml
@@ -17,7 +17,7 @@ Resources:
       Handler: main.handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         IdBasePath:
           Type: Api
@@ -43,7 +43,7 @@ Resources:
       Handler: main.echo_event_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         PathWithPathParams:
           Type: Api
@@ -68,7 +68,7 @@ Resources:
     Properties:
       Handler: main.echo_event_handler_2
       Runtime: python3.6
-      Timeout: 0
+      Timeout: 600
       CodeUri: .
       Events:
         EchoEventBodyPath:
@@ -83,7 +83,7 @@ Resources:
       Handler: main.echo_integer_body
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         EchoEventBodyPath:
           Type: Api
@@ -97,7 +97,7 @@ Resources:
       Handler: main.content_type_setter_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         ContentTypeSetter:
           Type: Api
@@ -111,7 +111,7 @@ Resources:
       Handler: main.only_set_status_code_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         OnlySetStatusCodePath:
           Type: Api
@@ -125,7 +125,7 @@ Resources:
       Handler: main.only_set_body_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         OnlySetBodyPath:
           Type: Api
@@ -139,7 +139,7 @@ Resources:
       Handler: main.string_status_code_handler
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         StringStatusCodePath:
           Type: Api
@@ -181,7 +181,7 @@ Resources:
       Handler: main.write_to_stderr
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         WriteToStderrPath:
           Type: Api
@@ -195,7 +195,7 @@ Resources:
       Handler: main.write_to_stdout
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         WriteToStdoutPath:
           Type: Api
@@ -209,7 +209,7 @@ Resources:
       Handler: main.invalid_response_returned
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         InvalidResponseReturned:
           Type: Api
@@ -223,7 +223,7 @@ Resources:
       Handler: main.invalid_hash_response
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         InvalidResponseReturned:
           Type: Api
@@ -237,7 +237,7 @@ Resources:
       Handler: main.base64_response
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         Base64ResponsePath:
           Type: Api
@@ -251,7 +251,7 @@ Resources:
       Handler: main.echo_base64_event_body
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         EchoBase64EventBodyPath:
           Type: Api
@@ -265,7 +265,7 @@ Resources:
       Handler: main.multiple_headers
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         IdBasePath:
           Type: Api
@@ -279,7 +279,7 @@ Resources:
       Handler: main.multiple_headers_overrides_headers
       Runtime: python3.6
       CodeUri: .
-      Timeout: 0
+      Timeout: 600
       Events:
         IdBasePath:
           Type: Api


### PR DESCRIPTION
- cause the builds to fail on appveyor rather than halting the test
  forever, resulting in a lengthy build timeout.
- had to play around with requirements to be able to adopt `pytest-timeout`, also do we need `tox`?

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
