### PR TITLE
feat: configuration file for sam cli commands

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,5 +12,5 @@ python-dateutil~=2.6, <2.8.1
 requests==2.22.0
 serverlessrepo==0.1.9
 aws_lambda_builders==0.5.0
-# https://github.com/mhammond/pywin32/issues/1439
 pywin32 < 226; sys_platform == 'win32'
+toml==0.10.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,5 +12,6 @@ python-dateutil~=2.6, <2.8.1
 requests==2.22.0
 serverlessrepo==0.1.9
 aws_lambda_builders==0.5.0
+# https://github.com/mhammond/pywin32/issues/1439
 pywin32 < 226; sys_platform == 'win32'
 toml==0.10.0

--- a/requirements/isolated.txt
+++ b/requirements/isolated.txt
@@ -32,6 +32,7 @@ requests==2.22.0
 s3transfer==0.2.1
 serverlessrepo==0.1.9
 six==1.11.0
+toml==0.10.0
 tzlocal==2.0.0
 urllib3==1.25.3
 websocket-client==0.56.0

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -1,0 +1,158 @@
+"""
+CLI configuration decorator to use TOML configuration files for click commands.
+"""
+
+## This section contains code copied and modified from [click_config_file][https://github.com/phha/click_config_file/blob/master/click_config_file.py]
+## SPDX-License-Identifier: MIT
+
+import functools
+import os
+import logging
+
+import click
+import toml
+
+__all__ = ("TomlProvider", "configuration_option")
+
+LOG = logging.getLogger(__name__)
+DEFAULT_CONFIG_FILE_NAME = "sam-app-config"
+
+
+class TomlProvider:
+    """
+    A parser for toml configuration files
+
+    Parameters
+    ----------
+    section : str
+        If this is set to something other than the default of `None`, the
+        provider will look for a corresponding section inside the
+        configuration file and return only the values from that section.
+    """
+
+    def __init__(self, section=None):
+        self.section = section
+
+    def __call__(self, file_path, cmd_name):
+        """
+        Parse and return the configuration parameters.
+
+        Parameters
+        ----------
+        file_path : str
+            The path to the configuration file
+        cmd_name : str
+            The name of the click command
+
+        Returns
+        -------
+        dict
+            A dictionary containing the configuration parameters.
+        """
+        config = toml.load(file_path)
+        if self.section:
+            try:
+                config = config[self.section]
+            except KeyError:
+                LOG.warning("Specified section: %s does not exist in the config file", self.section)
+        return config
+
+
+def configuration_callback(cmd_name, option_name, config_file_name, saved_callback, provider, ctx, param, value):
+    """
+    Callback for reading the config file.
+
+    Also takes care of calling user specified custom callback afterwards.
+
+    cmd_name : str
+        The command name. This is used to determine the configuration directory.
+    option_name : str
+        The name of the option. This is used for error messages.
+    config_file_name : str
+        The name of the configuration file.
+    saved_callback: callable
+        User-specified callback to be called later.
+    provider : callable
+        A callable that parses the configuration file and returns a dictionary
+        of the configuration parameters. Will be called as
+        `provider(file_path, cmd_name)`. Default: `toml_provider()`
+    ctx : object
+        Click context.
+    """
+    ctx.default_map = ctx.default_map or {}
+    cmd_name = cmd_name or ctx.info_name
+
+    default_value = os.path.join(".aws-sam", config_file_name)
+
+    param.default = default_value
+    value = value or default_value
+
+    if os.path.isfile(value):
+        try:
+            LOG.info("Config file location: %s", os.path.abspath(value))
+            config = provider(value, cmd_name)
+
+        except Exception as e:
+
+            raise click.BadOptionUsage(option_name, "Error reading configuration file: {}".format(e), ctx)
+        ctx.default_map.update(config)
+
+    return saved_callback(ctx, param, value) if saved_callback else value
+
+
+def configuration_option(*param_decls, **attrs):
+    """
+    Adds configuration file support to a click application.
+
+    This will create an option of type `click.File` expecting the path to a
+    configuration file. When specified, it overwrites the default values for
+    all other click arguments or options with the corresponding value from the
+    configuration file.
+
+    The default name of the option is `--config`.
+
+    This decorator accepts the same arguments as `click.option` and
+    `click.Path`. In addition, the following keyword arguments are available:
+
+    cmd_name : str
+        The command name. This is used to determine the configuration
+        directory. Default: `ctx.info_name`
+    config_file_name : str
+        The name of the configuration file. Default: `'sam-app-config'``
+    provider : callable
+        A callable that parses the configuration file and returns a dictionary
+        of the configuration parameters. Will be called as
+        `provider(file_path, cmd_name)`. Default: `toml_provider()`
+        """
+    param_decls = param_decls or ("--config",)
+    option_name = param_decls[0]
+
+    def decorator(f):
+
+        attrs.setdefault("is_eager", True)
+        attrs.setdefault("help", "Read configuration from FILE.")
+        attrs.setdefault("expose_value", False)
+        cmd_name = attrs.pop("cmd_name", None)
+        config_file_name = attrs.pop("config_file_name", DEFAULT_CONFIG_FILE_NAME)
+        provider = attrs.pop("provider", TomlProvider())
+        path_default_params = {
+            "exists": False,
+            "file_okay": True,
+            "dir_okay": False,
+            "writable": False,
+            "readable": True,
+            "resolve_path": False,
+        }
+        path_params = {k: attrs.pop(k, v) for k, v in path_default_params.items()}
+        attrs["type"] = click.Path(**path_params)
+        saved_callback = attrs.pop("callback", None)
+        partial_callback = functools.partial(
+            configuration_callback, cmd_name, option_name, config_file_name, saved_callback, provider
+        )
+        attrs["callback"] = partial_callback
+        return click.option(*param_decls, **attrs)(f)
+
+    return decorator
+
+
+# End section copied from [[click_config_file][https://github.com/phha/click_config_file/blob/master/click_config_file.py]

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -31,6 +31,10 @@ class TomlProvider:
 
     def __call__(self, file_path, config_env, cmd_name):
         """
+        Get resolved config based on the `file_path` for the configuration file,
+        `config_env` targeted inside the config file and corresponding `cmd_name`
+        as denoted by `click`.
+
         :param file_path: The path to the configuration file
         :param config_env: The name of the sectional config_env within configuration file.
         :param cmd_name: sam command name as defined by click

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -15,86 +15,93 @@ import toml
 __all__ = ("TomlProvider", "configuration_option")
 
 LOG = logging.getLogger(__name__)
-DEFAULT_CONFIG_FILE_NAME = "sam-app-config"
+DEFAULT_CONFIG_FILE_NAME = "sam-config"
+DEFAULT_IDENTIFER = "default"
 
 
 class TomlProvider:
     """
     A parser for toml configuration files
-
-    Parameters
-    ----------
-    section : str
-        If this is set to something other than the default of `None`, the
-        provider will look for a corresponding section inside the
-        configuration file and return only the values from that section.
+    :param cmd: sam command name as defined by click
+    :param section: section defined in the configuration file nested within `cmd`
     """
 
-    def __init__(self, section=None):
+    def __init__(self, cmd=None, section=None):
+        self.cmd = cmd
         self.section = section
 
-    def __call__(self, file_path, cmd_name):
+    def __call__(self, file_path, identifier, cmd_name):
         """
-        Parse and return the configuration parameters.
-
-        Parameters
-        ----------
-        file_path : str
-            The path to the configuration file
-        cmd_name : str
-            The name of the click command
-
-        Returns
-        -------
-        dict
-            A dictionary containing the configuration parameters.
+        :param file_path: The path to the configuration file
+        :param identifier: The name of the sectional identifier within configuration file.
+        :param cmd_name: sam command name as defined by click
+        :returns dictionary containing the configuration parameters under specified identifier
         """
         config = toml.load(file_path)
+        resolved_config = {}
         if self.section:
             try:
-                config = config[self.section]
+                resolved_config = self._get_identifier(config, identifier)[self.cmd][self.section]
             except KeyError:
-                LOG.warning("Specified section: %s does not exist in the config file", self.section)
-        return config
+                LOG.debug(
+                    "Error reading configuration file at %s with identifier %s, command %s, section %s",
+                    file_path,
+                    identifier,
+                    self.cmd,
+                    self.section,
+                )
+        return resolved_config
+
+    def _get_identifier(self, config, identifier):
+        """
+
+        :param config: loaded TOML configuration file into dictionary representation
+        :param identifier: top level section defined within TOML configuration file
+        :return:
+        """
+        return config.get(identifier)
 
 
-def configuration_callback(cmd_name, option_name, config_file_name, saved_callback, provider, ctx, param, value):
+def configuration_callback(cmd_name, option_name, identifier_name, saved_callback, provider, ctx, param, value):
     """
     Callback for reading the config file.
 
     Also takes care of calling user specified custom callback afterwards.
 
