### PR TITLE
fix: do not exit after throttling retries have been exhausted

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -359,10 +359,11 @@ class Deployer:
                 if self._check_stack_complete(stack_status):
                     stack_change_in_progress = False
                     break
-            except botocore.exceptions.ClientError:
+            except botocore.exceptions.ClientError as ex:
                 retry_attempts = retry_attempts + 1
                 if retry_attempts > self.max_attempts:
-                    raise
+                    LOG.error("Describing stack events for %s failed: %s", stack_name, str(ex))
+                    return
                 # Sleep in exponential backoff mode
                 time.sleep(math.pow(self.backoff, retry_attempts))
 


### PR DESCRIPTION
#1610 

- Do not exit after exhausting retries.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
