### PR TITLE
fix(ci): force chocolatey-core.extension 1.3.3

### DIFF
--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -38,6 +38,7 @@ install:
 
     # Make sure the temp directory exists for Python to use.
     # Install python3.8
+    - "choco install chocolatey-core.extension --version 1.3.3 --force -y"
     - "choco install python3 --version 3.8.0"
     - "C:\\Python38\\python.exe -m pip freeze"
     - "refreshenv"

--- a/appveyor-windows-build-ruby.yml
+++ b/appveyor-windows-build-ruby.yml
@@ -55,6 +55,7 @@ install:
     - "pip install -e \".[dev]\""
 
     # setup Ruby
+    - "choco install chocolatey-core.extension --version 1.3.3 --force -y"
     - "choco install ruby --version 2.5.3.1 --force -y"
     - "refreshenv"
     - "ruby --version"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Ruby and Python installed through choco needs 1.3.3 or choco installs fail.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
