### PR TITLE
Fixed typo of "sam deploy" option

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -72,7 +72,7 @@ def guided_deploy_stack_name(ctx, param, provided_value):
         raise click.BadOptionUsage(
             option_name=param.name,
             ctx=ctx,
-            message="Missing option '--stack-name', 'sam deploy –guided' can "
+            message="Missing option '--stack-name', 'sam deploy --guided' can "
             "be used to provide and save needed parameters for future deploys.",
         )
 


### PR DESCRIPTION
*Description of changes:*

I found typo : `–guided` option.
`--guided` is correct.

- https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-deploy.html

```sh
$ sam --version
SAM CLI, version 0.33.1

$ sam deploy
Usage: sam deploy [OPTIONS]
Try "sam deploy --help" for help.

Error: Missing option '--stack-name', 'sam deploy –guided' can be used to provide and save needed parameters for future deploys.
```

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

I understand it 👍

>By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Thanks.