### PR TITLE
fix: Move validation of timeout is an int further down the stack

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,3 +12,5 @@ python-dateutil~=2.6, <2.8.1
 requests==2.22.0
 serverlessrepo==0.1.9
 aws_lambda_builders==0.5.0
+# https://github.com/mhammond/pywin32/issues/1439
+pywin32 < 226; sys_platform == 'win32'

--- a/samcli/commands/local/lib/sam_function_provider.py
+++ b/samcli/commands/local/lib/sam_function_provider.py
@@ -1,11 +1,9 @@
 """
 Class that provides functions from a given SAM template
 """
-
-import ast
 import logging
 
-from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn, InvalidSamTemplateException
+from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
 from .exceptions import InvalidLayerReference
 from .provider import FunctionProvider, Function, LayerVersion
 from .sam_base_provider import SamBaseProvider
@@ -123,18 +121,11 @@ class SamFunctionProvider(FunctionProvider):
 
         LOG.debug("Found Serverless function with name='%s' and CodeUri='%s'", name, codeuri)
 
-        timeout = resource_properties.get("Timeout")
-        if isinstance(timeout, str):
-            try:
-                timeout = ast.literal_eval(timeout)
-            except ValueError:
-                raise InvalidSamTemplateException("Invalid Number for Timeout: {}".format(timeout))
-
         return Function(
             name=name,
             runtime=resource_properties.get("Runtime"),
             memory=resource_properties.get("MemorySize"),
-            timeout=timeout,
+            timeout=resource_properties.get("Timeout"),
             handler=resource_properties.get("Handler"),
             codeuri=codeuri,
             environment=resource_properties.get("Environment"),

--- a/samcli/local/lambdafn/config.py
+++ b/samcli/local/lambdafn/config.py
@@ -51,7 +51,12 @@ class FunctionConfig:
 
         if not isinstance(self.timeout, int):
             try:
-                self.timeout = int(ast.literal_eval(self.timeout))
+                self.timeout = ast.literal_eval(self.timeout)
+
+                # Guard against float values like "3.2"
+                if not isinstance(self.timeout, int):
+                    raise InvalidSamTemplateException("Invalid Number for Timeout: {}".format(self.timeout))
+
             except (ValueError, SyntaxError, TypeError):
                 raise InvalidSamTemplateException("Invalid Number for Timeout: {}".format(self.timeout))
 

--- a/samcli/local/lambdafn/config.py
+++ b/samcli/local/lambdafn/config.py
@@ -1,7 +1,9 @@
 """
 Lambda Function configuration data required by the runtime
 """
+import ast
 
+from samcli.commands.local.cli_common.user_exceptions import InvalidSamTemplateException
 from .env_vars import EnvironmentVariables
 
 
@@ -44,7 +46,14 @@ class FunctionConfig:
         self.code_abs_path = code_abs_path
         self.layers = layers
         self.memory = memory or self._DEFAULT_MEMORY
+
         self.timeout = timeout or self._DEFAULT_TIMEOUT_SECONDS
+
+        if not isinstance(self.timeout, int):
+            try:
+                self.timeout = int(ast.literal_eval(self.timeout))
+            except (ValueError, SyntaxError, TypeError):
+                raise InvalidSamTemplateException("Invalid Number for Timeout: {}".format(self.timeout))
 
         if not env_vars:
             env_vars = EnvironmentVariables(self.memory, self.timeout, self.handler)

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -255,7 +255,7 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
             name="myname",
             runtime="myruntime",
             memory="mymemorysize",
-            timeout=30,
+            timeout="30",
             handler="myhandler",
             codeuri="/usr/local",
             environment="myenvironment",
@@ -266,23 +266,6 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
         result = SamFunctionProvider._convert_sam_function_resource(name, properties, ["Layer1", "Layer2"])
 
         self.assertEqual(expected, result)
-
-    def test_must_fail_with_InvalidSamTemplateException(self):
-
-        name = "myname"
-        properties = {
-            "CodeUri": "/usr/local",
-            "Runtime": "myruntime",
-            "MemorySize": "mymemorysize",
-            "Timeout": "timeout",
-            "Handler": "myhandler",
-            "Environment": "myenvironment",
-            "Role": "myrole",
-            "Layers": ["Layer1", "Layer2"],
-        }
-
-        with self.assertRaises(InvalidSamTemplateException):
-            SamFunctionProvider._convert_sam_function_resource(name, properties, ["Layer1", "Layer2"])
 
     def test_must_skip_non_existent_properties(self):
 

--- a/tests/unit/local/lambdafn/test_config.py
+++ b/tests/unit/local/lambdafn/test_config.py
@@ -100,7 +100,14 @@ class TestFunctionConfigInvalidTimeouts(TestCase):
         self.layers = ["layer1"]
 
     @parameterized.expand(
-        [("none int string",), ({"dictionary": "is not a string either"},), ("/local/lambda/timeout",)]
+        [
+            ("none int string",),
+            ({"dictionary": "is not a string either"},),
+            ("/local/lambda/timeout",),
+            ("3.2",),
+            ("4.2",),
+            ("0.123",),
+        ]
     )
     def test_init_with_invalid_timeout_values(self, timeout):
         with self.assertRaises(InvalidSamTemplateException):

--- a/tests/unit/local/lambdafn/test_config.py
+++ b/tests/unit/local/lambdafn/test_config.py
@@ -1,7 +1,10 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
+from parameterized import parameterized
+
 from samcli.local.lambdafn.config import FunctionConfig
+from samcli.commands.local.cli_common.user_exceptions import InvalidSamTemplateException
 
 
 class TestFunctionConfig(TestCase):
@@ -59,3 +62,55 @@ class TestFunctionConfig(TestCase):
         self.assertEqual(config.env_vars.handler, self.handler)
         self.assertEqual(config.env_vars.memory, self.DEFAULT_MEMORY)
         self.assertEqual(config.env_vars.timeout, self.DEFAULT_TIMEOUT)
+
+    def test_init_with_timeout_of_int_string(self):
+        config = FunctionConfig(
+            self.name,
+            self.runtime,
+            self.handler,
+            self.code_path,
+            self.layers,
+            memory=self.memory,
+            timeout="34",
+            env_vars=self.env_vars_mock,
+        )
+
+        self.assertEqual(config.name, self.name)
+        self.assertEqual(config.runtime, self.runtime)
+        self.assertEqual(config.handler, self.handler)
+        self.assertEqual(config.code_abs_path, self.code_path)
+        self.assertEqual(config.layers, self.layers)
+        self.assertEqual(config.memory, self.memory)
+        self.assertEqual(config.timeout, 34)
+        self.assertEqual(config.env_vars, self.env_vars_mock)
+
+        self.assertEqual(self.env_vars_mock.handler, self.handler)
+        self.assertEqual(self.env_vars_mock.memory, self.memory)
+        self.assertEqual(self.env_vars_mock.timeout, 34)
+
+
+class TestFunctionConfigInvalidTimeouts(TestCase):
+    def setUp(self):
+        self.name = "name"
+        self.runtime = "runtime"
+        self.handler = "handler"
+        self.code_path = "codepath"
+        self.memory = 1234
+        self.env_vars_mock = Mock()
+        self.layers = ["layer1"]
+
+    @parameterized.expand(
+        [("none int string",), ({"dictionary": "is not a string either"},), ("/local/lambda/timeout",)]
+    )
+    def test_init_with_invalid_timeout_values(self, timeout):
+        with self.assertRaises(InvalidSamTemplateException):
+            FunctionConfig(
+                self.name,
+                self.runtime,
+                self.handler,
+                self.code_path,
+                self.layers,
+                memory=self.memory,
+                timeout=timeout,
+                env_vars=self.env_vars_mock,
+            )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
