### PR TITLE
bugfixes: `stack-name` is required on deploy

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -56,6 +56,24 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
     return result
 
 
+def guided_deploy_stack_name(ctx, param, provided_value):
+    """
+    Provide a default value for stack name if invoked with a guided deploy.
+    :param ctx:
+    :param param:
+    :param provided_value:
+    :return:
+    """
+
+    default_stack_name = "sam-app"
+    guided = ctx.params.get("guided", False) or ctx.params.get("g", False)
+
+    if not guided and not provided_value:
+        raise click.MissingParameter(param=param, ctx=ctx)
+
+    return provided_value if provided_value else default_stack_name
+
+
 def template_common_option(f):
     """
     Common ClI option for template

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -13,6 +13,7 @@ from samcli.commands._utils.custom_options.option_nargs import OptionNargs
 
 
 _TEMPLATE_OPTION_DEFAULT_VALUE = "template.[yaml|yml]"
+DEFAULT_STACK_NAME = "sam-app"
 
 
 LOG = logging.getLogger(__name__)
@@ -65,13 +66,12 @@ def guided_deploy_stack_name(ctx, param, provided_value):
     :return:
     """
 
-    default_stack_name = "sam-app"
     guided = ctx.params.get("guided", False) or ctx.params.get("g", False)
 
     if not guided and not provided_value:
         raise click.MissingParameter(param=param, ctx=ctx)
 
-    return provided_value if provided_value else default_stack_name
+    return provided_value if provided_value else DEFAULT_STACK_NAME
 
 
 def template_common_option(f):

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -60,16 +60,21 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
 def guided_deploy_stack_name(ctx, param, provided_value):
     """
     Provide a default value for stack name if invoked with a guided deploy.
-    :param ctx:
-    :param param:
-    :param provided_value:
-    :return:
+    :param ctx: Click Context
+    :param param: Param name
+    :param provided_value: Value provided by Click, it would be the value provided by the user.
+    :return: Actual value to be used in the CLI
     """
 
     guided = ctx.params.get("guided", False) or ctx.params.get("g", False)
 
     if not guided and not provided_value:
-        raise click.MissingParameter(param=param, ctx=ctx)
+        raise click.BadOptionUsage(
+            option_name=param.name,
+            ctx=ctx,
+            message="Missing option '--stack-name', 'sam deploy –guided' can "
+            "be used to provide and save needed parameters for future deploys.",
+        )
 
     return provided_value if provided_value else DEFAULT_STACK_NAME
 

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -145,9 +145,9 @@ def parameter_override_click_option():
         cls=OptionNargs,
         type=CfnParameterOverridesType(),
         default={},
-        help="Optional. A string that contains CloudFormation parameter overrides encoded as key=value "
-        "pairs. Use the same format as the AWS CLI, e.g. 'ParameterKey=KeyPairName,"
-        "ParameterValue=MyKey ParameterKey=InstanceType,ParameterValue=t1.micro'",
+        help="Optional. A string that contains AWS CloudFormation parameter overrides encoded as key=value pairs."
+        "For example, 'ParameterKey=KeyPairName,ParameterValue=MyKey ParameterKey=InstanceType,"
+        "ParameterValue=t1.micro' or KeyPairName=MyKey InstanceType=t1.micro",
     )
 
 

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -353,9 +353,10 @@ def prompt_parameters(parameter_override_keys, start_bold, end_bold):
                 )
                 _prompted_param_overrides[parameter_key] = {"Value": parameter, "Hidden": True}
             else:
+                # Make sure the default is casted to a string.
                 parameter = click.prompt(
                     f"\t{start_bold}Parameter {parameter_key}{end_bold}",
-                    default=_prompted_param_overrides.get(parameter_key, parameter_properties.get("Default", "")),
+                    default=_prompted_param_overrides.get(parameter_key, str(parameter_properties.get("Default", ""))),
                     type=click.STRING,
                 )
                 _prompted_param_overrides[parameter_key] = {"Value": parameter, "Hidden": False}

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -48,6 +48,14 @@ CONFIG_SECTION = "parameters"
     help=HELP_TEXT,
 )
 @configuration_option(provider=TomlProvider(section=CONFIG_SECTION))
