### PR TITLE
fix: change permissions and remove files on rmtree

### DIFF
--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -17,7 +17,7 @@ import click
 from samcli.cli.main import global_cfg
 from samcli.commands.exceptions import UserException, AppTemplateUpdateException
 from samcli.lib.utils import osutils
-from samcli.lib.utils.osutils import _rmtree_callback
+from samcli.lib.utils.osutils import rmtree_callback
 from samcli.local.common.runtime_template import RUNTIME_DEP_TEMPLATE_MAPPING
 
 LOG = logging.getLogger(__name__)
@@ -165,7 +165,7 @@ class InitTemplates:
     def _replace_app_templates(self, temp_path, dest_path):
         try:
             LOG.debug("Removing old templates from %s", str(dest_path))
-            shutil.rmtree(dest_path, onerror=_rmtree_callback)
+            shutil.rmtree(dest_path, onerror=rmtree_callback)
             LOG.debug("Copying templates from %s to %s", str(temp_path), str(dest_path))
             shutil.copytree(temp_path, dest_path, ignore=shutil.ignore_patterns("*.git"))
         except (OSError, shutil.Error):

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -17,6 +17,7 @@ import click
 from samcli.cli.main import global_cfg
 from samcli.commands.exceptions import UserException, AppTemplateUpdateException
 from samcli.lib.utils import osutils
+from samcli.lib.utils.osutils import _rmtree_callback
 from samcli.local.common.runtime_template import RUNTIME_DEP_TEMPLATE_MAPPING
 
 LOG = logging.getLogger(__name__)
@@ -164,7 +165,7 @@ class InitTemplates:
     def _replace_app_templates(self, temp_path, dest_path):
         try:
             LOG.debug("Removing old templates from %s", str(dest_path))
-            shutil.rmtree(dest_path)
+            shutil.rmtree(dest_path, onerror=_rmtree_callback)
             LOG.debug("Copying templates from %s to %s", str(temp_path), str(dest_path))
             shutil.copytree(temp_path, dest_path, ignore=shutil.ignore_patterns("*.git"))
         except (OSError, shutil.Error):

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -44,12 +44,20 @@ def mkdir_temp(mode=0o755, ignore_errors=False):
     finally:
         if temp_dir:
             if ignore_errors:
-                shutil.rmtree(temp_dir, False, _rmtree_callback)
+                shutil.rmtree(temp_dir, False, rmtree_callback)
             else:
                 shutil.rmtree(temp_dir)
 
 
-def _rmtree_callback(function, path, excinfo):
+def rmtree_callback(function, path, excinfo):
+    """
+    Callback function for shutil.rmtree to change permissions on the file path, so that
+    it's delete-able incase the file path is read-only.
+    :param function: platform and implementation dependent function.
+    :param path: argument to the function that caused it to fail.
+    :param excinfo: tuple returned by sys.exc_info()
+    :return:
+    """
     try:
         os.chmod(path=path, mode=stat.S_IWRITE)
         os.remove(path)

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -1,16 +1,13 @@
 """
 Common OS utilities
 """
-
-import sys
+import logging
 import os
 import shutil
+import stat
+import sys
 import tempfile
-import logging
-import contextlib
-
 from contextlib import contextmanager
-
 
 LOG = logging.getLogger(__name__)
 
@@ -53,7 +50,11 @@ def mkdir_temp(mode=0o755, ignore_errors=False):
 
 
 def _rmtree_callback(function, path, excinfo):
-    LOG.debug("rmtree failed in %s for %s, details: %s", function, path, excinfo)
+    try:
+        os.chmod(path=path, mode=stat.S_IWRITE)
+        os.remove(path)
+    except OSError:
+        LOG.debug("rmtree failed in %s for %s, details: %s", function, path, excinfo)
 
 
 def stdout():
@@ -88,7 +89,7 @@ def remove(path):
             pass
 
 
-@contextlib.contextmanager
+@contextmanager
 def tempfile_platform_independent():
     # NOTE(TheSriram): Setting delete=False is specific to windows.
     # https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile


### PR DESCRIPTION
### fix: change permissions and remove files on rmtree

Why is this change necessary?

* sam init clones from a git repository called aws-sam-cli-app-templates, but when attempting to reclone, removal of the old directory becomes problematic due to the read-only nature of the `.git` files that get downloaded and results in a traceback.

How does it address the issue?

* If a given file is not able to be deleted due to permission issues, write permissions are added to the file in question and deleted.

What side effects does this change have?

* None, the previous side-effects of leaving behind .git objects will be addressed.

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
