### PR TITLE
Fixes empty account id in CloudWatch Scheduled Event

### DIFF
--- a/samcli/commands/local/lib/generated_sample_events/events/cloudwatch/ScheduledEvent.json
+++ b/samcli/commands/local/lib/generated_sample_events/events/cloudwatch/ScheduledEvent.json
@@ -2,7 +2,7 @@
   "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
   "detail-type": "Scheduled Event",
   "source": "aws.events",
-  "account": "{{{account-id}}}",
+  "account": "{{{account_id}}}",
   "time": "1970-01-01T00:00:00Z",
   "region": "{{{region}}}",
   "resources": [


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

The account id in the generated event was empty. Before:

```
{
  "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
  "detail-type": "Scheduled Event",
  "source": "aws.events",
  "account": "",
  "time": "1970-01-01T00:00:00Z",
  "region": "us-east-1",
  "resources": [
    "arn:aws:events:us-east-1:123456789012:rule/ExampleRule"
  ],
  "detail": {}
}
```

After:

```
{
  "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
  "detail-type": "Scheduled Event",
  "source": "aws.events",
  "account": "123456789012",
  "time": "1970-01-01T00:00:00Z",
  "region": "us-east-1",
  "resources": [
    "arn:aws:events:us-east-1:123456789012:rule/ExampleRule"
  ],
  "detail": {}
}
```

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