-    cmd_name : str
-        The command name. This is used to determine the configuration directory.
-    option_name : str
-        The name of the option. This is used for error messages.
-    config_file_name : str
-        The name of the configuration file.
-    saved_callback: callable
-        User-specified callback to be called later.
-    provider : callable
-        A callable that parses the configuration file and returns a dictionary
+    :param cmd_name: `sam` command name derived from click.
+    :param option_name: The name of the option. This is used for error messages.
+    :param identifier_name: `top` level section within configuration file
+    :param saved_callback: User-specified callback to be called later.
+    :param provider:  A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
-        `provider(file_path, cmd_name)`. Default: `toml_provider()`
-    ctx : object
-        Click context.
+        `provider(file_path, identifier, cmd_name)`.
+    :param ctx: Click context
+    :param param: Click parameter
+    :param value: Specified value for identifier
+    :returns specified callback or the specified value for identifier.
     """
     ctx.default_map = ctx.default_map or {}
     cmd_name = cmd_name or ctx.info_name
 
-    default_value = os.path.join(".aws-sam", config_file_name)
+    config_file = os.getenv("SAM_CONFIG", os.path.abspath(os.path.join(".", DEFAULT_CONFIG_FILE_NAME)))
 
-    param.default = default_value
-    value = value or default_value
+    param.default = DEFAULT_IDENTIFER
+    identifier_name = value or identifier_name
 
-    if os.path.isfile(value):
+    if os.path.isfile(config_file):
         try:
-            LOG.info("Config file location: %s", os.path.abspath(value))
-            config = provider(value, cmd_name)
+            LOG.debug("Config file location: %s", os.path.abspath(config_file))
+            config = provider(config_file, identifier_name, cmd_name)
 
-        except Exception as e:
+        except Exception as ex:
 
-            raise click.BadOptionUsage(option_name, "Error reading configuration file: {}".format(e), ctx)
+            raise click.BadOptionUsage(
+                option_name,
+                "Error reading configuration file: {} with identifier {}, {}".format(
+                    config_file, identifier_name, str(ex)
+                ),
+                ctx,
+            )
         ctx.default_map.update(config)
 
     return saved_callback(ctx, param, value) if saved_callback else value
@@ -104,50 +111,37 @@ def configuration_option(*param_decls, **attrs):
     """
     Adds configuration file support to a click application.
 
-    This will create an option of type `click.File` expecting the path to a
-    configuration file. When specified, it overwrites the default values for
-    all other click arguments or options with the corresponding value from the
-    configuration file.
+    This will create an option of type `STRING` expecting the identifier in the
+    configuration file, by default this identifier is `default`. When specified,
+    the requisite portion of the configuration file is considered as the
+    source of truth.
 
-    The default name of the option is `--config`.
+    The default name of the option is `--identifier`.
 
-    This decorator accepts the same arguments as `click.option` and
-    `click.Path`. In addition, the following keyword arguments are available:
-
-    cmd_name : str
-        The command name. This is used to determine the configuration
-        directory. Default: `ctx.info_name`
-    config_file_name : str
-        The name of the configuration file. Default: `'sam-app-config'``
-    provider : callable
-        A callable that parses the configuration file and returns a dictionary
+    This decorator accepts the same arguments as `click.option`.
+    In addition, the following keyword arguments are available:
+    :param cmd_name: The command name. Default: `ctx.info_name`
+    :param identifier_name: The identifier name. This is used to determine which part of the configuration
+        needs to be read.
+    :param provider:         A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
-        `provider(file_path, cmd_name)`. Default: `toml_provider()`
-        """
-    param_decls = param_decls or ("--config",)
+        `provider(file_path, identifier, cmd_name)
+    """
+    param_decls = param_decls or ("--identifier",)
     option_name = param_decls[0]
 
     def decorator(f):
 
         attrs.setdefault("is_eager", True)
-        attrs.setdefault("help", "Read configuration from FILE.")
+        attrs.setdefault("help", "Read identifier from Configuration File.")
         attrs.setdefault("expose_value", False)
         cmd_name = attrs.pop("cmd_name", None)
-        config_file_name = attrs.pop("config_file_name", DEFAULT_CONFIG_FILE_NAME)
+        identifier_name = attrs.pop("identifier_name", DEFAULT_IDENTIFER)
         provider = attrs.pop("provider", TomlProvider())
-        path_default_params = {
-            "exists": False,
-            "file_okay": True,
-            "dir_okay": False,
-            "writable": False,
-            "readable": True,
-            "resolve_path": False,
-        }
-        path_params = {k: attrs.pop(k, v) for k, v in path_default_params.items()}
-        attrs["type"] = click.Path(**path_params)
+        attrs["type"] = click.STRING
         saved_callback = attrs.pop("callback", None)
         partial_callback = functools.partial(
-            configuration_callback, cmd_name, option_name, config_file_name, saved_callback, provider
+            configuration_callback, cmd_name, option_name, identifier_name, saved_callback, provider
         )
         attrs["callback"] = partial_callback
         return click.option(*param_decls, **attrs)(f)

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -113,7 +113,9 @@ def get_ctx_defaults(cmd_name, provider, ctx, config_env_name=DEFAULT_IDENTIFER)
     :param config_env_name: config-env within configuration file
     :return: dictionary of defaults for parameters
     """
-    config_file = os.path.join(os.getcwd(), DEFAULT_CONFIG_FILE_NAME)
+
+    cwd = getattr(ctx, "config_path", None)
+    config_file = os.path.join(cwd if cwd else os.getcwd(), DEFAULT_CONFIG_FILE_NAME)
     config = {}
     if os.path.isfile(config_file):
         LOG.debug("Config file location: %s", os.path.abspath(config_file))
@@ -169,7 +171,8 @@ def configuration_option(*param_decls, **attrs):
         attrs.setdefault("expose_value", False)
         # --config-env is hidden and can potentially be opened up in the future.
         attrs.setdefault("hidden", True)
-        config_env_name = attrs.pop("config_env_name", DEFAULT_IDENTIFER)
+        # explicitly ignore values passed to --config-env, can be opened up in the future.
+        config_env_name = DEFAULT_IDENTIFER
         provider = attrs.pop("provider")
         attrs["type"] = click.STRING
         saved_callback = attrs.pop("callback", None)

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -12,10 +12,10 @@ import logging
 import click
 import toml
 
-__all__ = ("TomlProvider", "configuration_option")
+__all__ = ("TomlProvider", "configuration_option", "get_ctx_defaults")
 
-LOG = logging.getLogger(__name__)
-DEFAULT_CONFIG_FILE_NAME = "sam-config"
+LOG = logging.getLogger("samcli")
+DEFAULT_CONFIG_FILE_NAME = "samconfig.toml"
 DEFAULT_IDENTIFER = "default"
 
 
@@ -26,43 +26,46 @@ class TomlProvider:
     :param section: section defined in the configuration file nested within `cmd`
     """
 
-    def __init__(self, cmd=None, section=None):
-        self.cmd = cmd
+    def __init__(self, section=None):
         self.section = section
 
-    def __call__(self, file_path, identifier, cmd_name):
+    def __call__(self, file_path, config_env, cmd_name):
         """
         :param file_path: The path to the configuration file
-        :param identifier: The name of the sectional identifier within configuration file.
+        :param config_env: The name of the sectional config_env within configuration file.
         :param cmd_name: sam command name as defined by click
-        :returns dictionary containing the configuration parameters under specified identifier
+        :returns dictionary containing the configuration parameters under specified config_env
         """
-        config = toml.load(file_path)
         resolved_config = {}
+        try:
+            config = toml.load(file_path)
+        except Exception as ex:
+            LOG.error("Error reading configuration file :%s %s", file_path, str(ex))
+            return resolved_config
         if self.section:
             try:
-                resolved_config = self._get_identifier(config, identifier)[self.cmd][self.section]
+                resolved_config = self._get_config_env(config, config_env)[cmd_name][self.section]
             except KeyError:
                 LOG.debug(
-                    "Error reading configuration file at %s with identifier %s, command %s, section %s",
+                    "Error reading configuration file at %s with config_env %s, command %s, section %s",
                     file_path,
-                    identifier,
-                    self.cmd,
+                    config_env,
+                    cmd_name,
                     self.section,
                 )
         return resolved_config
 
-    def _get_identifier(self, config, identifier):
+    def _get_config_env(self, config, config_env):
         """
 
         :param config: loaded TOML configuration file into dictionary representation
-        :param identifier: top level section defined within TOML configuration file
+        :param config_env: top level section defined within TOML configuration file
         :return:
         """
-        return config.get(identifier)
+        return config.get(config_env, config.get(DEFAULT_IDENTIFER, {}))
 
 
-def configuration_callback(cmd_name, option_name, identifier_name, saved_callback, provider, ctx, param, value):
+def configuration_callback(cmd_name, option_name, config_env_name, saved_callback, provider, ctx, param, value):
     """
     Callback for reading the config file.
 
