### PR TITLE
chore: fix java build and ruby appveyor builds

### DIFF
--- a/appveyor-windows-build-java-container.yml
+++ b/appveyor-windows-build-java-container.yml
@@ -27,19 +27,11 @@ environment:
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
 
-  matrix:
-    - optional_gate: true
-
-matrix:
-  allow_failures:
-    - optional_gate: true
-
 init:
   # Uncomment this for RDP
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: gcim Win32_Processor | % { "$($_.NumberOfLogicalProcessors) logical CPUs" }
   - ps: gcim Win32_OperatingSystem | % { "$([int]($_.TotalVisibleMemorySize/1mb)) Gb" }
-
 
 install:
 
@@ -83,7 +75,8 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_Java"
+    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java_in_container"
+
 
 # Uncomment for RDP
 # on_finish:

--- a/appveyor-windows-build-java-inprocess.yml
+++ b/appveyor-windows-build-java-inprocess.yml
@@ -1,0 +1,58 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+build: off
+
+environment:
+  AWS_DEFAULT_REGION: us-east-1
+  SAM_CLI_DEV: 1
+  APPVEYOR_CI_OVERRIDE: 1
+  GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python36-x64"
+  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  PYTHON_VERSION: '3.6.8'
+  PYTHON_ARCH: '64'
+
+install:
+
+    - "SET PATH=%PYTHON_HOME%;%PATH%"
+    - "echo %PYTHON_HOME%"
+    - "echo %PATH%"
+    - "python --version"
+
+    # Upgrade setuptools, wheel and virtualenv
+    - "python -m pip install --upgrade setuptools wheel virtualenv"
+
+    # Create new virtual environment with chosen python version and activate it
+    - "python -m virtualenv venv"
+    - "venv\\Scripts\\activate"
+    - "python --version"
+
+    # Actually install SAM CLI's dependencies
+    - "pip install -e \".[dev]\""
+
+    # setup Java, Maven and Gradle
+    - "refreshenv"
+    - "choco install maven -y --force"
+    - "refreshenv"
+    - "choco install gradle -y --force"
+    - "refreshenv"
+    - "java -version"
+    - "gradle -v"
+    - "mvn --version"
+
+    # setup Ruby dependencies
+    - "set PATH=C:\\Ruby25-x64\\bin;%PATH%"
+    - "gem --version"
+    - "gem install bundler -v 1.17.3"
+    - "bundler --version"
+
+    # Echo final Path
+    - "echo %PATH%"
+
+test_script:
+    # Reactivate virtualenv before running tests
+    - "venv\\Scripts\\activate"
+    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_java_in_process"

--- a/appveyor-windows-build-ruby.yml
+++ b/appveyor-windows-build-ruby.yml
@@ -27,13 +27,6 @@ environment:
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
 
-  matrix:
-    - optional_gate: true
-
-matrix:
-  allow_failures:
-    - optional_gate: true
-
 init:
   # Uncomment this for RDP
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor-windows-build-ruby.yml
+++ b/appveyor-windows-build-ruby.yml
@@ -81,7 +81,7 @@ test_script:
     # Reactivate virtualenv before running tests
     - "venv\\Scripts\\activate"
     - "docker system prune -a -f"
-    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k TestBuildCommand_RubyFunctions"
+    - "pytest -vv tests/integration/buildcmd/test_build_cmd.py -k test_building_ruby_in_container"
 
 # Uncomment for RDP
 # on_finish:


### PR DESCRIPTION
Split java and ruby builds into two functions, one for in process and one for container.
When running java builds on Windows Server 2019, the in process builds where hanging,
reason is known. Splitting the tests allows us to run the container builds on
Windows Server 2019, which is required due to needing docker that spins up a linux
instance. We can then run in-process builds in Visual Studio images, which works for java.

This commit will also update the ruby builds on windows but instead of running both in process
and container builds, we will only run container builds. When running ruby in-process builds
on Visual Studio images, we still see failures (which is assumed to be the same as when they
are run on Windows Server 2019 which is an ssl issue). This will at least allow us to verify
container builds for ruby, which will give us confidence that things are working as expected.

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
