### PR TITLE
Build and Package once per CodeUri instead of once per resource

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -170,7 +170,6 @@ class ApplicationBuilder:
         str
             Path to the location where built artifacts are available
         """
-        # TODO: implement if code_dir already exists then reuse rather than rebuilding
 
         # Create the arguments to pass to the builder
         # Code is always relative to the given base directory.

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -175,7 +175,7 @@ def folder_checksum(folder_path):
             checksum = file_checksum(os.path.join(root, file_name))
             checksums.append(checksum)
 
-    folder_hash = hashlib.md5(json.dumps(checksums).encode('utf-8')).hexdigest()
+    folder_hash = hashlib.md5(json.dumps(checksums).encode("utf-8")).hexdigest()
 
     return folder_hash
 

--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -32,6 +32,28 @@ from samcli.commands.package.exceptions import NoSuchBucketError, BucketNotSpeci
 LOG = logging.getLogger(__name__)
 
 
+def file_checksum(file_name):
+
+    with open(file_name, "rb") as file_handle:
+        md5 = hashlib.md5()
+        # Read file in chunks of 4096 bytes
+        block_size = 4096
+
+        # Save current cursor position and reset cursor to start of file
+        curpos = file_handle.tell()
+        file_handle.seek(0)
+
+        buf = file_handle.read(block_size)
+        while buf:
+            md5.update(buf)
+            buf = file_handle.read(block_size)
+
+        # Restore file cursor's position
+        file_handle.seek(curpos)
+
+        return md5.hexdigest()
+
+
 class S3Uploader:
     """
     Class to upload objects to S3 bucket that use versioning. If bucket
@@ -119,7 +141,7 @@ class S3Uploader:
         # uploads of same object. Uploader will check if the file exists in S3
         # and re-upload only if necessary. So the template points to same file
         # in multiple places, this will upload only once
-        filemd5 = self.file_checksum(file_name)
+        filemd5 = file_checksum(file_name)
         remote_path = filemd5
         if extension:
             remote_path = remote_path + "." + extension
@@ -149,27 +171,6 @@ class S3Uploader:
         if not self.bucket_name:
             raise BucketNotSpecifiedError()
         return "s3://{0}/{1}".format(self.bucket_name, obj_path)
-
-    def file_checksum(self, file_name):
-
-        with open(file_name, "rb") as file_handle:
-            md5 = hashlib.md5()
-            # Read file in chunks of 4096 bytes
-            block_size = 4096
-
-            # Save current cursor position and reset cursor to start of file
-            curpos = file_handle.tell()
-            file_handle.seek(0)
-
-            buf = file_handle.read(block_size)
-            while buf:
-                md5.update(buf)
-                buf = file_handle.read(block_size)
-
-            # Restore file cursor's position
-            file_handle.seek(curpos)
-
-            return md5.hexdigest()
 
     def to_path_style_s3_url(self, key, version=None):
         """

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -4,6 +4,7 @@ import string
 import random
 import zipfile
 import unittest
+import shutil
 
 from contextlib import contextmanager, closing
 from unittest import mock
@@ -16,6 +17,7 @@ from samcli.lib.package.artifact_exporter import (
     is_local_file,
     is_local_folder,
     upload_local_artifacts,
+    folder_checksum,
     zip_folder,
     make_abs_path,
     make_zip,
@@ -334,6 +336,14 @@ class TestArtifactExporter(unittest.TestCase):
 
         zip_and_upload_mock.assert_not_called()
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+
+    def test_folder_checksum(self):
+
+        with self.make_temp_dir() as dirname:
+            with tempfile.NamedTemporaryFile(mode="wb", delete=False, dir=dirname) as f:
+                f.write(b"Hello World!")
+                f.seek(0)
+                self.assertEqual("039113daf7964d4d8df16b47829f6d0d", folder_checksum(dirname))
 
     @patch("samcli.lib.package.artifact_exporter.make_zip")
     def test_zip_folder(self, make_zip_mock):
@@ -1090,7 +1100,7 @@ class TestArtifactExporter(unittest.TestCase):
             yield filename
         finally:
             if filename:
-                os.rmdir(filename)
+                shutil.rmtree(filename)
 
     def example_yaml_template(self):
         return """

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -83,8 +83,11 @@ class TestArtifactExporter(unittest.TestCase):
         with patch("samcli.lib.package.artifact_exporter.upload_local_artifacts") as upload_local_artifacts_mock:
             for idx, test in enumerate(setup):
                 self._helper_verify_export_resources(
-                    test["class"], uploaded_s3_url, upload_local_artifacts_mock, test["expected_result"],
-                    assert_upload_called=(idx == 0)
+                    test["class"],
+                    uploaded_s3_url,
+                    upload_local_artifacts_mock,
+                    test["expected_result"],
+                    assert_upload_called=(idx == 0),
                 )
 
     def test_invalid_export_resource(self):

--- a/tests/unit/lib/package/test_s3_uploader.py
+++ b/tests/unit/lib/package/test_s3_uploader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from botocore.exceptions import ClientError
 
 from samcli.commands.package.exceptions import NoSuchBucketError, BucketNotSpecifiedError
-from samcli.lib.package.s3_uploader import S3Uploader
+from samcli.lib.package.s3_uploader import S3Uploader, file_checksum
 
 
 class TestS3Uploader(TestCase):
@@ -104,17 +104,10 @@ class TestS3Uploader(TestCase):
                 s3_uploader.upload(f.name, remote_path)
 
     def test_file_checksum(self):
-        s3_uploader = S3Uploader(
-            s3_client=self.s3,
-            bucket_name=self.bucket_name,
-            prefix=self.prefix,
-            kms_key_id=self.kms_key_id,
-            force_upload=self.force_upload,
-        )
         with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
             f.write(b"Hello World!")
             f.seek(0)
-            self.assertEqual("ed076287532e86365e841e92bfc50d8c", s3_uploader.file_checksum(f.name))
+            self.assertEqual("ed076287532e86365e841e92bfc50d8c", file_checksum(f.name))
 
     def test_path_style_s3_url(self):
         s3_uploader = S3Uploader(
@@ -171,5 +164,5 @@ class TestS3Uploader(TestCase):
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             s3_url = s3_uploader.upload_with_dedup(f.name, "zip")
             self.assertEqual(
-                s3_url, "s3://{0}/{1}/{2}.zip".format(self.bucket_name, self.prefix, s3_uploader.file_checksum(f.name))
+                s3_url, "s3://{0}/{1}/{2}.zip".format(self.bucket_name, self.prefix, file_checksum(f.name))
             )


### PR DESCRIPTION
*Description of changes:*

- Update `sam build` to cache the built directory for each unique CodeUri.  This will prevent unnecessary duplication of CodeUri build directories when multiple functions share the same CodeUri.
- Update `sam package` artifact exporter to use the folder checksum as the suffix of the package name rather than a UUID.  This will prevent changing the output template file when the application hasn't changed.  If the application or template has not changed then the output template file will contain the same updated paths as previous `sam package` outputs.
- Update `sam package` artifact exporter to cache the package generated for each property name/value combination.  This will prevent generating and uploading multiple copies of the same artifact to S3 when multiple serverless resources use the same path.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

This is a change to the internal process that happens in `sam build` and `sam package` in order to improve efficiency and to avoid redeploying applications that haven't changed.  I'm not sure what if any new documentation is required.  Please advise.

I have not been able to get integration tests running locally on my machine.  I'd be happy to work on those if I can get them running.  Can anyone help me with that?