+@click.option(
+    "--guided",
+    "-g",
+    required=False,
+    is_flag=True,
+    is_eager=True,
+    help="Specify this flag to allow SAM CLI to guide you through the deployment using guided prompts.",
+)
 @template_click_option(include_build=True)
 @click.option(
     "--stack-name",
@@ -122,14 +130,6 @@ CONFIG_SECTION = "parameters"
     is_flag=True,
     help="Indicates whether to use JSON as the format for "
     "the output AWS CloudFormation template. YAML is used by default.",
-)
-@click.option(
-    "--guided",
-    "-g",
-    required=False,
-    is_flag=True,
-    is_eager=True,
-    help="Specify this flag to allow SAM CLI to guide you through the deployment using guided prompts.",
 )
 @metadata_override_option
 @notification_arns_override_option

--- a/samcli/lib/bootstrap/bootstrap.py
+++ b/samcli/lib/bootstrap/bootstrap.py
@@ -120,6 +120,27 @@ def _get_stack_template():
             - Key: ManagedStackSource
               Value: AwsSamCli
 
+      SamCliSourceBucketBucketPolicy:
+        Type: AWS::S3::BucketPolicy
+        Properties:
+          Bucket: !Ref SamCliSourceBucket
+          PolicyDocument:
+            Statement:
+              -
+                Action:
+                  - "s3:GetObject"
+                Effect: "Allow"
+                Resource:
+                  Fn::Join:
+                    - ""
+                    -
+                      - "arn:aws:s3:::"
+                      -
+                        !Ref SamCliSourceBucket
+                      - "/*"
+                Principal:
+                  Service: serverlessrepo.amazonaws.com
+
     Outputs:
       SourceBucket:
         Value: !Ref SamCliSourceBucket

--- a/samcli/lib/bootstrap/bootstrap.py
+++ b/samcli/lib/bootstrap/bootstrap.py
@@ -15,7 +15,7 @@ from samcli.cli.global_config import GlobalConfig
 from samcli.commands.exceptions import UserException, CredentialsError, RegionError
 
 
-SAM_CLI_STACK_NAME = "aws-sam-cli-managed-stack"
+SAM_CLI_STACK_NAME = "aws-sam-cli-managed-default"
 
 
 def manage_stack(profile, region):

--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -205,3 +205,5 @@ class ProgressPercentage:
                 "\rUploading to %s  %s / %s  (%.2f%%)" % (self._remote_path, self._seen_so_far, self._size, percentage)
             )
             sys.stderr.flush()
+            if int(percentage) == 100:
+                sys.stderr.write("\n")

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -193,7 +193,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
         deploy_process_execute.wait()
         # Error no stack name present
-        self.assertEqual(deploy_process_execute.returncode, 1)
+        self.assertEqual(deploy_process_execute.returncode, 2)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_capabilities(self, template_file):

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -10,9 +10,11 @@ from samcli.lib.config.samconfig import SamConfig
 
 
 class MockContext:
-    def __init__(self, info_name, parent):
+    def __init__(self, info_name, parent, params=None, command=None):
         self.info_name = info_name
         self.parent = parent
+        self.params = params
+        self.command = command
 
 
 class TestTomlProvider(TestCase):

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -115,7 +115,7 @@ class TestGuidedDeployStackName(TestCase):
         stack_name = None
         mock_params = MagicMock()
         mock_params.get = MagicMock(return_value=False)
