### PR TITLE
feat: Guided interactive deployment

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,4 +14,4 @@ serverlessrepo==0.1.9
 aws_lambda_builders==0.5.0
 # https://github.com/mhammond/pywin32/issues/1439
 pywin32 < 226; sys_platform == 'win32'
-toml==0.10.0
+tomlkit==0.5.8

--- a/requirements/isolated.txt
+++ b/requirements/isolated.txt
@@ -32,7 +32,7 @@ requests==2.22.0
 s3transfer==0.2.1
 serverlessrepo==0.1.9
 six==1.11.0
-toml==0.10.0
+tomlkit==0.5.8
 tzlocal==2.0.0
 urllib3==1.25.3
 websocket-client==0.56.0

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -6,17 +6,15 @@ CLI configuration decorator to use TOML configuration files for click commands.
 ## SPDX-License-Identifier: MIT
 
 import functools
-import os
 import logging
 
 import click
-import toml
+from samcli.cli.context import get_cmd_names
+from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV
 
 __all__ = ("TomlProvider", "configuration_option", "get_ctx_defaults")
 
-LOG = logging.getLogger("samcli")
-DEFAULT_CONFIG_FILE_NAME = "samconfig.toml"
-DEFAULT_IDENTIFER = "default"
+LOG = logging.getLogger(__name__)
 
 
 class TomlProvider:
@@ -29,44 +27,43 @@ class TomlProvider:
     def __init__(self, section=None):
         self.section = section
 
-    def __call__(self, file_path, config_env, cmd_name):
+    def __call__(self, config_dir, config_env, cmd_names):
         """
         Get resolved config based on the `file_path` for the configuration file,
         `config_env` targeted inside the config file and corresponding `cmd_name`
         as denoted by `click`.
 
-        :param file_path: The path to the configuration file
         :param config_env: The name of the sectional config_env within configuration file.
-        :param cmd_name: sam command name as defined by click
+        :param cmd_names list(str): sam command name as defined by click
         :returns dictionary containing the configuration parameters under specified config_env
         """
+
         resolved_config = {}
-        try:
-            config = toml.load(file_path)
-        except Exception as ex:
-            LOG.error("Error reading configuration file :%s %s", file_path, str(ex))
+
+        samconfig = SamConfig(config_dir)
+        LOG.debug("Config file location: %s", samconfig.path())
+
+        if not samconfig.exists():
+            LOG.debug("Config file does not exist")
             return resolved_config
-        if self.section:
-            try:
-                resolved_config = self._get_config_env(config, config_env)[cmd_name][self.section]
-            except KeyError:
-                LOG.debug(
-                    "Error reading configuration file at %s with config_env %s, command %s, section %s",
-                    file_path,
-                    config_env,
-                    cmd_name,
-                    self.section,
-                )
+
+        try:
+            LOG.debug("Getting configuration value for %s %s %s", cmd_names, self.section, config_env)
+            resolved_config = samconfig.get_all(cmd_names, self.section, env=config_env)
+        except KeyError:
+            LOG.debug(
+                "Error reading configuration file at %s with config_env=%s, command=%s, section=%s",
+                samconfig.path(),
+                config_dir,
+                config_env,
+                cmd_names,
+                self.section,
+            )
+        except Exception as ex:
+            LOG.error("Error reading configuration file: %s %s", samconfig.path(), str(ex))
+            raise ex
+
         return resolved_config
-
-    def _get_config_env(self, config, config_env):
-        """
-
-        :param config: loaded TOML configuration file into dictionary representation
-        :param config_env: top level section defined within TOML configuration file
-        :return:
-        """
-        return config.get(config_env, config.get(DEFAULT_IDENTIFER, {}))
 
 
 def configuration_callback(cmd_name, option_name, config_env_name, saved_callback, provider, ctx, param, value):
