### PR TITLE
feat: Interactively prompt for deploy arguments

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -144,7 +144,8 @@ def capabilities_click_option():
         "--capabilities",
         cls=OptionNargs,
         type=click.STRING,
-        required=True,
+        default=("CAPABILITY_IAM",),
+        required=False,
         help="A list of  capabilities  that  you  must  specify"
         "before  AWS  Cloudformation  can create certain stacks. Some stack tem-"
         "plates might include resources that can affect permissions in your  AWS"


### PR DESCRIPTION
*Description of changes:*
* `sam deploy -i` will now prompt for parameters if they haven't been provided. 
* I have also made `--capabilities` optional and default to `CAPABILITY_IAM`. Happy to revert if this is unacceptable.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
