### PR TITLE
Fix for stackTrace not returned in new Lambda containers.

### DIFF
--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -231,7 +231,17 @@ def do_cli(
 
         read_config_showcase(template_file=template_file)
 
-        guided_stack_name, guided_s3_bucket, guided_s3_prefix, guided_region, guided_profile, changeset_decision, _capabilities, _parameter_overrides, save_to_config = guided_deploy(
+        (
+            guided_stack_name,
+            guided_s3_bucket,
+            guided_s3_prefix,
+            guided_region,
+            guided_profile,
+            changeset_decision,
+            _capabilities,
+            _parameter_overrides,
+            save_to_config,
+        ) = guided_deploy(
             stack_name, s3_bucket, region, profile, confirm_changeset, _parameter_override_keys, parameter_overrides
         )
 

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -150,15 +150,14 @@ class LambdaOutputParser:
 
             # This is a best effort attempt to determine if the output (lambda_response) from the container was an
             # Error/Exception that was raised/returned/thrown from the container. To ensure minimal false positives in
-            # this checking, we check for all three keys that can occur in Lambda raised/thrown/returned an
+            # this checking, we check for all the keys that can occur in Lambda raised/thrown/returned an
             # Error/Exception. This still risks false positives when the data returned matches exactly a dictionary with
-            # the keys 'errorMessage', 'errorType' and 'stackTrace'.
+            # the keys 'errorMessage' and 'errorType'.
             if (
                 isinstance(lambda_response_dict, dict)
-                and len(lambda_response_dict) == 3
+                and len(lambda_response_dict) in [2, 3]
                 and "errorMessage" in lambda_response_dict
                 and "errorType" in lambda_response_dict
-                and "stackTrace" in lambda_response_dict
             ):
                 is_lambda_user_error_response = True
         except ValueError:

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -98,9 +98,7 @@ class TestLambdaOutputParser(TestCase):
             param(
                 '{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type"}', True
             ),
-            param(
-                '{"errorMessage": "has a message", "errorType": "has a type"}', True
-            ),
+            param('{"errorMessage": "has a message", "errorType": "has a type"}', True),
             param(
                 '{"error message": "has a message", "stack Trace": "has a stacktrace", "error Type": "has a type"}',
                 False,

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -99,6 +99,9 @@ class TestLambdaOutputParser(TestCase):
                 '{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type"}', True
             ),
             param(
+                '{"errorMessage": "has a message", "errorType": "has a type"}', True
+            ),
+            param(
                 '{"error message": "has a message", "stack Trace": "has a stacktrace", "error Type": "has a type"}',
                 False,
             ),


### PR DESCRIPTION
*Issue 1458:*

*Description of changes:* During `sam local start-api` we expect container to return response. We then parse this response with some caveat explained [here](https://github.com/awslabs/aws-sam-cli/blob/develop/samcli/local/services/base_local_service.py#L151-L155) and expect a particular set of keys. Due to recent changes in lambda one of the key was removed from the response. The key removed was `stackTrace`, we rely on this key to add `FunctionError` in our response to client. Since the key was removed we need to handle the scenario so that we don't loose the information of function error.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