@@ -70,78 +73,104 @@ def configuration_callback(cmd_name, option_name, identifier_name, saved_callbac
 
     :param cmd_name: `sam` command name derived from click.
     :param option_name: The name of the option. This is used for error messages.
-    :param identifier_name: `top` level section within configuration file
+    :param config_env_name: `top` level section within configuration file
     :param saved_callback: User-specified callback to be called later.
     :param provider:  A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
-        `provider(file_path, identifier, cmd_name)`.
+        `provider(file_path, config_env, cmd_name)`.
     :param ctx: Click context
     :param param: Click parameter
-    :param value: Specified value for identifier
-    :returns specified callback or the specified value for identifier.
+    :param value: Specified value for config_env
+    :returns specified callback or the specified value for config_env.
     """
+
+    # ctx, param and value are default arguments for click specified callbacks.
     ctx.default_map = ctx.default_map or {}
     cmd_name = cmd_name or ctx.info_name
-
-    config_file = os.getenv("SAM_CONFIG", os.path.abspath(os.path.join(".", DEFAULT_CONFIG_FILE_NAME)))
-
     param.default = DEFAULT_IDENTIFER
-    identifier_name = value or identifier_name
-
-    if os.path.isfile(config_file):
-        try:
-            LOG.debug("Config file location: %s", os.path.abspath(config_file))
-            config = provider(config_file, identifier_name, cmd_name)
-
-        except Exception as ex:
-
-            raise click.BadOptionUsage(
-                option_name,
-                "Error reading configuration file: {} with identifier {}, {}".format(
-                    config_file, identifier_name, str(ex)
-                ),
-                ctx,
-            )
-        ctx.default_map.update(config)
+    config_env_name = value or config_env_name
+    config = get_ctx_defaults(cmd_name, provider, ctx, config_env_name=config_env_name)
+    ctx.default_map.update(config)
 
     return saved_callback(ctx, param, value) if saved_callback else value
+
+
+def get_ctx_defaults(cmd_name, provider, ctx, config_env_name=DEFAULT_IDENTIFER):
+    """
+    Get the set of the parameters that are needed to be set into the click command.
+    This function also figures out the command name by looking up current click context's parent
+    and constructing the parsed command name that is used in default configuration file.
+    If a given cmd_name is start-api, the parsed name is "local_start_api".
+    provider is called with `config_file`, `config_env_name` and `parsed_cmd_name`.
+
+    :param cmd_name: `sam` command name
+    :param provider: provider to be called for reading configuration file
+    :param ctx: Click context
+    :param config_env_name: config-env within configuration file
+    :return: dictionary of defaults for parameters
+    """
+    config_file = os.path.join(os.getcwd(), DEFAULT_CONFIG_FILE_NAME)
+    config = {}
+    if os.path.isfile(config_file):
+        LOG.debug("Config file location: %s", os.path.abspath(config_file))
+
+        # Find parent of current context
+        _parent = ctx.parent
+        _cmd_names = []
+        # Need to find the total set of commands that current command is part of.
+        if cmd_name != ctx.info_name:
+            _cmd_names = [cmd_name]
+        _cmd_names.append(ctx.info_name)
+        # Go through all parents till a parent of a context exists.
+        while _parent.parent:
+            info_name = _parent.info_name
+            _cmd_names.append(info_name)
+            _parent = _parent.parent
+
+        # construct a parsed name that is of the format: a_b_c_d
+        parsed_cmd_name = "_".join(reversed([cmd.replace("-", "_").replace(" ", "_") for cmd in _cmd_names]))
+
+        config = provider(config_file, config_env_name, parsed_cmd_name)
+
+    return config
 
 
 def configuration_option(*param_decls, **attrs):
     """
     Adds configuration file support to a click application.
 
-    This will create an option of type `STRING` expecting the identifier in the
-    configuration file, by default this identifier is `default`. When specified,
+    This will create an option of type `STRING` expecting the config_env in the
+    configuration file, by default this config_env is `default`. When specified,
     the requisite portion of the configuration file is considered as the
     source of truth.
 
-    The default name of the option is `--identifier`.
+    The default name of the option is `--config-env`.
 
     This decorator accepts the same arguments as `click.option`.
     In addition, the following keyword arguments are available:
     :param cmd_name: The command name. Default: `ctx.info_name`
-    :param identifier_name: The identifier name. This is used to determine which part of the configuration
+    :param config_env_name: The config_env name. This is used to determine which part of the configuration
         needs to be read.
     :param provider:         A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
-        `provider(file_path, identifier, cmd_name)
+        `provider(file_path, config_env, cmd_name)
     """
-    param_decls = param_decls or ("--identifier",)
+    param_decls = param_decls or ("--config-env",)
     option_name = param_decls[0]
 
     def decorator(f):
 
         attrs.setdefault("is_eager", True)
-        attrs.setdefault("help", "Read identifier from Configuration File.")
+        attrs.setdefault("help", "Read config-env from Configuration File.")
         attrs.setdefault("expose_value", False)
-        cmd_name = attrs.pop("cmd_name", None)
-        identifier_name = attrs.pop("identifier_name", DEFAULT_IDENTIFER)
-        provider = attrs.pop("provider", TomlProvider())
+        # --config-env is hidden and can potentially be opened up in the future.
+        attrs.setdefault("hidden", True)
+        config_env_name = attrs.pop("config_env_name", DEFAULT_IDENTIFER)
+        provider = attrs.pop("provider")
         attrs["type"] = click.STRING
         saved_callback = attrs.pop("callback", None)
         partial_callback = functools.partial(
-            configuration_callback, cmd_name, option_name, identifier_name, saved_callback, provider
+            configuration_callback, None, option_name, config_env_name, saved_callback, provider
         )
         attrs["callback"] = partial_callback
         return click.option(*param_decls, **attrs)(f)

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -7,6 +7,7 @@ import logging
 from functools import partial
 
 import click
+from click.types import FuncParamType
 from samcli.cli.types import CfnParameterOverridesType, CfnMetadataType, CfnTags
 from samcli.commands._utils.custom_options.option_nargs import OptionNargs
 
@@ -143,7 +144,7 @@ def capabilities_click_option():
     return click.option(
         "--capabilities",
         cls=OptionNargs,
-        type=click.STRING,
+        type=FuncParamType(lambda value: value.split(" ")),
         required=True,
         help="A list of  capabilities  that  you  must  specify"
         "before  AWS  Cloudformation  can create certain stacks. Some stack tem-"
@@ -182,7 +183,7 @@ def notification_arns_click_option():
     return click.option(
         "--notification-arns",
         cls=OptionNargs,
-        type=click.STRING,
+        type=FuncParamType(lambda value: value.split(" ")),
         required=False,
         help="Amazon  Simple  Notification  Service  topic"
         "Amazon  Resource  Names  (ARNs) that AWS CloudFormation associates with"

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -47,7 +47,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     result = os.path.abspath(provided_value)
 
     if ctx:
-        setattr(ctx, "config_path", os.path.dirname(provided_value))
+        setattr(ctx, "config_path", result)
     LOG.debug("Using SAM Template at %s", result)
     return result
 

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -47,7 +47,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     result = os.path.abspath(provided_value)
 
     if ctx:
-        setattr(ctx, "config_path", result)
+        setattr(ctx, "config_path", os.path.dirname(result))
     LOG.debug("Using SAM Template at %s", result)
     return result
 

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -44,8 +44,10 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
             if os.path.exists(option):
                 provided_value = option
                 break
-
     result = os.path.abspath(provided_value)
+
+    if ctx:
+        setattr(ctx, "config_path", os.path.dirname(provided_value))
     LOG.debug("Using SAM Template at %s", result)
     return result
 
@@ -75,6 +77,7 @@ def template_click_option(include_build=True):
     Click Option for template option
     """
     return click.option(
+        "--template-file",
         "--template",
         "-t",
         default=_TEMPLATE_OPTION_DEFAULT_VALUE,
@@ -82,6 +85,7 @@ def template_click_option(include_build=True):
         envvar="SAM_TEMPLATE_FILE",
         callback=partial(get_or_default_template_file_name, include_build=include_build),
         show_default=True,
+        is_eager=True,
         help="AWS SAM template file",
     )
 

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -10,6 +10,7 @@ from samcli.commands._utils.options import template_option_without_build, docker
     parameter_override_option
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.lib.telemetry.metrics import track_command
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 
 LOG = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ $ sam build && sam package --s3-bucket <bucketname>
 """
 
 
+@configuration_option(provider=TomlProvider(section="build"))
 @click.command("build", help=HELP_TEXT, short_help="Build your Lambda function code")
 @click.option('--build-dir', '-b',
               default=DEFAULT_BUILD_DIR,

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -84,7 +84,7 @@ $ sam build && sam package --s3-bucket <bucketname>
 @track_command
 def cli(ctx,
         function_identifier,
-        template,
+        template_file,
         base_dir,
         build_dir,
         use_container,
@@ -97,7 +97,7 @@ def cli(ctx,
 
     mode = _get_mode_value_from_envvar("SAM_BUILD_MODE", choices=["debug"])
 
-    do_cli(function_identifier, template, base_dir, build_dir, True, use_container, manifest, docker_network,
+    do_cli(function_identifier, template_file, base_dir, build_dir, True, use_container, manifest, docker_network,
            skip_pull_image, parameter_overrides, mode)  # pragma: no cover
 
 

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -54,7 +54,6 @@ $ sam build && sam package --s3-bucket <bucketname>
 """
 
 
-@configuration_option(provider=TomlProvider(section="build"))
 @click.command("build", help=HELP_TEXT, short_help="Build your Lambda function code")
 @click.option('--build-dir', '-b',
               default=DEFAULT_BUILD_DIR,
@@ -79,6 +78,7 @@ $ sam build && sam package --s3-bucket <bucketname>
 @docker_common_options
 @cli_framework_options
 @aws_creds_options
+@configuration_option(provider=TomlProvider(cmd="build", section="parameters"))
 @click.argument('function_identifier', required=False)
 @pass_context
 @track_command

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -54,6 +54,7 @@ $ sam build && sam package --s3-bucket <bucketname>
 """
 
 
+@configuration_option(provider=TomlProvider(section="parameters"))
 @click.command("build", help=HELP_TEXT, short_help="Build your Lambda function code")
 @click.option('--build-dir', '-b',
               default=DEFAULT_BUILD_DIR,
@@ -78,7 +79,6 @@ $ sam build && sam package --s3-bucket <bucketname>
 @docker_common_options
 @cli_framework_options
 @aws_creds_options
-@configuration_option(provider=TomlProvider(cmd="build", section="parameters"))
 @click.argument('function_identifier', required=False)
 @pass_context
 @track_command

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -4,7 +4,7 @@ CLI command for "deploy" command
 
 import click
 
-
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 from samcli.commands._utils.options import (
     parameter_override_option,
     capabilities_override_option,
@@ -27,6 +27,7 @@ e.g. sam deploy --template-file packaged.yaml --stack-name sam-app --capabilitie
 """
 
 
+@configuration_option(provider=TomlProvider(section="parameters"))
 @click.command(
     "deploy",
     short_help=SHORT_HELP,

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -10,6 +10,7 @@ from samcli.commands._utils.options import (
     capabilities_override_option,
     tags_override_option,
     notification_arns_override_option,
+    template_click_option,
 )
 from samcli.cli.main import pass_context, common_options, aws_creds_options
 from samcli.lib.telemetry.metrics import track_command
@@ -34,14 +35,7 @@ e.g. sam deploy --template-file packaged.yaml --stack-name sam-app --capabilitie
     context_settings={"ignore_unknown_options": False, "allow_interspersed_args": True, "allow_extra_args": True},
     help=HELP_TEXT,
 )
-@click.option(
-    "--template-file",
-    "--template",
-    "-t",
-    required=True,
-    type=click.Path(),
-    help="The path where your AWS SAM template is located",
-)
+@template_click_option(include_build=False)
 @click.option(
     "--stack-name",
     required=True,

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -8,6 +8,7 @@ from json import JSONDecodeError
 
 import click
 
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 from samcli.commands.exceptions import UserException
 from samcli.cli.main import pass_context, common_options, global_cfg
 from samcli.local.common.runtime_template import RUNTIMES, SUPPORTED_DEP_MANAGERS
@@ -55,6 +56,7 @@ Common usage:
 """
 
 
+@configuration_option(provider=TomlProvider(section="parameters"))
 @click.command(
     "init",
     help=HELP_TEXT,

--- a/samcli/commands/local/generate_event/event_generation.py
+++ b/samcli/commands/local/generate_event/event_generation.py
@@ -3,10 +3,12 @@ Generates the services and commands for selection in SAM CLI generate-event
 """
 
 import functools
+
 import click
 
-from samcli.cli.options import debug_option
 import samcli.commands.local.lib.generated_sample_events.events as events
+from samcli.cli.cli_config_file import TomlProvider, get_ctx_defaults
+from samcli.cli.options import debug_option
 from samcli.lib.telemetry.metrics import track_command
 
 
@@ -150,9 +152,13 @@ class EventTypeSubCommand(click.MultiCommand):
         command_callback = functools.partial(
             self.cmd_implementation, self.events_lib, self.top_level_cmd_name, cmd_name
         )
+
+        config = get_ctx_defaults(cmd_name=cmd_name, provider=TomlProvider(section="parameters"), ctx=ctx)
+
         cmd = click.Command(
             name=cmd_name,
             short_help=self.subcmd_definition[cmd_name]["help"],
+            context_settings={"default_map": config},
             params=parameters,
             callback=command_callback,
         )

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -31,6 +31,7 @@ STDIN_FILE_NAME = "-"
 
 
 @click.command("invoke", help=HELP_TEXT, short_help="Invokes a local Lambda function once.")
+@configuration_option(provider=TomlProvider(cmd="local_invoke", section="parameters"))
 @click.option(
     "--event",
     "-e",
@@ -42,7 +43,6 @@ STDIN_FILE_NAME = "-"
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options
-@configuration_option(provider=TomlProvider(section="local_invoke"))
 @click.argument("function_identifier", required=False)
 @pass_context
 @track_command  # pylint: disable=R0914

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -49,7 +49,7 @@ STDIN_FILE_NAME = "-"
 def cli(
     ctx,
     function_identifier,
-    template,
+    template_file,
     event,
     no_event,
     env_vars,
@@ -70,7 +70,7 @@ def cli(
     do_cli(
         ctx,
         function_identifier,
-        template,
+        template_file,
         event,
         no_event,
         env_vars,

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -8,6 +8,7 @@ import click
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands.local.cli_common.options import invoke_common_options
 from samcli.lib.telemetry.metrics import track_command
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 
 LOG = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ STDIN_FILE_NAME = "-"
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options
+@configuration_option(provider=TomlProvider(section="local_invoke"))
 @click.argument("function_identifier", required=False)
 @pass_context
 @track_command  # pylint: disable=R0914

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -31,7 +31,7 @@ STDIN_FILE_NAME = "-"
 
 
 @click.command("invoke", help=HELP_TEXT, short_help="Invokes a local Lambda function once.")
-@configuration_option(provider=TomlProvider(cmd="local_invoke", section="parameters"))
+@configuration_option(provider=TomlProvider(section="parameters"))
 @click.option(
     "--event",
     "-e",

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -32,7 +32,7 @@ and point SAM to the directory or file containing build artifacts.
     short_help="Sets up a local endpoint you can use to test your API. Supports hot-reloading "
     "so you don't need to restart this service when you make changes to your function.",
 )
-@configuration_option(provider=TomlProvider(cmd="local_start_api", section="parameters"))
+@configuration_option(provider=TomlProvider(section="parameters"))
 @service_common_options(3000)
 @click.option(
     "--static-dir",

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -52,7 +52,7 @@ def cli(
     port,
     static_dir,
     # Common Options for Lambda Invoke
-    template,
+    template_file,
     env_vars,
     debug_port,
     debug_args,
@@ -72,7 +72,7 @@ def cli(
         host,
         port,
         static_dir,
-        template,
+        template_file,
         env_vars,
         debug_port,
         debug_args,

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -8,6 +8,7 @@ import click
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands.local.cli_common.options import invoke_common_options, service_common_options
 from samcli.lib.telemetry.metrics import track_command
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 
 LOG = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ and point SAM to the directory or file containing build artifacts.
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options  # pylint: disable=R0914
+@configuration_option(provider=TomlProvider(section="local_start_api"))
 @pass_context
 @track_command
 def cli(

--- a/samcli/commands/local/start_api/cli.py
+++ b/samcli/commands/local/start_api/cli.py
@@ -32,6 +32,7 @@ and point SAM to the directory or file containing build artifacts.
     short_help="Sets up a local endpoint you can use to test your API. Supports hot-reloading "
     "so you don't need to restart this service when you make changes to your function.",
 )
+@configuration_option(provider=TomlProvider(cmd="local_start_api", section="parameters"))
 @service_common_options(3000)
 @click.option(
     "--static-dir",
@@ -42,7 +43,6 @@ and point SAM to the directory or file containing build artifacts.
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options  # pylint: disable=R0914
-@configuration_option(provider=TomlProvider(section="local_start_api"))
 @pass_context
 @track_command
 def cli(

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -50,11 +50,11 @@ Here is a Python example:
     help=HELP_TEXT,
     short_help="Starts a local endpoint you can use to invoke your local Lambda functions.",
 )
+@configuration_option(provider=TomlProvider(cmd="local_start_lambda", section="parameters"))
 @service_common_options(3001)
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options
-@configuration_option(provider=TomlProvider(section="local_start_lambda"))
 @pass_context
 @track_command
 def cli(

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -50,7 +50,7 @@ Here is a Python example:
     help=HELP_TEXT,
     short_help="Starts a local endpoint you can use to invoke your local Lambda functions.",
 )
-@configuration_option(provider=TomlProvider(cmd="local_start_lambda", section="parameters"))
+@configuration_option(provider=TomlProvider(section="parameters"))
 @service_common_options(3001)
 @invoke_common_options
 @cli_framework_options

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -8,6 +8,7 @@ import click
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands.local.cli_common.options import invoke_common_options, service_common_options
 from samcli.lib.telemetry.metrics import track_command
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 
 LOG = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ Here is a Python example:
 @invoke_common_options
 @cli_framework_options
 @aws_creds_options
+@configuration_option(provider=TomlProvider(section="local_start_lambda"))
 @pass_context
 @track_command
 def cli(

--- a/samcli/commands/local/start_lambda/cli.py
+++ b/samcli/commands/local/start_lambda/cli.py
@@ -63,7 +63,7 @@ def cli(
     host,
     port,
     # Common Options for Lambda Invoke
-    template,
+    template_file,
     env_vars,
     debug_port,
     debug_args,
@@ -82,7 +82,7 @@ def cli(
         ctx,
         host,
         port,
-        template,
+        template_file,
         env_vars,
         debug_port,
         debug_args,

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -33,7 +33,7 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
 
 
 @click.command("logs", help=HELP_TEXT, short_help="Fetch logs for a function")
-@configuration_option(provider=TomlProvider(cmd="logs", section="parameters"))
+@configuration_option(provider=TomlProvider(section="parameters"))
 @click.option(
     "--name",
     "-n",

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -33,6 +33,7 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
 
 
 @click.command("logs", help=HELP_TEXT, short_help="Fetch logs for a function")
+@configuration_option(provider=TomlProvider(cmd="logs", section="parameters"))
 @click.option(
     "--name",
     "-n",
@@ -71,7 +72,6 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
     "become available.",
 )
 @cli_framework_options
-@configuration_option(provider=TomlProvider(section="logs"))
 @aws_creds_options
 @pass_context
 @track_command

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -7,6 +7,7 @@ import click
 
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.lib.telemetry.metrics import track_command
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 LOG = logging.getLogger(__name__)
 
@@ -70,6 +71,7 @@ $ sam logs -n HelloWorldFunction --stack-name mystack --filter "error" \n
     "become available.",
 )
 @cli_framework_options
+@configuration_option(provider=TomlProvider(section="logs"))
 @aws_creds_options
 @pass_context
 @track_command

--- a/samcli/commands/package/__init__.py
+++ b/samcli/commands/package/__init__.py
@@ -4,3 +4,4 @@
 
 # Expose the cli object here
 from .command import cli  # noqa
+

--- a/samcli/commands/package/__init__.py
+++ b/samcli/commands/package/__init__.py
@@ -4,4 +4,3 @@
 
 # Expose the cli object here
 from .command import cli  # noqa
-

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import click
 
+from samcli.cli.cli_config_file import TomlProvider, configuration_option
 from samcli.cli.main import pass_context, common_options, aws_creds_options
 from samcli.commands._utils.options import (
     metadata_override_option,
@@ -40,6 +41,7 @@ The following resources and their property locations are supported.
 
 
 @click.command("package", short_help=SHORT_HELP, help=HELP_TEXT, context_settings=dict(max_content_width=120))
+@configuration_option(provider=TomlProvider(cmd="package", section="parameters"))
 # TODO(TheSriram): Move to template_common_option across aws-sam-cli
 @click.option(
     "--template",

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -11,6 +11,7 @@ from samcli.commands._utils.options import (
     metadata_override_option,
     _TEMPLATE_OPTION_DEFAULT_VALUE,
     get_or_default_template_file_name,
+    template_click_option,
 )
 from samcli.commands._utils.resources import resources_generator
 from samcli.lib.telemetry.metrics import track_command
@@ -42,18 +43,7 @@ The following resources and their property locations are supported.
 
 @click.command("package", short_help=SHORT_HELP, help=HELP_TEXT, context_settings=dict(max_content_width=120))
 @configuration_option(provider=TomlProvider(section="parameters"))
-# TODO(TheSriram): Move to template_common_option across aws-sam-cli
-@click.option(
-    "--template",
-    "--template-file",
-    "-t",
-    default=_TEMPLATE_OPTION_DEFAULT_VALUE,
-    type=click.Path(),
-    envvar="SAM_TEMPLATE_FILE",
-    callback=partial(get_or_default_template_file_name, include_build=True),
-    show_default=True,
-    help="AWS SAM template file",
-)
+@template_click_option(include_build=True)
 @click.option(
     "--s3-bucket",
     required=True,
@@ -99,12 +89,12 @@ The following resources and their property locations are supported.
 @aws_creds_options
 @pass_context
 @track_command
-def cli(ctx, template, s3_bucket, s3_prefix, kms_key_id, output_template_file, use_json, force_upload, metadata):
+def cli(ctx, template_file, s3_bucket, s3_prefix, kms_key_id, output_template_file, use_json, force_upload, metadata):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
     do_cli(
-        template,
+        template_file,
         s3_bucket,
         s3_prefix,
         kms_key_id,

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -41,7 +41,7 @@ The following resources and their property locations are supported.
 
 
 @click.command("package", short_help=SHORT_HELP, help=HELP_TEXT, context_settings=dict(max_content_width=120))
-@configuration_option(provider=TomlProvider(cmd="package", section="parameters"))
+@configuration_option(provider=TomlProvider(section="parameters"))
 # TODO(TheSriram): Move to template_common_option across aws-sam-cli
 @click.option(
     "--template",

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -41,7 +41,7 @@ SEMANTIC_VERSION = "SemanticVersion"
 
 
 @click.command("publish", help=HELP_TEXT, short_help=SHORT_HELP)
-@configuration_option(provider=TomlProvider(cmd="publish", section="parameters"))
+@configuration_option(provider=TomlProvider(section="parameters"))
 @template_common_option
 @click.option("--semantic-version", help=SEMANTIC_VERSION_HELP)
 @aws_creds_options

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -48,10 +48,10 @@ SEMANTIC_VERSION = "SemanticVersion"
 @cli_framework_options
 @pass_context
 @track_command
-def cli(ctx, template, semantic_version):
+def cli(ctx, template_file, semantic_version):
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(ctx, template, semantic_version)  # pragma: no cover
+    do_cli(ctx, template_file, semantic_version)  # pragma: no cover
 
 
 def do_cli(ctx, template, semantic_version):

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -11,6 +11,7 @@ from samcli.cli.main import pass_context, common_options as cli_framework_option
 from samcli.commands._utils.options import template_common_option
 from samcli.commands._utils.template import get_template_data
 from samcli.lib.telemetry.metrics import track_command
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 LOG = logging.getLogger(__name__)
 
@@ -40,6 +41,7 @@ SEMANTIC_VERSION = "SemanticVersion"
 
 
 @click.command("publish", help=HELP_TEXT, short_help=SHORT_HELP)
+@configuration_option(provider=TomlProvider(section="publish"))
 @template_common_option
 @click.option("--semantic-version", help=SEMANTIC_VERSION_HELP)
 @aws_creds_options

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -41,7 +41,7 @@ SEMANTIC_VERSION = "SemanticVersion"
 
 
 @click.command("publish", help=HELP_TEXT, short_help=SHORT_HELP)
-@configuration_option(provider=TomlProvider(section="publish"))
+@configuration_option(provider=TomlProvider(cmd="publish", section="parameters"))
 @template_common_option
 @click.option("--semantic-version", help=SEMANTIC_VERSION_HELP)
 @aws_creds_options

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -10,9 +10,11 @@ import click
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
 from samcli.commands._utils.options import template_option_without_build
 from samcli.lib.telemetry.metrics import track_command
+from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 
 @click.command("validate", short_help="Validate an AWS SAM template.")
+@configuration_option(provider=TomlProvider(section="validate"))
 @template_option_without_build
 @aws_creds_options
 @cli_framework_options

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -14,7 +14,7 @@ from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 
 @click.command("validate", short_help="Validate an AWS SAM template.")
-@configuration_option(provider=TomlProvider(section="validate"))
+@configuration_option(provider=TomlProvider(cmd="validate", section="parameters"))
 @template_option_without_build
 @aws_creds_options
 @cli_framework_options

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -20,11 +20,11 @@ from samcli.cli.cli_config_file import configuration_option, TomlProvider
 @cli_framework_options
 @pass_context
 @track_command
-def cli(ctx, template):
+def cli(ctx, template_file):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
 
-    do_cli(ctx, template)  # pragma: no cover
+    do_cli(ctx, template_file)  # pragma: no cover
 
 
 def do_cli(ctx, template):

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -14,7 +14,7 @@ from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
 
 @click.command("validate", short_help="Validate an AWS SAM template.")
-@configuration_option(provider=TomlProvider(cmd="validate", section="parameters"))
+@configuration_option(provider=TomlProvider(section="parameters"))
 @template_option_without_build
 @aws_creds_options
 @cli_framework_options

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -5,69 +5,78 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 
-from samcli.cli.cli_config_file import TomlProvider, configuration_option, configuration_callback
+from samcli.cli.cli_config_file import (
+    TomlProvider,
+    configuration_option,
+    configuration_callback,
+    get_ctx_defaults,
+    DEFAULT_CONFIG_FILE_NAME,
+)
+
+
+class MockContext:
+    def __init__(self, info_name, parent):
+        self.info_name = info_name
+        self.parent = parent
 
 
 class TestTomlProvider(TestCase):
     def setUp(self):
         self.toml_provider = TomlProvider()
-        self.identifier = "identifier"
+        self.config_env = "config_env"
         self.parameters = "parameters"
         self.cmd_name = "topic"
 
     def test_toml_valid_with_section(self):
         with tempfile.NamedTemporaryFile(delete=False) as toml_file:
-            toml_file.write(b"[identifier.topic.parameters]\nword='clarity'\n")
+            toml_file.write(b"[config_env.topic.parameters]\nword='clarity'\n")
             toml_file.flush()
             self.assertEqual(
-                TomlProvider(cmd=self.cmd_name, section=self.parameters)(
-                    toml_file.name, self.identifier, self.cmd_name
-                ),
+                TomlProvider(section=self.parameters)(toml_file.name, self.config_env, self.cmd_name),
                 {"word": "clarity"},
             )
 
-    def test_toml_invalid(self):
+    def test_toml_invalid_empty_dict(self):
         with tempfile.NamedTemporaryFile(delete=False) as toml_file:
             toml_file.write(b"[topic]\nword=clarity\n")
             toml_file.flush()
-            with self.assertRaises(ValueError):
-                self.toml_provider(toml_file.name, self.identifier, self.cmd_name)
+            self.assertEqual(self.toml_provider(toml_file.name, self.config_env, self.cmd_name), {})
 
 
 class TestCliConfiguration(TestCase):
     def setUp(self):
         self.cmd_name = "test_cmd"
         self.option_name = "test_option"
-        self.identifier_name = "test_identifier"
-        self.custom_identifier = "custom"
+        self.config_env = "test_config_env"
         self.saved_callback = MagicMock()
         self.provider = MagicMock()
         self.ctx = MagicMock()
         self.param = MagicMock()
+        self.value = MagicMock()
 
     class Dummy:
         pass
 
-    def test_callback_with_valid_identifier(self):
+    def test_callback_with_valid_config_env(self):
         configuration_callback(
             cmd_name=self.cmd_name,
             option_name=self.option_name,
-            identifier_name=self.identifier_name,
+            config_env_name=self.config_env,
             saved_callback=self.saved_callback,
             provider=self.provider,
             ctx=self.ctx,
             param=self.param,
-            value=self.custom_identifier,
+            value=self.value,
         )
         self.assertEqual(self.saved_callback.call_count, 1)
-        for arg in [self.ctx, self.param, self.custom_identifier]:
+        for arg in [self.ctx, self.param, self.value]:
             self.assertIn(arg, self.saved_callback.call_args[0])
 
-    def test_callback_with_invalid_identifier(self):
+    def test_callback_with_invalid_config_env(self):
         configuration_callback(
             cmd_name=self.cmd_name,
             option_name=self.option_name,
-            identifier_name=self.identifier_name,
+            config_env_name=self.config_env,
             saved_callback=self.saved_callback,
             provider=self.provider,
             ctx=self.ctx,
@@ -81,39 +90,53 @@ class TestCliConfiguration(TestCase):
         configuration_callback(
             cmd_name=self.cmd_name,
             option_name=self.option_name,
-            identifier_name=self.identifier_name,
+            config_env_name=self.config_env,
             saved_callback=self.saved_callback,
             provider=self.provider,
             ctx=self.ctx,
             param=self.param,
-            value=self.custom_identifier,
+            value=self.value,
         )
         self.assertEqual(self.provider.call_count, 0)
         self.assertEqual(self.saved_callback.call_count, 1)
-        for arg in [self.ctx, self.param, self.custom_identifier]:
+        for arg in [self.ctx, self.param, self.value]:
             self.assertIn(arg, self.saved_callback.call_args[0])
-
-    @patch("samcli.cli.cli_config_file.os.path.isfile")
-    def test_callback_with_env_variable_set(self, mock_os_isfile):
-        with patch.dict(os.environ, {"SAM_CONFIG": "~/sam-configurations/sam-config"}):
-            configuration_callback(
-                cmd_name=self.cmd_name,
-                option_name=self.option_name,
-                identifier_name=self.identifier_name,
-                saved_callback=self.saved_callback,
-                provider=self.provider,
-                ctx=self.ctx,
-                param=self.param,
-                value=self.custom_identifier,
-            )
-            self.assertEqual(self.provider.call_count, 1)
-            self.provider.assert_called_with("~/sam-configurations/sam-config", self.custom_identifier, self.cmd_name)
 
     def test_configuration_option(self):
         toml_provider = TomlProvider()
         click_option = configuration_option(provider=toml_provider)
         clc = click_option(self.Dummy())
         self.assertEqual(clc.__click_params__[0].is_eager, True)
-        self.assertEqual(clc.__click_params__[0].help, "Read identifier from Configuration File.")
+        self.assertEqual(clc.__click_params__[0].help, "Read config-env from Configuration File.")
+        self.assertEqual(clc.__click_params__[0].hidden, True)
         self.assertEqual(clc.__click_params__[0].expose_value, False)
-        self.assertEqual(clc.__click_params__[0].callback.args, (None, "--identifier", "default", None, toml_provider))
+        self.assertEqual(clc.__click_params__[0].callback.args, (None, "--config-env", "default", None, toml_provider))
+
+    @patch("samcli.cli.cli_config_file.os.path.isfile", return_value=True)
+    def test_get_ctx_defaults_non_nested(self, mock_os_file):
+        provider = MagicMock()
+
+        mock_context1 = MockContext(info_name="sam", parent=None)
+        mock_context2 = MockContext(info_name="local", parent=mock_context1)
+        mock_context3 = MockContext(info_name="start-api", parent=mock_context2)
+
+        get_ctx_defaults("start-api", provider, mock_context3)
+
+        provider.assert_called_with(os.path.join(os.getcwd(), DEFAULT_CONFIG_FILE_NAME), "default", "local_start_api")
+
+    @patch("samcli.cli.cli_config_file.os.path.isfile", return_value=True)
+    def test_get_ctx_defaults_nested(self, mock_os_file):
+        provider = MagicMock()
+
+        mock_context1 = MockContext(info_name="sam", parent=None)
+        mock_context2 = MockContext(info_name="local", parent=mock_context1)
+        mock_context3 = MockContext(info_name="generate-event", parent=mock_context2)
+        mock_context4 = MockContext(info_name="alexa-skills-kit", parent=mock_context3)
+
+        get_ctx_defaults("intent-answer", provider, mock_context4)
+
+        provider.assert_called_with(
+            os.path.join(os.getcwd(), DEFAULT_CONFIG_FILE_NAME),
+            "default",
+            "local_generate_event_alexa_skills_kit_intent_answer",
+        )

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -1,9 +1,9 @@
+import os
 import tempfile
 
 from unittest import TestCase
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
-import click
 
 from samcli.cli.cli_config_file import TomlProvider, configuration_option, configuration_callback
 
@@ -11,33 +11,35 @@ from samcli.cli.cli_config_file import TomlProvider, configuration_option, confi
 class TestTomlProvider(TestCase):
     def setUp(self):
         self.toml_provider = TomlProvider()
+        self.identifier = "identifier"
+        self.parameters = "parameters"
         self.cmd_name = "topic"
-
-    def test_toml_valid(self):
-        with tempfile.NamedTemporaryFile(delete=False) as toml_file:
-            toml_file.write(b"[topic]\nword='clarity'\n")
-            toml_file.flush()
-            self.assertEqual(self.toml_provider(toml_file.name, self.cmd_name), {"topic": {"word": "clarity"}})
 
     def test_toml_valid_with_section(self):
         with tempfile.NamedTemporaryFile(delete=False) as toml_file:
-            toml_file.write(b"[topic]\nword='clarity'\n")
+            toml_file.write(b"[identifier.topic.parameters]\nword='clarity'\n")
             toml_file.flush()
-            self.assertEqual(TomlProvider(section="topic")(toml_file.name, self.cmd_name), {"word": "clarity"})
+            self.assertEqual(
+                TomlProvider(cmd=self.cmd_name, section=self.parameters)(
+                    toml_file.name, self.identifier, self.cmd_name
+                ),
+                {"word": "clarity"},
+            )
 
     def test_toml_invalid(self):
         with tempfile.NamedTemporaryFile(delete=False) as toml_file:
             toml_file.write(b"[topic]\nword=clarity\n")
             toml_file.flush()
             with self.assertRaises(ValueError):
-                self.toml_provider(toml_file.name, self.cmd_name)
+                self.toml_provider(toml_file.name, self.identifier, self.cmd_name)
 
 
 class TestCliConfiguration(TestCase):
     def setUp(self):
         self.cmd_name = "test_cmd"
         self.option_name = "test_option"
-        self.config_file_name = "test_file"
+        self.identifier_name = "test_identifier"
+        self.custom_identifier = "custom"
         self.saved_callback = MagicMock()
         self.provider = MagicMock()
         self.ctx = MagicMock()
@@ -46,27 +48,26 @@ class TestCliConfiguration(TestCase):
     class Dummy:
         pass
 
-    def test_callback_with_valid_file(self):
-        with tempfile.NamedTemporaryFile(delete=False) as toml_file:
-            configuration_callback(
-                cmd_name=self.cmd_name,
-                option_name=self.option_name,
-                config_file_name=toml_file.name,
-                saved_callback=self.saved_callback,
-                provider=self.provider,
-                ctx=self.ctx,
-                param=self.param,
-                value=toml_file.name,
-            )
-            self.assertEqual(self.saved_callback.call_count, 1)
-            for arg in [self.ctx, self.param, toml_file.name]:
-                self.assertIn(arg, self.saved_callback.call_args[0])
-
-    def test_callback_with_invalid_file(self):
+    def test_callback_with_valid_identifier(self):
         configuration_callback(
             cmd_name=self.cmd_name,
             option_name=self.option_name,
-            config_file_name=self.config_file_name,
+            identifier_name=self.identifier_name,
+            saved_callback=self.saved_callback,
+            provider=self.provider,
+            ctx=self.ctx,
+            param=self.param,
+            value=self.custom_identifier,
+        )
+        self.assertEqual(self.saved_callback.call_count, 1)
+        for arg in [self.ctx, self.param, self.custom_identifier]:
+            self.assertIn(arg, self.saved_callback.call_args[0])
+
+    def test_callback_with_invalid_identifier(self):
+        configuration_callback(
+            cmd_name=self.cmd_name,
+            option_name=self.option_name,
+            identifier_name=self.identifier_name,
             saved_callback=self.saved_callback,
             provider=self.provider,
             ctx=self.ctx,
@@ -75,29 +76,44 @@ class TestCliConfiguration(TestCase):
         )
         self.assertEqual(self.provider.call_count, 0)
 
-    def test_callback_with_exception(self):
-        self.provider = MagicMock(side_effect=Exception)
-        with tempfile.NamedTemporaryFile(delete=False) as temp_value:
-            with self.assertRaises(click.BadOptionUsage):
-                configuration_callback(
-                    cmd_name=self.cmd_name,
-                    option_name=self.option_name,
-                    config_file_name=self.config_file_name,
-                    saved_callback=self.saved_callback,
-                    provider=self.provider,
-                    ctx=self.ctx,
-                    param=self.param,
-                    value=temp_value.name,
-                )
+    @patch("samcli.cli.cli_config_file.os.path.isfile", return_value=False)
+    def test_callback_with_config_file_not_file(self, mock_os_isfile):
+        configuration_callback(
+            cmd_name=self.cmd_name,
+            option_name=self.option_name,
+            identifier_name=self.identifier_name,
+            saved_callback=self.saved_callback,
+            provider=self.provider,
+            ctx=self.ctx,
+            param=self.param,
+            value=self.custom_identifier,
+        )
+        self.assertEqual(self.provider.call_count, 0)
+        self.assertEqual(self.saved_callback.call_count, 1)
+        for arg in [self.ctx, self.param, self.custom_identifier]:
+            self.assertIn(arg, self.saved_callback.call_args[0])
+
+    @patch("samcli.cli.cli_config_file.os.path.isfile")
+    def test_callback_with_env_variable_set(self, mock_os_isfile):
+        with patch.dict(os.environ, {"SAM_CONFIG": "~/sam-configurations/sam-config"}):
+            configuration_callback(
+                cmd_name=self.cmd_name,
+                option_name=self.option_name,
+                identifier_name=self.identifier_name,
+                saved_callback=self.saved_callback,
+                provider=self.provider,
+                ctx=self.ctx,
+                param=self.param,
+                value=self.custom_identifier,
+            )
             self.assertEqual(self.provider.call_count, 1)
+            self.provider.assert_called_with("~/sam-configurations/sam-config", self.custom_identifier, self.cmd_name)
 
     def test_configuration_option(self):
         toml_provider = TomlProvider()
         click_option = configuration_option(provider=toml_provider)
         clc = click_option(self.Dummy())
         self.assertEqual(clc.__click_params__[0].is_eager, True)
-        self.assertEqual(clc.__click_params__[0].help, "Read configuration from FILE.")
+        self.assertEqual(clc.__click_params__[0].help, "Read identifier from Configuration File.")
         self.assertEqual(clc.__click_params__[0].expose_value, False)
-        self.assertEqual(
-            clc.__click_params__[0].callback.args, (None, "--config", "sam-app-config", None, toml_provider)
-        )
+        self.assertEqual(clc.__click_params__[0].callback.args, (None, "--identifier", "default", None, toml_provider))

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -1,0 +1,103 @@
+import tempfile
+
+from unittest import TestCase
+from unittest.mock import Mock, MagicMock, patch, call
+
+import click
+
+from samcli.cli.cli_config_file import TomlProvider, configuration_option, configuration_callback
+
+
+class TestTomlProvider(TestCase):
+    def setUp(self):
+        self.toml_provider = TomlProvider()
+        self.cmd_name = "topic"
+
+    def test_toml_valid(self):
+        with tempfile.NamedTemporaryFile(delete=False) as toml_file:
+            toml_file.write(b"[topic]\nword='clarity'\n")
+            toml_file.flush()
+            self.assertEqual(self.toml_provider(toml_file.name, self.cmd_name), {"topic": {"word": "clarity"}})
+
+    def test_toml_valid_with_section(self):
+        with tempfile.NamedTemporaryFile(delete=False) as toml_file:
+            toml_file.write(b"[topic]\nword='clarity'\n")
+            toml_file.flush()
+            self.assertEqual(TomlProvider(section="topic")(toml_file.name, self.cmd_name), {"word": "clarity"})
+
+    def test_toml_invalid(self):
+        with tempfile.NamedTemporaryFile(delete=False) as toml_file:
+            toml_file.write(b"[topic]\nword=clarity\n")
+            toml_file.flush()
+            with self.assertRaises(ValueError):
+                self.toml_provider(toml_file.name, self.cmd_name)
+
+
+class TestCliConfiguration(TestCase):
+    def setUp(self):
+        self.cmd_name = "test_cmd"
+        self.option_name = "test_option"
+        self.config_file_name = "test_file"
+        self.saved_callback = MagicMock()
+        self.provider = MagicMock()
+        self.ctx = MagicMock()
+        self.param = MagicMock()
+
+    class Dummy:
+        pass
+
+    def test_callback_with_valid_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as toml_file:
+            configuration_callback(
+                cmd_name=self.cmd_name,
+                option_name=self.option_name,
+                config_file_name=toml_file.name,
+                saved_callback=self.saved_callback,
+                provider=self.provider,
+                ctx=self.ctx,
+                param=self.param,
+                value=toml_file.name,
+            )
+            self.assertEqual(self.saved_callback.call_count, 1)
+            for arg in [self.ctx, self.param, toml_file.name]:
+                self.assertIn(arg, self.saved_callback.call_args[0])
+
+    def test_callback_with_invalid_file(self):
+        configuration_callback(
+            cmd_name=self.cmd_name,
+            option_name=self.option_name,
+            config_file_name=self.config_file_name,
+            saved_callback=self.saved_callback,
+            provider=self.provider,
+            ctx=self.ctx,
+            param=self.param,
+            value="invalid",
+        )
+        self.assertEqual(self.provider.call_count, 0)
+
+    def test_callback_with_exception(self):
+        self.provider = MagicMock(side_effect=Exception)
+        with tempfile.NamedTemporaryFile(delete=False) as temp_value:
+            with self.assertRaises(click.BadOptionUsage):
+                configuration_callback(
+                    cmd_name=self.cmd_name,
+                    option_name=self.option_name,
+                    config_file_name=self.config_file_name,
+                    saved_callback=self.saved_callback,
+                    provider=self.provider,
+                    ctx=self.ctx,
+                    param=self.param,
+                    value=temp_value.name,
+                )
+            self.assertEqual(self.provider.call_count, 1)
+
+    def test_configuration_option(self):
+        toml_provider = TomlProvider()
+        click_option = configuration_option(provider=toml_provider)
+        clc = click_option(self.Dummy())
+        self.assertEqual(clc.__click_params__[0].is_eager, True)
+        self.assertEqual(clc.__click_params__[0].help, "Read configuration from FILE.")
+        self.assertEqual(clc.__click_params__[0].expose_value, False)
+        self.assertEqual(
+            clc.__click_params__[0].callback.args, (None, "--config", "sam-app-config", None, toml_provider)
+        )

--- a/tests/unit/cli/test_types.py
+++ b/tests/unit/cli/test_types.py
@@ -12,19 +12,12 @@ class TestCfnParameterOverridesType(TestCase):
 
     @parameterized.expand(
         [
-            (("some string"),),
-            # Key must not contain spaces
-            (('ParameterKey="Ke y",ParameterValue=Value'),),
-            # No value
-            (("ParameterKey=Key,ParameterValue="),),
-            # No key
-            (("ParameterKey=,ParameterValue=Value"),),
-            # Case sensitive
-            (("parameterkey=Key,ParameterValue=Value"),),
-            # No space after comma
-            (("ParameterKey=Key, ParameterValue=Value"),),
+            # Random string
+            ("some string",),
+            # Only commas
+            (",,",),
             # Bad separator
-            (("ParameterKey:Key,ParameterValue:Value"),),
+            ("ParameterKey:Key,ParameterValue:Value",),
         ]
     )
     def test_must_fail_on_invalid_format(self, input):
@@ -39,6 +32,10 @@ class TestCfnParameterOverridesType(TestCase):
                 ("ParameterKey=KeyPairName,ParameterValue=MyKey ParameterKey=InstanceType,ParameterValue=t1.micro",),
                 {"KeyPairName": "MyKey", "InstanceType": "t1.micro"},
             ),
+            (("KeyPairName=MyKey InstanceType=t1.micro",), {"KeyPairName": "MyKey", "InstanceType": "t1.micro"}),
+            (("KeyPairName=MyKey, InstanceType=t1.micro,",), {"KeyPairName": "MyKey,", "InstanceType": "t1.micro,"}),
+            (('ParameterKey="Ke y",ParameterValue=Value',), {"ParameterKey": "Ke y"}),
+            ((("ParameterKey=Key,ParameterValue="),), {"ParameterKey": "Key,ParameterValue="}),
             (('ParameterKey="Key",ParameterValue=Val\\ ue',), {"Key": "Val ue"}),
             (('ParameterKey="Key",ParameterValue="Val\\"ue"',), {"Key": 'Val"ue'}),
             (("ParameterKey=Key,ParameterValue=Value",), {"Key": "Value"}),
@@ -146,38 +143,3 @@ class TestCfnTags(TestCase):
     def test_successful_parsing(self, input, expected):
         result = self.param_type.convert(input, None, None)
         self.assertEqual(result, expected, msg="Failed with Input = " + str(input))
-
-
-# class TestCfnCapabilitiesType(TestCase):
-#     def setUp(self):
-#         self.param_type = CfnCapabilitiesType()
-#
-#     @parameterized.expand(
-#         [
-#             # Just a string
-#             ("some string"),
-#             # tuple of string
-#             ("some string",),
-#             # non-tuple valid string
-#             "CAPABILITY_NAMED_IAM",
-#         ]
-#     )
-#     def test_must_fail_on_invalid_format(self, input):
-#         self.param_type.fail = Mock()
-#         self.param_type.convert(input, "param", "ctx")
-#
-#         self.param_type.fail.assert_called_with(ANY, "param", "ctx")
-#
-#     @parameterized.expand(
-#         [
-#             (("CAPABILITY_AUTO_EXPAND",), ("CAPABILITY_AUTO_EXPAND",)),
-#             (("CAPABILITY_AUTO_EXPAND", "CAPABILITY_NAMED_IAM"), ("CAPABILITY_AUTO_EXPAND", "CAPABILITY_NAMED_IAM")),
-#             (
-#                 ("CAPABILITY_AUTO_EXPAND", "CAPABILITY_NAMED_IAM", "CAPABILITY_IAM"),
-#                 ("CAPABILITY_AUTO_EXPAND", "CAPABILITY_NAMED_IAM", "CAPABILITY_IAM"),
-#             ),
-#         ]
-#     )
-#     def test_successful_parsing(self, input, expected):
-#         result = self.param_type.convert(input, None, None)
-#         self.assertEqual(result, expected, msg="Failed with Input = " + str(input))

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -9,6 +9,10 @@ from unittest.mock import patch
 from samcli.commands._utils.options import get_or_default_template_file_name, _TEMPLATE_OPTION_DEFAULT_VALUE
 
 
+class Mock:
+    pass
+
+
 class TestGetOrDefaultTemplateFileName(TestCase):
     def test_must_return_abspath_of_user_provided_value(self):
         filename = "foo.txt"
@@ -49,4 +53,21 @@ class TestGetOrDefaultTemplateFileName(TestCase):
 
         result = get_or_default_template_file_name(None, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=True)
         self.assertEqual(result, "absPath")
+        os_mock.path.abspath.assert_called_with(expected)
+
+    @patch("samcli.commands._utils.options.os")
+    def test_verify_ctx(self, os_mock):
+
+        ctx = Mock()
+
+        expected = os.path.join(".aws-sam", "build", "template.yaml")
+
+        os_mock.path.exists.return_value = True
+        os_mock.path.join = os.path.join  # Use the real method
+        os_mock.path.abspath.return_value = "a/b/c/absPath"
+        os_mock.path.dirname.return_value = "a/b/c"
+
+        result = get_or_default_template_file_name(ctx, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=True)
+        self.assertEqual(result, "a/b/c/absPath")
+        self.assertEqual(ctx.config_path, "a/b/c")
         os_mock.path.abspath.assert_called_with(expected)

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -65,9 +65,9 @@ class TestGetOrDefaultTemplateFileName(TestCase):
         os_mock.path.exists.return_value = True
         os_mock.path.join = os.path.join  # Use the real method
         os_mock.path.abspath.return_value = "a/b/c/absPath"
-        os_mock.path.dirname.return_value = "a/b/c/absPath"
+        os_mock.path.dirname.return_value = "a/b/c"
 
         result = get_or_default_template_file_name(ctx, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=True)
         self.assertEqual(result, "a/b/c/absPath")
-        self.assertEqual(ctx.config_path, "a/b/c/absPath")
+        self.assertEqual(ctx.config_path, "a/b/c")
         os_mock.path.abspath.assert_called_with(expected)

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -65,9 +65,9 @@ class TestGetOrDefaultTemplateFileName(TestCase):
         os_mock.path.exists.return_value = True
         os_mock.path.join = os.path.join  # Use the real method
         os_mock.path.abspath.return_value = "a/b/c/absPath"
-        os_mock.path.dirname.return_value = "a/b/c"
+        os_mock.path.dirname.return_value = "a/b/c/absPath"
 
         result = get_or_default_template_file_name(ctx, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=True)
         self.assertEqual(result, "a/b/c/absPath")
-        self.assertEqual(ctx.config_path, "a/b/c")
+        self.assertEqual(ctx.config_path, "a/b/c/absPath")
         os_mock.path.abspath.assert_called_with(expected)

--- a/tests/unit/commands/local/generate_event/test_event_generation.py
+++ b/tests/unit/commands/local/generate_event/test_event_generation.py
@@ -124,7 +124,11 @@ class TestEventTypeSubCommand(TestCase):
         s = EventTypeSubCommand(self.events_lib_mock, "hello", all_commands)
         s.get_command(None, "hi")
         click_mock.Command.assert_called_once_with(
-            name="hi", short_help="Generates a hello Event", params=[], callback=callback_object_mock
+            name="hi",
+            short_help="Generates a hello Event",
+            params=[],
+            callback=callback_object_mock,
+            context_settings={"default_map": {}},
         )
 
     def test_subcommand_list_return_value(self):


### PR DESCRIPTION
- add passthroughs to the CLI command line interface via a configuration
  file
- local defaults are set at: `samconfig.toml` at project root.
- This commit contains code copied and modified from https://github.com/phha/click_config_file/blob/master/click_config_file.py under MIT license
- Design doc PR is separate: https://github.com/awslabs/aws-sam-cli/pull/1503

- [ ] Design doc
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
