### PR TITLE
fix: helpful error message when deploy happens across regions

### DIFF
--- a/samcli/commands/deploy/exceptions.py
+++ b/samcli/commands/deploy/exceptions.py
@@ -47,6 +47,15 @@ class DeployStackOutPutFailedError(UserException):
         )
 
 
+class DeployBucketInDifferentRegionError(UserException):
+    def __init__(self, msg):
+        self.msg = msg
+
+        message_fmt = "{msg} : deployment s3 bucket is in a different region, try sam deploy --guided"
+
+        super(DeployBucketInDifferentRegionError, self).__init__(message=message_fmt.format(msg=self.msg))
+
+
 class DeployBucketRequiredError(UserException):
     def __init__(self):
 


### PR DESCRIPTION
- deployment s3 bucket is specific to the region it was created in.
  cfn/lambda requires code to be packaged within the same region as
  where the stack is to be deployed. When such a case is encountered
  prompt to use `sam deploy --guided`

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
