### PR TITLE
fix: add version to `samconfig.toml` file

### DIFF
--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -5,6 +5,12 @@ Class containing error conditions that are exposed to the user.
 import click
 
 
+class ConfigException(click.ClickException):
+    """
+    Exception class when configuration file fails checks.
+    """
+
+
 class UserException(click.ClickException):
     """
     Base class for all exceptions that need to be surfaced to the user. Typically, we will display the exception

--- a/samcli/lib/config/exceptions.py
+++ b/samcli/lib/config/exceptions.py
@@ -1,0 +1,7 @@
+"""
+Exceptions to be used by samconfig.py
+"""
+
+
+class SamConfigVersionException(Exception):
+    pass

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -103,8 +103,8 @@ class SamConfig:
             If the data is invalid
         """
 
-        self._read()
         if not self.document:
+            self._read()
             # Empty document prepare the initial structure.
             self.document.update({env: {self._to_key(cmd_names): {section: {key: value}}}})
         # Only update appropriate key value pairs within a section

--- a/samcli/lib/config/version.py
+++ b/samcli/lib/config/version.py
@@ -1,0 +1,6 @@
+"""
+Constants and helper functions for samconfig.toml's versioning.
+"""
+
+SAM_CONFIG_VERSION = 0.1
+VERSION_KEY = "version"

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -421,3 +421,80 @@ class TestDeployliCommand(TestCase):
         self.assertEqual(mock_save_config.call_count, 0)
         mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
         self.assertEqual(context_mock.run.call_count, 1)
+
+    @patch("samcli.commands.package.command.click")
+    @patch("samcli.commands.package.package_context.PackageContext")
+    @patch("samcli.commands.deploy.command.click")
+    @patch("samcli.commands.deploy.deploy_context.DeployContext")
+    @patch("samcli.commands.deploy.command.save_config")
+    @patch("samcli.commands.deploy.command.manage_stack")
+    @patch("samcli.commands.deploy.command.get_template_parameters")
+    @patch("samcli.commands.deploy.command.get_config_ctx")
+    def test_all_args_guided_no_params_no_save_config(
+        self,
+        mock_get_config_ctx,
+        mock_get_template_parameters,
+        mock_managed_stack,
+        mock_save_config,
+        mock_deploy_context,
+        mock_deploy_click,
+        mock_package_context,
+        mock_package_click,
+    ):
+
+        context_mock = Mock()
+        mock_sam_config = MagicMock()
+        mock_sam_config.exists = MagicMock(return_value=True)
+        mock_get_config_ctx.return_value = (None, mock_sam_config)
+        mock_get_template_parameters.return_value = {}
+        mock_deploy_context.return_value.__enter__.return_value = context_mock
+        mock_deploy_click.prompt = MagicMock(side_effect=["sam-app", "us-east-1", ("CAPABILITY_IAM",)])
+        mock_deploy_click.confirm = MagicMock(side_effect=[True, False, False])
+
+        mock_managed_stack.return_value = "managed-s3-bucket"
+
+        do_cli(
+            template_file=self.template_file,
+            stack_name=self.stack_name,
+            s3_bucket=None,
+            force_upload=self.force_upload,
+            s3_prefix=self.s3_prefix,
+            kms_key_id=self.kms_key_id,
+            parameter_overrides=self.parameter_overrides,
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region=self.region,
+            profile=self.profile,
+            use_json=self.use_json,
+            metadata=self.metadata,
+            guided=True,
+            confirm_changeset=True,
+        )
+
+        mock_deploy_context.assert_called_with(
+            template_file=ANY,
+            stack_name="sam-app",
+            s3_bucket="managed-s3-bucket",
+            force_upload=self.force_upload,
+            s3_prefix="sam-app",
+            kms_key_id=self.kms_key_id,
+            parameter_overrides=self.parameter_overrides,
+            capabilities=self.capabilities,
+            no_execute_changeset=self.no_execute_changeset,
+            role_arn=self.role_arn,
+            notification_arns=self.notification_arns,
+            fail_on_empty_changeset=self.fail_on_empty_changset,
+            tags=self.tags,
+            region="us-east-1",
+            profile=self.profile,
+            confirm_changeset=True,
+        )
+
+        context_mock.run.assert_called_with()
+        self.assertEqual(mock_save_config.call_count, 0)
+        mock_managed_stack.assert_called_with(profile=self.profile, region="us-east-1")
+        self.assertEqual(context_mock.run.call_count, 1)

--- a/tests/unit/lib/samconfig/test_samconfig.py
+++ b/tests/unit/lib/samconfig/test_samconfig.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from unittest import TestCase
 
+from samcli.lib.config.exceptions import SamConfigVersionException
+from samcli.lib.config.version import VERSION_KEY, SAM_CONFIG_VERSION
 from samcli.lib.config.samconfig import SamConfig, DEFAULT_CONFIG_FILE_NAME
 
 
@@ -20,6 +22,7 @@ class TestSamConfig(TestCase):
         self.samconfig.flush()
         self.assertTrue(self.samconfig.exists())
         self.assertTrue(self.samconfig.sanity_check())
+        self.assertEqual(SAM_CONFIG_VERSION, self.samconfig.document.get(VERSION_KEY))
 
     def test_init(self):
         self.assertEqual(self.samconfig.filepath, Path(self.config_dir, DEFAULT_CONFIG_FILE_NAME))
@@ -36,3 +39,30 @@ class TestSamConfig(TestCase):
 
     def test_check_sanity(self):
         self.assertTrue(self.samconfig.sanity_check())
+
+    def test_check_version_non_supported_type(self):
+        self._setup_config()
+        self.samconfig.document.remove(VERSION_KEY)
+        self.samconfig.document.add(VERSION_KEY, "aadeff")
+        with self.assertRaises(SamConfigVersionException):
+            self.samconfig.sanity_check()
+
+    def test_check_version_no_version_exists(self):
+        self._setup_config()
+        self.samconfig.document.remove(VERSION_KEY)
+        with self.assertRaises(SamConfigVersionException):
+            self.samconfig.sanity_check()
+
+    def test_check_version_float(self):
+        self._setup_config()
+        self.samconfig.document.remove(VERSION_KEY)
+        self.samconfig.document.add(VERSION_KEY, 0.2)
+        self.samconfig.sanity_check()
+
+    def test_write_config_file_non_standard_version(self):
+        self._setup_config()
+        self.samconfig.document.remove(VERSION_KEY)
+        self.samconfig.document.add(VERSION_KEY, 0.2)
+        self.samconfig.put(cmd_names=["local", "start", "api"], section="parameters", key="skip_pull_image", value=True)
+        self.samconfig.sanity_check()
+        self.assertEqual(self.samconfig.document.get(VERSION_KEY), 0.2)


### PR DESCRIPTION
- support version key, any float is okay.
- if a config file is present and the version key is missing, we do not
  process it.
- if a config file is missing, thats fine. this check does not get in
  the way.
- validation logic to determine if a SAM CLI version is compatible can
  be written later.

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
