### PR TITLE
fix: collect prior output from attached containers

### DIFF
--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -199,7 +199,7 @@ class Container:
         real_container = self.docker_client.containers.get(self.id)
 
         # Fetch both stdout and stderr streams from Docker as a single iterator.
-        logs_itr = real_container.attach(stream=True, logs=False, demux=True)
+        logs_itr = real_container.attach(stream=True, logs=True, demux=True)
 
         self._write_container_output(logs_itr, stdout=stdout, stderr=stderr)
 

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -451,7 +451,7 @@ class TestContainer_wait_for_logs(TestCase):
 
         self.container.wait_for_logs(stdout=stdout_mock, stderr=stderr_mock)
 
-        real_container_mock.attach.assert_called_with(stream=True, logs=False, demux=True)
+        real_container_mock.attach.assert_called_with(stream=True, logs=True, demux=True)
         self.container._write_container_output.assert_called_with(output_itr, stdout=stdout_mock, stderr=stderr_mock)
 
     def test_must_skip_if_no_stdout_and_stderr(self):


### PR DESCRIPTION
When attaching to a docker container, specify logs=True in order to
receive the output the container has generated prior to it being
attached.

*Issue #, if available:*

Related to #1551

PR #1552 switched to using Docker API for attaching to containers. However, it is invoked with `logs=False` so that only the output generated by the container after attaching is collected. This means that some initial output may get lost.

*Description of changes:*

Specify `logs=True` when attaching to a container to ensure the complete output is collected.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