@@ -91,7 +88,7 @@ def configuration_callback(cmd_name, option_name, config_env_name, saved_callbac
     # ctx, param and value are default arguments for click specified callbacks.
     ctx.default_map = ctx.default_map or {}
     cmd_name = cmd_name or ctx.info_name
-    param.default = DEFAULT_IDENTIFER
+    param.default = None
     config_env_name = value or config_env_name
     config = get_ctx_defaults(cmd_name, provider, ctx, config_env_name=config_env_name)
     ctx.default_map.update(config)
@@ -99,7 +96,7 @@ def configuration_callback(cmd_name, option_name, config_env_name, saved_callbac
     return saved_callback(ctx, param, value) if saved_callback else value
 
 
-def get_ctx_defaults(cmd_name, provider, ctx, config_env_name=DEFAULT_IDENTIFER):
+def get_ctx_defaults(cmd_name, provider, ctx, config_env_name):
     """
     Get the set of the parameters that are needed to be set into the click command.
     This function also figures out the command name by looking up current click context's parent
@@ -114,31 +111,9 @@ def get_ctx_defaults(cmd_name, provider, ctx, config_env_name=DEFAULT_IDENTIFER)
     :return: dictionary of defaults for parameters
     """
 
-    cwd = getattr(ctx, "config_path", None)
-    config_file = os.path.join(cwd if cwd else os.getcwd(), DEFAULT_CONFIG_FILE_NAME)
-    config = {}
-    if os.path.isfile(config_file):
-        LOG.debug("Config file location: %s", os.path.abspath(config_file))
-
-        # Find parent of current context
-        _parent = ctx.parent
-        _cmd_names = []
-        # Need to find the total set of commands that current command is part of.
-        if cmd_name != ctx.info_name:
-            _cmd_names = [cmd_name]
-        _cmd_names.append(ctx.info_name)
-        # Go through all parents till a parent of a context exists.
-        while _parent.parent:
-            info_name = _parent.info_name
-            _cmd_names.append(info_name)
-            _parent = _parent.parent
-
-        # construct a parsed name that is of the format: a_b_c_d
-        parsed_cmd_name = "_".join(reversed([cmd.replace("-", "_").replace(" ", "_") for cmd in _cmd_names]))
-
-        config = provider(config_file, config_env_name, parsed_cmd_name)
-
-    return config
+    # `config_dir` will be a directory relative to SAM template, if it is available. If not it's relative to cwd
+    config_dir = getattr(ctx, "samconfig_dir", None) or SamConfig.config_dir()
+    return provider(config_dir, config_env_name, get_cmd_names(cmd_name, ctx))
 
 
 def configuration_option(*param_decls, **attrs):
@@ -172,7 +147,7 @@ def configuration_option(*param_decls, **attrs):
         # --config-env is hidden and can potentially be opened up in the future.
         attrs.setdefault("hidden", True)
         # explicitly ignore values passed to --config-env, can be opened up in the future.
-        config_env_name = DEFAULT_IDENTIFER
+        config_env_name = DEFAULT_ENV
         provider = attrs.pop("provider")
         attrs["type"] = click.STRING
         saved_callback = attrs.pop("callback", None)

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -54,14 +54,12 @@ class TomlProvider:
             LOG.debug(
                 "Error reading configuration file at %s with config_env=%s, command=%s, section=%s",
                 samconfig.path(),
-                config_dir,
                 config_env,
                 cmd_names,
                 self.section,
             )
         except Exception as ex:
             LOG.error("Error reading configuration file: %s %s", samconfig.path(), str(ex))
-            raise ex
 
         return resolved_config
 

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -5,6 +5,7 @@ CLI configuration decorator to use TOML configuration files for click commands.
 ## This section contains code copied and modified from [click_config_file][https://github.com/phha/click_config_file/blob/master/click_config_file.py]
 ## SPDX-License-Identifier: MIT
 
+import os
 import functools
 import logging
 
@@ -110,7 +111,7 @@ def get_ctx_defaults(cmd_name, provider, ctx, config_env_name):
     """
 
     # `config_dir` will be a directory relative to SAM template, if it is available. If not it's relative to cwd
-    config_dir = getattr(ctx, "samconfig_dir", None) or SamConfig.config_dir()
+    config_dir = getattr(ctx, "samconfig_dir", None) or os.getcwd()
     return provider(config_dir, config_env_name, get_cmd_names(cmd_name, ctx))
 
 

--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -50,7 +50,11 @@ class TomlProvider:
 
         try:
             LOG.debug("Getting configuration value for %s %s %s", cmd_names, self.section, config_env)
-            resolved_config = samconfig.get_all(cmd_names, self.section, env=config_env)
+
+            # NOTE(TheSriram): change from tomlkit table type to normal dictionary,
+            # so that click defaults work out of the box.
+            resolved_config = {k: v for k, v in samconfig.get_all(cmd_names, self.section, env=config_env).items()}
+
         except KeyError:
             LOG.debug(
                 "Error reading configuration file at %s with config_env=%s, command=%s, section=%s",

--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -146,3 +146,20 @@ class Context:
             boto3.setup_default_session(region_name=self._aws_region, profile_name=self._aws_profile)
         except botocore.exceptions.ProfileNotFound as ex:
             raise CredentialsError(str(ex))
+
+
+def get_cmd_names(cmd_name, ctx):
+    # Find parent of current context
+    _parent = ctx.parent
+    _cmd_names = []
+    # Need to find the total set of commands that current command is part of.
+    if cmd_name != ctx.info_name:
+        _cmd_names = [cmd_name]
+    _cmd_names.append(ctx.info_name)
+    # Go through all parents till a parent of a context exists.
+    while _parent.parent:
+        info_name = _parent.info_name
+        _cmd_names.append(info_name)
+        _parent = _parent.parent
+
+    return _cmd_names

--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -164,6 +164,11 @@ def get_cmd_names(cmd_name, ctx):
         List containing subcommand names. Ex: ["local", "start-api"]
 
     """
+    if not ctx:
+        return []
+
+    if ctx and not getattr(ctx, "parent", None):
+        return [ctx.info_name]
     # Find parent of current context
     _parent = ctx.parent
     _cmd_names = []

--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -149,6 +149,21 @@ class Context:
 
 
 def get_cmd_names(cmd_name, ctx):
+    """
+    Given the click core context, return a list representing all the subcommands passed to the CLI
+
+    Parameters
+    ----------
+    cmd_name : name of current command
+
+    ctx : click.Context
+
+    Returns
+    -------
+    list(str)
+        List containing subcommand names. Ex: ["local", "start-api"]
+
+    """
     # Find parent of current context
     _parent = ctx.parent
     _cmd_names = []
@@ -162,4 +177,6 @@ def get_cmd_names(cmd_name, ctx):
         _cmd_names.append(info_name)
         _parent = _parent.parent
 
+    # Make sure the output reads natural. Ex: ["local", "start-api"]
+    _cmd_names.reverse()
     return _cmd_names

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -31,6 +31,8 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     :return: Actual value to be used in the CLI
     """
 
+    original_template_path = os.path.abspath(provided_value)
+
     search_paths = ["template.yaml", "template.yml"]
 
     if include_build:
@@ -48,7 +50,9 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     result = os.path.abspath(provided_value)
 
     if ctx:
-        setattr(ctx, "samconfig_dir", SamConfig.config_dir(result))
+        # sam configuration file should always be relative to the supplied original template and should not to be set
+        # to be .aws-sam/build/
+        setattr(ctx, "samconfig_dir", os.path.dirname(original_template_path))
     LOG.debug("Using SAM Template at %s", result)
     return result
 

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -10,7 +10,6 @@ import click
 from click.types import FuncParamType
 from samcli.cli.types import CfnParameterOverridesType, CfnMetadataType, CfnTags
 from samcli.commands._utils.custom_options.option_nargs import OptionNargs
-from samcli.lib.config.samconfig import SamConfig
 
 
 _TEMPLATE_OPTION_DEFAULT_VALUE = "template.[yaml|yml]"
@@ -154,7 +153,6 @@ def capabilities_click_option():
     return click.option(
         "--capabilities",
         cls=OptionNargs,
-        default=("CAPABILITY_IAM",),
         required=False,
         type=FuncParamType(func=_space_separated_list_func_type),
         help="A list of  capabilities  that  you  must  specify"

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -156,7 +156,7 @@ def capabilities_click_option():
         cls=OptionNargs,
         default=("CAPABILITY_IAM",),
         required=False,
-        type=FuncParamType(lambda value: value.split(" ") if not isinstance(value, tuple) else value),
+        type=FuncParamType(func=_space_separated_list_func_type),
         help="A list of  capabilities  that  you  must  specify"
         "before  AWS  Cloudformation  can create certain stacks. Some stack tem-"
         "plates might include resources that can affect permissions in your  AWS"
@@ -194,7 +194,7 @@ def notification_arns_click_option():
     return click.option(
         "--notification-arns",
         cls=OptionNargs,
-        type=FuncParamType(lambda value: value.split(" ") if not isinstance(value, tuple) else value),
+        type=FuncParamType(func=_space_separated_list_func_type),
         required=False,
         help="Amazon  Simple  Notification  Service  topic"
         "Amazon  Resource  Names  (ARNs) that AWS CloudFormation associates with"
@@ -204,3 +204,10 @@ def notification_arns_click_option():
 
 def notification_arns_override_option(f):
     return notification_arns_click_option()(f)
+
+
+def _space_separated_list_func_type(value):
+    return value.split(" ") if not isinstance(value, tuple) else value
+
+
+_space_separated_list_func_type.__name__ = "LIST"

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -10,6 +10,7 @@ import click
 from click.types import FuncParamType
 from samcli.cli.types import CfnParameterOverridesType, CfnMetadataType, CfnTags
 from samcli.commands._utils.custom_options.option_nargs import OptionNargs
+from samcli.lib.config.samconfig import SamConfig
 
 
 _TEMPLATE_OPTION_DEFAULT_VALUE = "template.[yaml|yml]"
@@ -47,7 +48,7 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     result = os.path.abspath(provided_value)
 
     if ctx:
-        setattr(ctx, "config_path", os.path.dirname(result))
+        setattr(ctx, "samconfig_dir", SamConfig.config_dir(result))
     LOG.debug("Using SAM Template at %s", result)
     return result
 

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -149,6 +149,8 @@ def capabilities_click_option():
     return click.option(
         "--capabilities",
         cls=OptionNargs,
+        default=("CAPABILITY_IAM",),
+        required=False,
         type=FuncParamType(lambda value: value.split(" ") if not isinstance(value, tuple) else value),
         help="A list of  capabilities  that  you  must  specify"
         "before  AWS  Cloudformation  can create certain stacks. Some stack tem-"

--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -204,3 +204,20 @@ def _resolve_relative_to(path, original_root, new_root):
     return os.path.relpath(
         os.path.normpath(os.path.join(original_root, path)), new_root  # Absolute original path w.r.t ``original_root``
     )  # Resolve the original path with respect to ``new_root``
+
+
+def get_template_parameters(template_file):
+    """
+    Get Parameters from a template file.
+
+    Parameters
+    ----------
+    template_file : string
+        Path to the template to read
+
+    Returns
+    -------
+    Template Parameters as a dictionary
+    """
+    template_dict = get_template_data(template_file=template_file)
+    return template_dict.get("Parameters", dict())

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -3,7 +3,7 @@ CLI command for "deploy" command
 """
 
 import tempfile
-
+import json
 import click
 
 from samcli.commands._utils.options import (
@@ -17,6 +17,8 @@ from samcli.commands._utils.options import (
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
 from samcli.cli.main import pass_context, common_options, aws_creds_options
 from samcli.lib.telemetry.metrics import track_command
+from samcli.lib.utils.colors import Colored
+from samcli.lib.bootstrap.bootstrap import manage_stack
 
 
 SHORT_HELP = "Deploy an AWS SAM application."
@@ -31,6 +33,24 @@ e.g. sam deploy --template-file packaged.yaml --stack-name sam-app --capabilitie
 """
 
 
+def prompt_callback(msg, default):
+    def callback(ctx, param, value):
+        interactive = ctx.params.get("interactive")
+
+        if interactive:
+            param.prompt = msg
+            param.default = value or default
+            return param.prompt_for_value(ctx)
+        elif value:
+            # Value provided + No Interactive. Return the value
+            return value
+        else:
+            # Value not provided + No Interactive
+            raise click.exceptions.MissingParameter(param=param, ctx=ctx)
+
+    return callback
+
+
 @click.command(
     "deploy",
     short_help=SHORT_HELP,
@@ -41,7 +61,8 @@ e.g. sam deploy --template-file packaged.yaml --stack-name sam-app --capabilitie
 @template_click_option(include_build=True)
 @click.option(
     "--stack-name",
-    required=True,
+    required=False,
+    default="sam-app",
     help="The name of the AWS CloudFormation stack you're deploying to. "
     "If you specify an existing stack, the command updates the stack. "
     "If you specify a new stack, the command creates it.",
@@ -106,6 +127,14 @@ e.g. sam deploy --template-file packaged.yaml --stack-name sam-app --capabilitie
     help="Indicates whether to use JSON as the format for "
     "the output AWS CloudFormation template. YAML is used by default.",
 )
+@click.option(
+    "--interactive",
+    "-i",
+    required=False,
+    is_flag=True,
+    is_eager=True,
+    help="Specify this flag to allow SAM CLI to guide you through the deployment using interactive prompts.",
+)
 @metadata_override_option
 @notification_arns_override_option
 @tags_override_option
@@ -132,6 +161,7 @@ def cli(
     use_json,
     tags,
     metadata,
+    interactive,
 ):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
@@ -151,6 +181,7 @@ def cli(
         use_json,
         tags,
         metadata,
+        interactive,
         ctx.region,
         ctx.profile,
     )  # pragma: no cover
@@ -172,11 +203,22 @@ def do_cli(
     use_json,
     tags,
     metadata,
+    interactive,
     region,
     profile,
 ):
     from samcli.commands.package.package_context import PackageContext
     from samcli.commands.deploy.deploy_context import DeployContext
+
+    confirm_changeset = False
+    if interactive:
+        stack_name, s3_bucket, region, profile, confirm_changeset = guided_deploy(
+            stack_name, s3_bucket, region, profile
+        )
+
+        # We print deploy args only on interactive.
+        # Should we print this always?
+        print_deploy_args(stack_name, s3_bucket, region, profile, capabilities, parameter_overrides, confirm_changeset)
 
     with tempfile.NamedTemporaryFile() as output_template_file:
 
@@ -211,5 +253,48 @@ def do_cli(
             tags=tags,
             region=region,
             profile=profile,
+            confirm_changeset=confirm_changeset,
         ) as deploy_context:
             deploy_context.run()
+
+
+def guided_deploy(stack_name, s3_bucket, region, profile):
+    default_region = region or "us-east-1"
+    default_profile = profile or "default"
+
+    color = Colored()
+    tick = color.yellow("✓")
+
+    click.echo(color.yellow("\nDeploy Arguments\n================"))
+
+    stack_name = click.prompt(f"{tick} Stack Name", default=stack_name, type=click.STRING)
+    confirm_changeset = click.confirm(f"{tick} Confirm changeset before deploy", default=True)
+    region = click.prompt(f"{tick} AWS Region", default=default_region, type=click.STRING)
+    profile = click.prompt(f"{tick} AWS Profile", default=default_profile, type=click.STRING)
+
+    save_to_samconfig = click.confirm(f"{tick} Save values to samconfig.toml", default=True)
+
+    if not s3_bucket:
+        click.echo(color.yellow("\nConfiguring Deployment S3 Bucket\n================================"))
+        s3_bucket = manage_stack(profile, region)
+        click.echo(f"{tick} Using Deployment Bucket: {s3_bucket}")
+        click.echo("You may specify a different default deployment bucket in samconfig.toml")
+
+    return stack_name, s3_bucket, region, profile, confirm_changeset
+
+
+def print_deploy_args(stack_name, s3_bucket, region, profile, capabilities, parameter_overrides, confirm_changeset):
+
+    param_overrides_string = json.dumps(parameter_overrides, indent=2)
+    capabilities_string = json.dumps(capabilities)
+
+    click.secho("\nDeploying with following values\n===============================", fg="yellow")
+    click.echo(f"Stack Name                 : {stack_name}")
+    click.echo(f"Region                     : {region}")
+    click.echo(f"Profile                    : {profile}")
+    click.echo(f"Deployment S3 Bucket       : {s3_bucket}")
+    click.echo(f"Parameter Overrides        : {param_overrides_string}")
+    click.echo(f"Capabilities               : {capabilities_string}")
+    click.echo(f"Confirm Changeset          : {confirm_changeset}")
+
+    click.secho("\nInitiating Deployment\n=====================", fg="yellow")

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -33,24 +33,6 @@ e.g. sam deploy --template-file packaged.yaml --stack-name sam-app --capabilitie
 """
 
 
-def prompt_callback(msg, default):
-    def callback(ctx, param, value):
-        interactive = ctx.params.get("interactive")
-
-        if interactive:
-            param.prompt = msg
-            param.default = value or default
-            return param.prompt_for_value(ctx)
-        elif value:
-            # Value provided + No Interactive. Return the value
-            return value
-        else:
-            # Value not provided + No Interactive
-            raise click.exceptions.MissingParameter(param=param, ctx=ctx)
-
-    return callback
-
-
 @click.command(
     "deploy",
     short_help=SHORT_HELP,
@@ -272,7 +254,7 @@ def guided_deploy(stack_name, s3_bucket, region, profile):
     region = click.prompt(f"{tick} AWS Region", default=default_region, type=click.STRING)
     profile = click.prompt(f"{tick} AWS Profile", default=default_profile, type=click.STRING)
 
-    save_to_samconfig = click.confirm(f"{tick} Save values to samconfig.toml", default=True)
+    _ = click.confirm(f"{tick} Save values to samconfig.toml", default=True)
 
     if not s3_bucket:
         click.echo(color.yellow("\nConfiguring Deployment S3 Bucket\n================================"))

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -322,11 +322,10 @@ def guided_deploy(
 
     save_to_config = click.confirm(f"\t{tick} Save arguments to samconfig.toml", default=True)
 
-    if not s3_bucket:
-        click.echo(color.yellow("\n\tConfiguring Deployment S3 Bucket\n\t================================"))
-        s3_bucket = manage_stack(profile=profile, region=region)
-        click.echo(f"\t{tick} Using Deployment Bucket: {s3_bucket}")
-        click.echo("\tYou may specify a different default deployment bucket in samconfig.toml")
+    click.echo(color.yellow("\n\tConfiguring Deployment S3 Bucket\n\t================================"))
+    s3_bucket = manage_stack(profile=profile, region=region)
+    click.echo(f"\t{tick} Using Deployment Bucket: {s3_bucket}")
+    click.echo("\tYou may specify a different default deployment bucket in samconfig.toml")
 
     return (
         stack_name,

--- a/samcli/commands/deploy/exceptions.py
+++ b/samcli/commands/deploy/exceptions.py
@@ -7,7 +7,7 @@ from samcli.commands.exceptions import UserException
 class ChangeEmptyError(UserException):
     def __init__(self, stack_name):
         self.stack_name = stack_name
-        message_fmt = "No changes to deploy.Stack {stack_name} is up to date"
+        message_fmt = "No changes to deploy. Stack {stack_name} is up to date"
         super(ChangeEmptyError, self).__init__(message=message_fmt.format(stack_name=self.stack_name))
 
 

--- a/samcli/commands/local/generate_event/event_generation.py
+++ b/samcli/commands/local/generate_event/event_generation.py
@@ -10,6 +10,7 @@ import samcli.commands.local.lib.generated_sample_events.events as events
 from samcli.cli.cli_config_file import TomlProvider, get_ctx_defaults
 from samcli.cli.options import debug_option
 from samcli.lib.telemetry.metrics import track_command
+import samcli.lib.config.samconfig as samconfig
 
 
 class ServiceCommand(click.MultiCommand):
@@ -153,7 +154,12 @@ class EventTypeSubCommand(click.MultiCommand):
             self.cmd_implementation, self.events_lib, self.top_level_cmd_name, cmd_name
         )
 
-        config = get_ctx_defaults(cmd_name=cmd_name, provider=TomlProvider(section="parameters"), ctx=ctx)
+        config = get_ctx_defaults(
+            cmd_name=cmd_name,
+            provider=TomlProvider(section="parameters"),
+            ctx=ctx,
+            config_env_name=samconfig.DEFAULT_ENV,
+        )
 
         cmd = click.Command(
             name=cmd_name,

--- a/samcli/lib/bootstrap/bootstrap.py
+++ b/samcli/lib/bootstrap/bootstrap.py
@@ -31,9 +31,9 @@ def _create_or_get_stack(cloudformation_client):
         ds_resp = cloudformation_client.describe_stacks(StackName=SAM_CLI_STACK_NAME)
         stacks = ds_resp["Stacks"]
         stack = stacks[0]
-        LOG.info("Found managed SAM CLI stack.")
+        LOG.info("\tFound managed SAM CLI stack.")
     except ClientError:
-        LOG.info("Managed SAM CLI stack not found, creating.")
+        LOG.info("\tManaged SAM CLI stack not found, creating.")
         stack = _create_stack(cloudformation_client)  # exceptions are not captured from subcommands
     # Sanity check for non-none stack? Sanity check for tag?
     tags = stack["Tags"]
@@ -78,16 +78,16 @@ def _create_stack(cloudformation_client):
         ChangeSetName=change_set_name,  # this must be unique for the stack, but we only create so that's fine
     )
     stack_id = change_set_resp["StackId"]
-    LOG.info("Waiting for managed stack change set to create.")
+    LOG.info("\tWaiting for managed stack change set to create.")
     change_waiter = cloudformation_client.get_waiter("change_set_create_complete")
     change_waiter.wait(
         ChangeSetName=change_set_name, StackName=SAM_CLI_STACK_NAME, WaiterConfig={"Delay": 15, "MaxAttempts": 60}
     )
     cloudformation_client.execute_change_set(ChangeSetName=change_set_name, StackName=SAM_CLI_STACK_NAME)
-    LOG.info("Waiting for managed stack to be created.")
+    LOG.info("\tWaiting for managed stack to be created.")
     stack_waiter = cloudformation_client.get_waiter("stack_create_complete")
     stack_waiter.wait(StackName=stack_id, WaiterConfig={"Delay": 15, "MaxAttempts": 60})
-    LOG.info("Managed SAM CLI stack creation complete.")
+    LOG.info("\tManaged SAM CLI stack creation complete.")
     ds_resp = cloudformation_client.describe_stacks(StackName=SAM_CLI_STACK_NAME)
     stacks = ds_resp["Stacks"]
     return stacks[0]

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -1,0 +1,129 @@
+import os
+import logging
+import tomlkit
+
+from pathlib import Path
+
+LOG = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_FILE_NAME = "samconfig.toml"
+DEFAULT_ENV = "default"
+
+
+class SamConfig:
+    """
+    Class to interface with `samconfig.toml` file.
+    """
+
+    document = None
+
+    def __init__(self, config_dir, filename=None):
+        """
+        Initialize the class
+
+        Parameters
+        ----------
+        config_dir : string
+            Directory where the configuration file needs to be stored
+
+        filename : string
+            Optional. Name of the configuration file. It is recommended to stick with default so in the future we
+            could automatically support auto-resolving multiple config files within same directory.
+        """
+        self.filepath = Path(config_dir, filename or DEFAULT_CONFIG_FILE_NAME)
+
+    def get_all(self, cmd_names, section, env=DEFAULT_ENV):
+        """
+        Gets a value from the configuration file for the given environment, command and section
+
+        Parameters
+        ----------
+        cmd_names : list(str)
+            List of representing the entire command. Ex: ["local", "generate-event", "s3", "put"]
+
+        section : str
+            Specific section within the command to look into Ex: `parameters`
+
+        env : str
+            Optional, Name of the environment
+
+        Returns
+        -------
+        dict
+            Dictionary of configuration options in the file. None, if the config doesn't exist.
+
+        Raises
+        ------
+        KeyError
+            If the config file does *not* have the specific section
+        """
+
+        env = env or DEFAULT_ENV
+
+        self._read()
+        return self.document[env][self._to_key(cmd_names)][section]
+
+    def put(self, cmd_names, section, key, value, env=DEFAULT_ENV):
+        """
+        Writes the `key=value` under the given section. You have to call the `flush()` method after `put()` in
+        order to write the values back to the config file. Otherwise they will be just saved in-memory, available
+        for future access, but never saved back to the file.
+
+        Parameters
+        ----------
+        cmd_names : list(str)
+            List of representing the entire command. Ex: ["local", "generate-event", "s3", "put"]
+
+        section : str
+            Specific section within the command to look into Ex: `parameters`
+
+        key : str
+            Key to write the data under
+
+        value
+            Value to write. Could be any of the supported TOML types.
+
+        env : str
+            Optional, Name of the environment
+        """
+
+        self._read()
+        self.document[env][self._to_key(cmd_names)][section][key] = value
+
+    def flush(self):
+        self._write()
+
+    def exists(self):
+        return self.filepath.exists()
+
+    def path(self):
+        return str(self.filepath)
+
+    @staticmethod
+    def config_dir(template_file_path=None):
+        """
+        SAM Config file is always relative to the SAM Template. If it the template is not
+        given, then it is relative to cwd()
+        """
+        if template_file_path:
+            return os.path.dirname(template_file_path)
+        else:
+            return os.getcwd()
+
+    def _read(self):
+        if self.document:
+            return self.document
+
+        txt = self.filepath.read_text()
+        self.document = tomlkit.loads(txt)
+
+    def _write(self):
+        if not self.document:
+            return
+
+        self.filepath.write_text(tomlkit.dumps(self.document))
+
+    @staticmethod
+    def _to_key(cmd_names):
+        # construct a parsed name that is of the format: a_b_c_d
+        return "_".join(reversed([cmd.replace("-", "_").replace(" ", "_") for cmd in cmd_names]))

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -103,7 +103,11 @@ class SamConfig:
         """
 
         self._read()
-        self.document.update({env: {self._to_key(cmd_names): {section: {key: value}}}})
+        if not self.document:
+            # Empty document prepare the initial structure.
+            self.document.update({env: {self._to_key(cmd_names): {section: {key: value}}}})
+        # Only update appropriate key value pairs within a section
+        self.document[env][self._to_key(cmd_names)][section].update({key: value})
 
     def flush(self):
         """

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -1,8 +1,13 @@
+"""
+Class representing the samconfig.toml
+"""
+
 import os
 import logging
-import tomlkit
 
 from pathlib import Path
+
+import tomlkit
 
 LOG = logging.getLogger(__name__)
 
@@ -56,6 +61,9 @@ class SamConfig:
         ------
         KeyError
             If the config file does *not* have the specific section
+
+        tomlkit.exceptions.TOMLKitError
+            If the configuration file is invalid
         """
 
         env = env or DEFAULT_ENV
@@ -85,12 +93,26 @@ class SamConfig:
 
         env : str
             Optional, Name of the environment
+
+        Raises
+        ------
+        tomlkit.exceptions.TOMLKitError
+            If the data is invalid
         """
 
         self._read()
         self.document[env][self._to_key(cmd_names)][section][key] = value
 
     def flush(self):
+        """
+        Write the data back to file
+
+        Raises
+        ------
+        tomlkit.exceptions.TOMLKitError
+            If the data is invalid
+
+        """
         self._write()
 
     def exists(self):
@@ -107,8 +129,8 @@ class SamConfig:
         """
         if template_file_path:
             return os.path.dirname(template_file_path)
-        else:
-            return os.getcwd()
+
+        return os.getcwd()
 
     def _read(self):
         if self.document:
@@ -116,6 +138,8 @@ class SamConfig:
 
         txt = self.filepath.read_text()
         self.document = tomlkit.loads(txt)
+
+        return self.document
 
     def _write(self):
         if not self.document:
@@ -126,4 +150,4 @@ class SamConfig:
     @staticmethod
     def _to_key(cmd_names):
         # construct a parsed name that is of the format: a_b_c_d
-        return "_".join(reversed([cmd.replace("-", "_").replace(" ", "_") for cmd in cmd_names]))
+        return "_".join([cmd.replace("-", "_").replace(" ", "_") for cmd in cmd_names])

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -36,6 +36,8 @@ class SamConfig:
             could automatically support auto-resolving multiple config files within same directory.
         """
         self.filepath = Path(config_dir, filename or DEFAULT_CONFIG_FILE_NAME)
+        if not self.filepath.exists():
+            open(self.filepath, "a+").close()
 
     def get_all(self, cmd_names, section, env=DEFAULT_ENV):
         """
@@ -101,7 +103,7 @@ class SamConfig:
         """
 
         self._read()
-        self.document[env][self._to_key(cmd_names)][section][key] = value
+        self.document.update({env: {self._to_key(cmd_names): {section: {key: value}}}})
 
     def flush(self):
         """

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -251,7 +251,6 @@ class Deployer:
         try:
             waiter.wait(ChangeSetName=changeset_id, StackName=stack_name, WaiterConfig=waiter_config)
         except botocore.exceptions.WaiterError as ex:
-            LOG.debug("Create changeset waiter exception", exc_info=ex)
 
             resp = ex.last_response
             status = resp["Status"]

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -69,5 +69,5 @@ class TestGetOrDefaultTemplateFileName(TestCase):
 
         result = get_or_default_template_file_name(ctx, None, _TEMPLATE_OPTION_DEFAULT_VALUE, include_build=True)
         self.assertEqual(result, "a/b/c/absPath")
-        self.assertEqual(ctx.config_path, "a/b/c")
+        self.assertEqual(ctx.samconfig_dir, "a/b/c")
         os_mock.path.abspath.assert_called_with(expected)

--- a/tests/unit/commands/_utils/test_template.py
+++ b/tests/unit/commands/_utils/test_template.py
@@ -12,6 +12,7 @@ from samcli.commands._utils.template import (
     RESOURCES_WITH_LOCAL_PATHS,
     _update_relative_paths,
     move_template,
+    get_template_parameters,
 )
 
 
@@ -41,6 +42,26 @@ class Test_get_template_data(TestCase):
             result = get_template_data(filename)
 
             self.assertEqual(result, parse_result)
+
+        m.assert_called_with(filename, "r")
+        yaml_parse_mock.assert_called_with(file_data)
+
+    @patch("samcli.commands._utils.template.yaml_parse")
+    @patch("samcli.commands._utils.template.pathlib")
+    def test_must_read_file_and_get_parameters(self, pathlib_mock, yaml_parse_mock):
+        filename = "filename"
+        file_data = "contents of the file"
+        parse_result = {"Parameters": {"Myparameter": "String"}}
+
+        pathlib_mock.Path.return_value.exists.return_value = True  # Fake that the file exists
+
+        m = mock_open(read_data=file_data)
+        yaml_parse_mock.return_value = parse_result
+
+        with patch("samcli.commands._utils.template.open", m):
+            result = get_template_parameters(filename)
+
+            self.assertEqual(result, {"Myparameter": "String"})
 
         m.assert_called_with(filename, "r")
         yaml_parse_mock.assert_called_with(file_data)

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -25,6 +25,7 @@ class TestDeployliCommand(TestCase):
         self.profile = None
         self.use_json = True
         self.metadata = {}
+        self.interactive = True
 
     @patch("samcli.commands.package.command.click")
     @patch("samcli.commands.package.package_context.PackageContext")
@@ -53,6 +54,7 @@ class TestDeployliCommand(TestCase):
             profile=self.profile,
             use_json=self.use_json,
             metadata=self.metadata,
+            interactive=self.interactive,
         )
 
         mock_deploy_context.assert_called_with(

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -15,7 +15,7 @@ class TestDeployliCommand(TestCase):
         self.no_execute_changeset = False
         self.notification_arns = []
         self.parameter_overrides = {"a": "b"}
-        self.capabilities = "CAPABILITY_IAM"
+        self.capabilities = ("CAPABILITY_IAM",)
         self.tags = {"c": "d"}
         self.fail_on_empty_changset = True
         self.role_arn = "role_arn"
@@ -100,7 +100,7 @@ class TestDeployliCommand(TestCase):
         context_mock = Mock()
         mock_deploy_context.return_value.__enter__.return_value = context_mock
         mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1", "default"])
-        mock_deploy_click.confirm = MagicMock(side_effect=[True, True])
+        mock_deploy_click.confirm = MagicMock(side_effect=[True, True, True])
 
         mock_managed_stack.return_value = "managed-s3-bucket"
         mock_save_config.return_value = True
@@ -149,6 +149,7 @@ class TestDeployliCommand(TestCase):
         context_mock.run.assert_called_with()
         mock_save_config.assert_called_with(
             "input-template-file",
+            capabilities=("CAPABILITY_IAM",),
             confirm_changeset=True,
             profile="default",
             region="us-east-1",

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -87,8 +87,10 @@ class TestDeployliCommand(TestCase):
     @patch("samcli.commands.deploy.deploy_context.DeployContext")
     @patch("samcli.commands.deploy.command.save_config")
     @patch("samcli.commands.deploy.command.manage_stack")
+    @patch("samcli.commands.deploy.command.get_template_parameters")
     def test_all_args_interactive(
         self,
+        mock_get_template_parameters,
         mock_managed_stack,
         mock_save_config,
         mock_deploy_context,
@@ -98,9 +100,94 @@ class TestDeployliCommand(TestCase):
     ):
 
         context_mock = Mock()
+        mock_get_template_parameters.return_value = {"Myparameter": {"Type": "String"}}
         mock_deploy_context.return_value.__enter__.return_value = context_mock
-        mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1"])
-        mock_deploy_click.confirm = MagicMock(side_effect=[True, True, True])
+        mock_deploy_click.prompt = MagicMock(
+            side_effect=["sam-app", "us-east-1", "InteractiveParameter", ("CAPABILITY_IAM",)]
+        )
+        mock_deploy_click.confirm = MagicMock(side_effect=[True, False, True])
+
+        mock_managed_stack.return_value = "managed-s3-bucket"
+        mock_save_config.return_value = True
+
+        do_cli(
+            template_file=self.template_file,
+            stack_name=self.stack_name,
+            s3_bucket=None,
+            force_upload=self.force_upload,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key_id,
+            parameter_overrides=self.parameter_overrides,
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region=self.region,
+            profile=self.profile,
+            use_json=self.use_json,
+            metadata=self.metadata,
+            interactive=True,
+            confirm_changeset=True,
+        )
+
+        mock_deploy_context.assert_called_with(
+            template_file=ANY,
+            stack_name="sam-app",
+            s3_bucket="managed-s3-bucket",
+            force_upload=self.force_upload,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key_id,
+            parameter_overrides={"Myparameter": "InteractiveParameter"},
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region="us-east-1",
+            profile=self.profile,
+            confirm_changeset=True,
+        )
+
+        context_mock.run.assert_called_with()
+        mock_save_config.assert_called_with(
+            "input-template-file",
+            capabilities=("CAPABILITY_IAM",),
+            confirm_changeset=True,
+            profile=self.profile,
+            region="us-east-1",
+            s3_bucket="managed-s3-bucket",
+            stack_name="sam-app",
+            parameter_overrides={"Myparameter": "InteractiveParameter"},
+        )
+        mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
+        self.assertEqual(context_mock.run.call_count, 1)
+
+    @patch("samcli.commands.package.command.click")
+    @patch("samcli.commands.package.package_context.PackageContext")
+    @patch("samcli.commands.deploy.command.click")
+    @patch("samcli.commands.deploy.deploy_context.DeployContext")
+    @patch("samcli.commands.deploy.command.save_config")
+    @patch("samcli.commands.deploy.command.manage_stack")
+    @patch("samcli.commands.deploy.command.get_template_parameters")
+    def test_all_args_interactive_no_params(
+        self,
+        mock_get_template_parameters,
+        mock_managed_stack,
+        mock_save_config,
+        mock_deploy_context,
+        mock_deploy_click,
+        mock_package_context,
+        mock_package_click,
+    ):
+
+        context_mock = Mock()
+        mock_get_template_parameters.return_value = {}
+        mock_deploy_context.return_value.__enter__.return_value = context_mock
+        mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1", ("CAPABILITY_IAM",)])
+        mock_deploy_click.confirm = MagicMock(side_effect=[True, False, True])
 
         mock_managed_stack.return_value = "managed-s3-bucket"
         mock_save_config.return_value = True
@@ -155,6 +242,7 @@ class TestDeployliCommand(TestCase):
             region="us-east-1",
             s3_bucket="managed-s3-bucket",
             stack_name="sam-app",
+            parameter_overrides=self.parameter_overrides,
         )
         mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -99,7 +99,7 @@ class TestDeployliCommand(TestCase):
 
         context_mock = Mock()
         mock_deploy_context.return_value.__enter__.return_value = context_mock
-        mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1", "default"])
+        mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1"])
         mock_deploy_click.confirm = MagicMock(side_effect=[True, True, True])
 
         mock_managed_stack.return_value = "managed-s3-bucket"
@@ -142,7 +142,7 @@ class TestDeployliCommand(TestCase):
             fail_on_empty_changeset=self.fail_on_empty_changset,
             tags=self.tags,
             region="us-east-1",
-            profile="default",
+            profile=self.profile,
             confirm_changeset=True,
         )
 
@@ -151,10 +151,10 @@ class TestDeployliCommand(TestCase):
             "input-template-file",
             capabilities=("CAPABILITY_IAM",),
             confirm_changeset=True,
-            profile="default",
+            profile=self.profile,
             region="us-east-1",
             s3_bucket="managed-s3-bucket",
             stack_name="sam-app",
         )
-        mock_managed_stack.assert_called_with(profile="default", region="us-east-1")
+        mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, Mock, ANY
+from unittest.mock import patch, Mock, ANY, MagicMock
 
 from samcli.commands.deploy.command import do_cli
 
@@ -25,7 +25,8 @@ class TestDeployliCommand(TestCase):
         self.profile = None
         self.use_json = True
         self.metadata = {}
-        self.interactive = True
+        self.interactive = False
+        self.confirm_changeset = False
 
     @patch("samcli.commands.package.command.click")
     @patch("samcli.commands.package.package_context.PackageContext")
@@ -55,6 +56,7 @@ class TestDeployliCommand(TestCase):
             use_json=self.use_json,
             metadata=self.metadata,
             interactive=self.interactive,
+            confirm_changeset=self.confirm_changeset,
         )
 
         mock_deploy_context.assert_called_with(
@@ -73,7 +75,85 @@ class TestDeployliCommand(TestCase):
             tags=self.tags,
             region=self.region,
             profile=self.profile,
+            confirm_changeset=self.confirm_changeset,
         )
 
         context_mock.run.assert_called_with()
+        self.assertEqual(context_mock.run.call_count, 1)
+
+    @patch("samcli.commands.package.command.click")
+    @patch("samcli.commands.package.package_context.PackageContext")
+    @patch("samcli.commands.deploy.command.click")
+    @patch("samcli.commands.deploy.deploy_context.DeployContext")
+    @patch("samcli.commands.deploy.command.save_config")
+    @patch("samcli.commands.deploy.command.manage_stack")
+    def test_all_args_interactive(
+        self,
+        mock_managed_stack,
+        mock_save_config,
+        mock_deploy_context,
+        mock_deploy_click,
+        mock_package_context,
+        mock_package_click,
+    ):
+
+        context_mock = Mock()
+        mock_deploy_context.return_value.__enter__.return_value = context_mock
+        mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1", "default"])
+        mock_deploy_click.confirm = MagicMock(side_effect=[True, True])
+
+        mock_managed_stack.return_value = "managed-s3-bucket"
+        mock_save_config.return_value = True
+
+        do_cli(
+            template_file=self.template_file,
+            stack_name=self.stack_name,
+            s3_bucket=None,
+            force_upload=self.force_upload,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key_id,
+            parameter_overrides=self.parameter_overrides,
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region=self.region,
+            profile=self.profile,
+            use_json=self.use_json,
+            metadata=self.metadata,
+            interactive=True,
+            confirm_changeset=True,
+        )
+
+        mock_deploy_context.assert_called_with(
+            template_file=ANY,
+            stack_name="sam-app",
+            s3_bucket="managed-s3-bucket",
+            force_upload=self.force_upload,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key_id,
+            parameter_overrides=self.parameter_overrides,
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region="us-east-1",
+            profile="default",
+            confirm_changeset=True,
+        )
+
+        context_mock.run.assert_called_with()
+        mock_save_config.assert_called_with(
+            "input-template-file",
+            confirm_changeset=True,
+            profile="default",
+            region="us-east-1",
+            s3_bucket="managed-s3-bucket",
+            stack_name="sam-app",
+        )
+        mock_managed_stack.assert_called_with(profile="default", region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch, Mock, ANY, MagicMock
 
 from samcli.commands.deploy.command import do_cli
+from samcli.lib.config.samconfig import SamConfig
 
 
 class TestDeployliCommand(TestCase):
@@ -169,14 +170,16 @@ class TestDeployliCommand(TestCase):
     @patch("samcli.commands.package.package_context.PackageContext")
     @patch("samcli.commands.deploy.command.click")
     @patch("samcli.commands.deploy.deploy_context.DeployContext")
-    @patch("samcli.commands.deploy.command.save_config")
     @patch("samcli.commands.deploy.command.manage_stack")
     @patch("samcli.commands.deploy.command.get_template_parameters")
-    def test_all_args_interactive_no_params(
+    @patch("samcli.commands.deploy.command.SamConfig")
+    @patch("samcli.commands.deploy.command.get_cmd_names")
+    def test_all_args_interactive_no_params_save_config(
         self,
+        mock_get_cmd_names,
+        mock_sam_config,
         mock_get_template_parameters,
         mock_managed_stack,
-        mock_save_config,
         mock_deploy_context,
         mock_deploy_click,
         mock_package_context,
@@ -184,13 +187,13 @@ class TestDeployliCommand(TestCase):
     ):
 
         context_mock = Mock()
+
         mock_get_template_parameters.return_value = {}
         mock_deploy_context.return_value.__enter__.return_value = context_mock
         mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1", ("CAPABILITY_IAM",)])
         mock_deploy_click.confirm = MagicMock(side_effect=[True, False, True])
-
+        mock_get_cmd_names.return_value = ["deploy"]
         mock_managed_stack.return_value = "managed-s3-bucket"
-        mock_save_config.return_value = True
 
         do_cli(
             template_file=self.template_file,
@@ -234,15 +237,77 @@ class TestDeployliCommand(TestCase):
         )
 
         context_mock.run.assert_called_with()
-        mock_save_config.assert_called_with(
-            "input-template-file",
-            capabilities=("CAPABILITY_IAM",),
-            confirm_changeset=True,
-            profile=self.profile,
-            region="us-east-1",
-            s3_bucket="managed-s3-bucket",
-            stack_name="sam-app",
+        mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
+        self.assertEqual(context_mock.run.call_count, 1)
+
+    @patch("samcli.commands.package.command.click")
+    @patch("samcli.commands.package.package_context.PackageContext")
+    @patch("samcli.commands.deploy.command.click")
+    @patch("samcli.commands.deploy.deploy_context.DeployContext")
+    @patch("samcli.commands.deploy.command.save_config")
+    @patch("samcli.commands.deploy.command.manage_stack")
+    @patch("samcli.commands.deploy.command.get_template_parameters")
+    def test_all_args_interactive_no_params_no_save_config(
+        self,
+        mock_get_template_parameters,
+        mock_managed_stack,
+        mock_save_config,
+        mock_deploy_context,
+        mock_deploy_click,
+        mock_package_context,
+        mock_package_click,
+    ):
+
+        context_mock = Mock()
+        mock_get_template_parameters.return_value = {}
+        mock_deploy_context.return_value.__enter__.return_value = context_mock
+        mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1", ("CAPABILITY_IAM",)])
+        mock_deploy_click.confirm = MagicMock(side_effect=[True, False, False])
+
+        mock_managed_stack.return_value = "managed-s3-bucket"
+
+        do_cli(
+            template_file=self.template_file,
+            stack_name=self.stack_name,
+            s3_bucket=None,
+            force_upload=self.force_upload,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key_id,
             parameter_overrides=self.parameter_overrides,
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region=self.region,
+            profile=self.profile,
+            use_json=self.use_json,
+            metadata=self.metadata,
+            interactive=True,
+            confirm_changeset=True,
         )
+
+        mock_deploy_context.assert_called_with(
+            template_file=ANY,
+            stack_name="sam-app",
+            s3_bucket="managed-s3-bucket",
+            force_upload=self.force_upload,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key_id,
+            parameter_overrides=self.parameter_overrides,
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region="us-east-1",
+            profile=self.profile,
+            confirm_changeset=True,
+        )
+
+        context_mock.run.assert_called_with()
+        self.assertEqual(mock_save_config.call_count, 0)
         mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -26,7 +26,7 @@ class TestPackageCommand(TestCase):
             tags={"a": "b"},
             region=None,
             profile=None,
-            confirm_changeset=True,
+            confirm_changeset=False,
         )
 
     def test_template_improper(self):

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -26,6 +26,7 @@ class TestPackageCommand(TestCase):
             tags={"a": "b"},
             region=None,
             profile=None,
+            confirm_changeset=True,
         )
 
     def test_template_improper(self):

--- a/tests/unit/lib/config/test_samconfig.py
+++ b/tests/unit/lib/config/test_samconfig.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+
+from unittest import TestCase
+
+from samcli.lib.config.samconfig import SamConfig, DEFAULT_CONFIG_FILE_NAME
+
+
+class TestSamConfig(TestCase):
+    def setUp(self):
+        self.config_dir = os.getcwd()
+        self.samconfig = SamConfig(self.config_dir)
+        open(self.samconfig.path(), "w").close()
+
+    def tearDown(self):
+        if self.samconfig.exists():
+            os.remove(self.samconfig.path())
+
+    def _setup_config(self):
+        self.samconfig.put(cmd_names=["local", "start", "api"], section="parameters", key="port", value=5401)
+        self.samconfig.flush()
+
+    def test_init(self):
+        self.assertEqual(self.samconfig.filepath, Path(self.config_dir, DEFAULT_CONFIG_FILE_NAME))
+
+    def test_check_config_get(self):
+        self._setup_config()
+        self.assertEqual(
+            {"port": 5401}, self.samconfig.get_all(cmd_names=["local", "start", "api"], section="parameters")
+        )
+
+    def test_check_config_exists(self):
+        self._setup_config()
+        self.assertTrue(self.samconfig.exists())


### PR DESCRIPTION
*Description of changes:*
`sam deploy -i` now provides an interactive guided deployment experience. 

Remaining:
- [x] Store parameters in samconfig.toml
- [ ] Unit tests are still pending. 

**Screenshot**
<img width="982" alt="Screen Shot 2019-11-15 at 1 40 31 AM" src="https://user-images.githubusercontent.com/22755571/68933180-fa80b480-0748-11ea-8ca4-ba3d11cbc7ae.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