-        with self.assertRaises(click.MissingParameter):
+        with self.assertRaises(click.BadOptionUsage):
             guided_deploy_stack_name(
                 ctx=MockContext(info_name="test", parent=None, params=mock_params),
                 param=MagicMock(),

--- a/tests/unit/commands/_utils/test_options.py
+++ b/tests/unit/commands/_utils/test_options.py
@@ -5,8 +5,16 @@ Test the common CLI options
 import os
 
 from unittest import TestCase
-from unittest.mock import patch
-from samcli.commands._utils.options import get_or_default_template_file_name, _TEMPLATE_OPTION_DEFAULT_VALUE
+from unittest.mock import patch, MagicMock
+
+import click
+
+from samcli.commands._utils.options import (
+    get_or_default_template_file_name,
+    _TEMPLATE_OPTION_DEFAULT_VALUE,
+    guided_deploy_stack_name,
+)
+from tests.unit.cli.test_cli_config_file import MockContext
 
 
 class Mock:
@@ -71,3 +79,45 @@ class TestGetOrDefaultTemplateFileName(TestCase):
         self.assertEqual(result, "a/b/c/absPath")
         self.assertEqual(ctx.samconfig_dir, "a/b/c")
         os_mock.path.abspath.assert_called_with(expected)
+
+
+class TestGuidedDeployStackName(TestCase):
+    def test_must_return_provided_value_guided(self):
+        stack_name = "provided-stack"
+        mock_params = MagicMock()
+        mock_params.get = MagicMock(return_value=True)
+        result = guided_deploy_stack_name(
+            ctx=MockContext(info_name="test", parent=None, params=mock_params),
+            param=MagicMock(),
+            provided_value=stack_name,
+        )
+        self.assertEqual(result, stack_name)
+
+    def test_must_return_default_value_guided(self):
+        stack_name = None
+        mock_params = MagicMock()
+        mock_params.get = MagicMock(return_value=True)
+        result = guided_deploy_stack_name(
+            ctx=MockContext(info_name="test", parent=None, params=mock_params),
+            param=MagicMock(),
+            provided_value=stack_name,
+        )
+        self.assertEqual(result, "sam-app")
+
+    def test_must_return_provided_value_non_guided(self):
+        stack_name = "provided-stack"
+        mock_params = MagicMock()
+        mock_params.get = MagicMock(return_value=False)
+        result = guided_deploy_stack_name(ctx=MagicMock(), param=MagicMock(), provided_value=stack_name)
+        self.assertEqual(result, "provided-stack")
+
+    def test_exception_missing_parameter_no_value_non_guided(self):
+        stack_name = None
+        mock_params = MagicMock()
+        mock_params.get = MagicMock(return_value=False)
+        with self.assertRaises(click.MissingParameter):
+            guided_deploy_stack_name(
+                ctx=MockContext(info_name="test", parent=None, params=mock_params),
+                param=MagicMock(),
+                provided_value=stack_name,
+            )

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -146,7 +146,7 @@ class TestDeployliCommand(TestCase):
             stack_name="sam-app",
             s3_bucket="managed-s3-bucket",
             force_upload=self.force_upload,
-            s3_prefix=self.s3_prefix,
+            s3_prefix="sam-app",
             kms_key_id=self.kms_key_id,
             parameter_overrides={"Myparameter": "guidedParameter", "MyNoEchoParameter": "secure"},
             capabilities=self.capabilities,
@@ -169,6 +169,7 @@ class TestDeployliCommand(TestCase):
             region="us-east-1",
             s3_bucket="managed-s3-bucket",
             stack_name="sam-app",
+            s3_prefix="sam-app",
             parameter_overrides={
                 "Myparameter": {"Value": "guidedParameter", "Hidden": False},
                 "MyNoEchoParameter": {"Value": "secure", "Hidden": True},
@@ -238,7 +239,7 @@ class TestDeployliCommand(TestCase):
             stack_name="sam-app",
             s3_bucket="managed-s3-bucket",
             force_upload=self.force_upload,
-            s3_prefix=self.s3_prefix,
+            s3_prefix="sam-app",
             kms_key_id=self.kms_key_id,
             parameter_overrides={"Myparameter": "guidedParameter", "MyNoEchoParameter": "secure"},
             capabilities=self.capabilities,
@@ -256,12 +257,13 @@ class TestDeployliCommand(TestCase):
         mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)
 
-        self.assertEqual(mock_sam_config.put.call_count, 6)
+        self.assertEqual(mock_sam_config.put.call_count, 7)
         self.assertEqual(
             mock_sam_config.put.call_args_list,
             [
                 call(["deploy"], "parameters", "stack_name", "sam-app"),
                 call(["deploy"], "parameters", "s3_bucket", "managed-s3-bucket"),
+                call(["deploy"], "parameters", "s3_prefix", "sam-app"),
                 call(["deploy"], "parameters", "region", "us-east-1"),
                 call(["deploy"], "parameters", "confirm_changeset", True),
                 call(["deploy"], "parameters", "capabilities", "CAPABILITY_IAM"),
@@ -325,7 +327,7 @@ class TestDeployliCommand(TestCase):
             stack_name="sam-app",
             s3_bucket="managed-s3-bucket",
             force_upload=self.force_upload,
-            s3_prefix=self.s3_prefix,
+            s3_prefix="sam-app",
             kms_key_id=self.kms_key_id,
             parameter_overrides=self.parameter_overrides,
             capabilities=self.capabilities,
@@ -401,7 +403,7 @@ class TestDeployliCommand(TestCase):
             stack_name="sam-app",
             s3_bucket="managed-s3-bucket",
             force_upload=self.force_upload,
-            s3_prefix=self.s3_prefix,
+            s3_prefix="sam-app",
             kms_key_id=self.kms_key_id,
             parameter_overrides=self.parameter_overrides,
             capabilities=self.capabilities,

--- a/tests/unit/lib/bootstrap/test_bootstrap.py
+++ b/tests/unit/lib/bootstrap/test_bootstrap.py
@@ -44,7 +44,7 @@ class TestBootstrapManagedStack(TestCase):
             "ChangeSetType": "CREATE",
             "ChangeSetName": "InitialCreation",
         }
-        ccs_resp = {"Id": "id", "StackId": "aws-sam-cli-managed-stack"}
+        ccs_resp = {"Id": "id", "StackId": "aws-sam-cli-managed-default"}
         stubber.add_response("create_change_set", ccs_resp, ccs_params)
         # describe change set creation status for waiter
         dcs_params = {"ChangeSetName": "InitialCreation", "StackName": SAM_CLI_STACK_NAME}
@@ -189,7 +189,7 @@ class TestBootstrapManagedStack(TestCase):
             "ChangeSetType": "CREATE",
             "ChangeSetName": "InitialCreation",
         }
-        ccs_resp = {"Id": "id", "StackId": "aws-sam-cli-managed-stack"}
+        ccs_resp = {"Id": "id", "StackId": "aws-sam-cli-managed-default"}
         stubber.add_response("create_change_set", ccs_resp, ccs_params)
         # describe change set creation status for waiter
         dcs_params = {"ChangeSetName": "InitialCreation", "StackName": SAM_CLI_STACK_NAME}

--- a/tests/unit/lib/deploy/test_deployer.py
+++ b/tests/unit/lib/deploy/test_deployer.py
@@ -193,6 +193,26 @@ class TestDeployer(TestCase):
                 tags={"unit": "true"},
             )
 
+    def test_create_changeset_ClientErrorException_generic(self):
+        self.deployer.has_stack = MagicMock(return_value=False)
+        self.deployer._client.create_change_set = MagicMock(
+            side_effect=ClientError(error_response={"Error": {"Message": "Message"}}, operation_name="create_changeset")
+        )
+        with self.assertRaises(ChangeSetError):
+            self.deployer.create_changeset(
+                stack_name="test",
+                cfn_template=" ",
+                parameter_values=[
+                    {"ParameterKey": "a", "ParameterValue": "b"},
+                    {"ParameterKey": "c", "UsePreviousValue": True},
+                ],
+                capabilities=["CAPABILITY_IAM"],
+                role_arn="role-arn",
+                notification_arns=[],
+                s3_uploader=S3Uploader(s3_client=self.s3_client, bucket_name="test_bucket"),
+                tags={"unit": "true"},
+            )
+
     def test_describe_changeset_with_changes(self):
         response = [
             {


### PR DESCRIPTION
- providing non standard capabilities gives an appropriate error message
- add s3 prefix to be the stack name during guided deploy

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
