### PR TITLE
fix(debug): Add NODE_PATH env var when debugging Node10/12

### DIFF
--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -157,7 +157,9 @@ class LambdaDebugSettings:
                         ]
                     ),
                 ],
-                debug_env_vars={},
+                debug_env_vars={
+                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node10/node_modules:/var/runtime/node_modules"
+                },
             ),
             Runtime.nodejs12x.value: DebugSettings(
                 [
@@ -177,7 +179,9 @@ class LambdaDebugSettings:
                         ]
                     ),
                 ],
-                debug_env_vars={},
+                debug_env_vars={
+                    "NODE_PATH": "/opt/nodejs/node_modules:/opt/nodejs/node12/node_modules:/var/runtime/node_modules"
+                },
             ),
             Runtime.python27.value: DebugSettings(
                 ["/usr/bin/python2.7"] + debug_args_list + ["/var/runtime/awslambda/bootstrap.py"], debug_env_vars={}

--- a/tests/unit/lib/bootstrap/test_bootstrap.py
+++ b/tests/unit/lib/bootstrap/test_bootstrap.py
@@ -13,7 +13,7 @@ from samcli.lib.bootstrap.bootstrap import manage_stack, _create_or_get_stack, _
 
 class TestBootstrapManagedStack(TestCase):
     def _stubbed_cf_client(self):
-        cf = botocore.session.get_session().create_client("cloudformation")
+        cf = botocore.session.get_session().create_client("cloudformation", region_name="us-west-2")
         return [cf, Stubber(cf)]
 
     @patch("boto3.Session")


### PR DESCRIPTION
To support debugging for Nodejs10.x and Nodejs12.x, SAM CLI overrides
the entrypoint to the container. In newer runtimes (that are based
on the provided runtime), we overrided the bootstrap file which can
have side-effects. In the case of Nodejs, the bootstrap file adds
the NODE_PATH env var. Since we override this, NODE_PATH does not
get setup on the system and causes modules to not load (in some
cases, #1246). With #1634 (Java11 Debug support), we added a
capability to attach Env Vars into the container for debug mode
invokes. We will use this to apply the NODE_PATH onto the container
for debug.

I attempted to move all the args we pass into NODE_OPTIONS, which would
make Nodejs work like Java11 for debug. That is, allow us not to override
the entrypoint and still be able to apply the needed flags to the interpreted.
Unfortunately, NODE_OPTIONS restricts values that can be passed in,
which includes `--nolazy`. This flag is used to tell Nodejs to parse
all JavaScript files first instead of on first access. This ensures that
breakpoints to not "jump" to a different location in the file. It could
be worth exploring whether `--nolazy` is strictly required but for now
leaving as is.

*Issue #, if available:*

*Description of changes:*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
