### PR TITLE
[WIP] fix: change rest to numpy docstrings

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -22,10 +22,18 @@ LOG = logging.getLogger(__name__)
 
 
 class TomlProvider:
-    """
-    A parser for toml configuration files
-    :param cmd: sam command name as defined by click
-    :param section: section defined in the configuration file nested within `cmd`
+    """A parser for toml configuration files
+
+    Parameters
+    ----------
+    cmd :
+        sam command name as defined by click
+    section :
+        section defined in the configuration file nested within `cmd`
+
+    Returns
+    -------
+
     """
 
     def __init__(self, section=None):
@@ -81,22 +89,36 @@ class TomlProvider:
 
 
 def configuration_callback(cmd_name, option_name, config_env_name, saved_callback, provider, ctx, param, value):
-    """
-    Callback for reading the config file.
+    """Callback for reading the config file.
 
     Also takes care of calling user specified custom callback afterwards.
 
-    :param cmd_name: `sam` command name derived from click.
-    :param option_name: The name of the option. This is used for error messages.
-    :param config_env_name: `top` level section within configuration file
-    :param saved_callback: User-specified callback to be called later.
-    :param provider:  A callable that parses the configuration file and returns a dictionary
+    Parameters
+    ----------
+    cmd_name :
+        sam` command name derived from click.
+    option_name :
+        The name of the option. This is used for error messages.
+    config_env_name :
+        top` level section within configuration file
+    saved_callback :
+        User-specified callback to be called later.
+    provider :
+        A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
         `provider(file_path, config_env, cmd_name)`.
-    :param ctx: Click context
-    :param param: Click parameter
-    :param value: Specified value for config_env
-    :returns specified callback or the specified value for config_env.
+    ctx :
+        Click context
+    param :
+        Click parameter
+    value :
+        Specified value for config_env
+
+    Returns
+    -------
+    type
+        specified callback or the specified value for config_env.
+
     """
 
     # ctx, param and value are default arguments for click specified callbacks.
@@ -111,18 +133,28 @@ def configuration_callback(cmd_name, option_name, config_env_name, saved_callbac
 
 
 def get_ctx_defaults(cmd_name, provider, ctx, config_env_name):
-    """
-    Get the set of the parameters that are needed to be set into the click command.
+    """Get the set of the parameters that are needed to be set into the click command.
     This function also figures out the command name by looking up current click context's parent
     and constructing the parsed command name that is used in default configuration file.
     If a given cmd_name is start-api, the parsed name is "local_start_api".
     provider is called with `config_file`, `config_env_name` and `parsed_cmd_name`.
 
-    :param cmd_name: `sam` command name
-    :param provider: provider to be called for reading configuration file
-    :param ctx: Click context
-    :param config_env_name: config-env within configuration file
-    :return: dictionary of defaults for parameters
+    Parameters
+    ----------
+    cmd_name :
+        sam` command name
+    provider :
+        provider to be called for reading configuration file
+    ctx :
+        Click context
+    config_env_name :
+        config-env within configuration file
+
+    Returns
+    -------
+    type
+        dictionary of defaults for parameters
+
     """
 
     # `config_dir` will be a directory relative to SAM template, if it is available. If not it's relative to cwd
@@ -131,18 +163,12 @@ def get_ctx_defaults(cmd_name, provider, ctx, config_env_name):
 
 
 def configuration_option(*param_decls, **attrs):
-    """
-    Adds configuration file support to a click application.
+    """Adds configuration file support to a click application.
 
     NOTE: This decorator should be added to the top of parameter chain, right below click.command, before
           any options are declared.
 
     Example:
-        >>> @click.command("hello")
-            @configuration_option(provider=TomlProvider(section="parameters"))
-            @click.option('--name', type=click.String)
-            def hello(name):
-                print("Hello " + name)
 
     This will create an option of type `STRING` expecting the config_env in the
     configuration file, by default this config_env is `default`. When specified,
@@ -153,12 +179,31 @@ def configuration_option(*param_decls, **attrs):
 
     This decorator accepts the same arguments as `click.option`.
     In addition, the following keyword arguments are available:
-    :param cmd_name: The command name. Default: `ctx.info_name`
-    :param config_env_name: The config_env name. This is used to determine which part of the configuration
+
+    Parameters
+    ----------
+    cmd_name :
+        The command name. Default: `ctx.info_name`
+    config_env_name :
+        The config_env name. This is used to determine which part of the configuration
         needs to be read.
-    :param provider:         A callable that parses the configuration file and returns a dictionary
+    provider :
+        A callable that parses the configuration file and returns a dictionary
         of the configuration parameters. Will be called as
         `provider(file_path, config_env, cmd_name)
+    *param_decls :
+
+    **attrs :
+
+
+    Returns
+    -------
+
+    >>> @click.command("hello")
+            @configuration_option(provider=TomlProvider(section="parameters"))
+            @click.option('--name', type=click.String)
+            def hello(name):
+                print("Hello " + name)
     """
     param_decls = param_decls or ("--config-env",)
     option_name = param_decls[0]

--- a/samcli/cli/command.py
+++ b/samcli/cli/command.py
@@ -27,8 +27,7 @@ _SAM_CLI_COMMAND_PACKAGES = [
 
 
 class BaseCommand(click.MultiCommand):
-    """
-    Dynamically loads commands. It takes a list of names of Python packages representing the commands, loads
+    """Dynamically loads commands. It takes a list of names of Python packages representing the commands, loads
     these packages, and initializes them as Click commands. If a command "hello" is available in a Python package
     "foo.bar.hello", then this package name is passed to this class to load the command. This allows commands
     to be written as standalone packages that are dynamically initialized by the CLI.
@@ -45,6 +44,13 @@ class BaseCommand(click.MultiCommand):
 
     By convention, the name of last module in the package's name is the command's name. ie. A package of "foo.bar.baz"
     will produce a command name "baz".
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, *args, cmd_packages=None, **kwargs):
@@ -65,12 +71,19 @@ class BaseCommand(click.MultiCommand):
 
     @staticmethod
     def _set_commands(package_names):
-        """
-        Extract the command name from package name. Last part of the module path is the command
+        """Extract the command name from package name. Last part of the module path is the command
         ie. if path is foo.bar.baz, then "baz" is the command name.
 
-        :param package_names: List of package names
-        :return: Dictionary with command name as key and the package name as value.
+        Parameters
+        ----------
+        package_names :
+            List of package names
+
+        Returns
+        -------
+        type
+            Dictionary with command name as key and the package name as value.
+
         """
 
         commands = OrderedDict()
@@ -82,21 +95,36 @@ class BaseCommand(click.MultiCommand):
         return commands
 
     def list_commands(self, ctx):
-        """
-        Overrides a method from Click that returns a list of commands available in the CLI.
+        """Overrides a method from Click that returns a list of commands available in the CLI.
 
-        :param ctx: Click context
-        :return: List of commands available in the CLI
+        Parameters
+        ----------
+        ctx :
+            Click context
+
+        Returns
+        -------
+        type
+            List of commands available in the CLI
+
         """
         return list(self._commands.keys())
 
     def get_command(self, ctx, cmd_name):
-        """
-        Overrides method from ``click.MultiCommand`` that returns Click CLI object for given command name, if found.
+        """Overrides method from ``click.MultiCommand`` that returns Click CLI object for given command name, if found.
 
-        :param ctx: Click context
-        :param cmd_name: Top-level command name
-        :return: Click object representing the command
+        Parameters
+        ----------
+        ctx :
+            Click context
+        cmd_name :
+            Top-level command name
+
+        Returns
+        -------
+        type
+            Click object representing the command
+
         """
         if cmd_name not in self._commands:
             logger.error("Command %s not available", cmd_name)

--- a/samcli/cli/context.py
+++ b/samcli/cli/context.py
@@ -12,8 +12,7 @@ from samcli.commands.exceptions import CredentialsError
 
 
 class Context:
-    """
-    Top level context object for the CLI. Exposes common functionality required by a CLI, including logging,
+    """Top level context object for the CLI. Exposes common functionality required by a CLI, including logging,
     environment config parsing, debug logging etc.
 
     This object is passed by Click to every command that adds the proper annotation.
@@ -22,6 +21,13 @@ class Context:
 
     This class itself does not rely on how Click works. It is just a plain old Python class that holds common
     properties used by every CLI command.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self):
@@ -39,10 +45,16 @@ class Context:
 
     @debug.setter
     def debug(self, value):
-        """
-        Turn on debug logging if necessary.
+        """Turn on debug logging if necessary.
 
-        :param value: Value of debug flag
+        Parameters
+        ----------
+        value :
+            Value of debug flag
+
+        Returns
+        -------
+
         """
         self._debug = value
 
@@ -57,8 +69,16 @@ class Context:
 
     @region.setter
     def region(self, value):
-        """
-        Set AWS region
+        """Set AWS region
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
         """
         self._aws_region = value
         self._refresh_session()
@@ -69,30 +89,46 @@ class Context:
 
     @profile.setter
     def profile(self, value):
-        """
-        Set AWS profile for credential resolution
+        """Set AWS profile for credential resolution
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
         """
         self._aws_profile = value
         self._refresh_session()
 
     @property
     def session_id(self):
-        """
-        Returns the ID of this command session. This is a randomly generated UUIDv4 which will not change until the
+        """Returns the ID of this command session. This is a randomly generated UUIDv4 which will not change until the
         command terminates.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         return self._session_id
 
     @property
     def command_path(self):
-        """
-        Returns the full path of the command as invoked ex: "sam local generate-event s3 put". Wrapper to
+        """Returns the full path of the command as invoked ex: "sam local generate-event s3 put". Wrapper to
         https://click.palletsprojects.com/en/7.x/api/#click.Context.command_path
+
+        Parameters
+        ----------
 
         Returns
         -------
-        str
-            Full path of the command invoked
+
+
         """
 
         # Uses Click's Core Context. Note, this is different from this class, also confusingly named `Context`.
@@ -105,8 +141,7 @@ class Context:
 
     @staticmethod
     def get_current_context():
-        """
-        Get the current Context object from Click's context stacks. This method is safe to run within the
+        """Get the current Context object from Click's context stacks. This method is safe to run within the
         actual command's handler that has a ``@pass_context`` annotation. Outside of the handler, you run
         the risk of creating a new Context object which is entirely different from the Context object used by your
         command.
@@ -117,10 +152,14 @@ class Context:
                 # downstream method invoked as part of the handler.
                  this_context = Context.get_current_context()
                 assert ctx == this_context
-         Returns
+
+        Parameters
+        ----------
+
+        Returns
         -------
-        samcli.cli.context.Context
-            Instance of this object, if we are running in a Click command. None otherwise.
+
+
         """
 
         # Click has the concept of Context stacks. Think of them as linked list containing custom objects that are
@@ -137,10 +176,16 @@ class Context:
         return None
 
     def _refresh_session(self):
-        """
-        Update boto3's default session by creating a new session based on values set in the context. Some properties of
+        """Update boto3's default session by creating a new session based on values set in the context. Some properties of
         the Boto3's session object are read-only. Therefore when Click parses new AWS session related properties (like
         region & profile), it will call this method to create a new session with latest values for these properties.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         try:
             boto3.setup_default_session(region_name=self._aws_region, profile_name=self._aws_profile)
@@ -149,8 +194,7 @@ class Context:
 
 
 def get_cmd_names(cmd_name, ctx):
-    """
-    Given the click core context, return a list representing all the subcommands passed to the CLI
+    """Given the click core context, return a list representing all the subcommands passed to the CLI
 
     Parameters
     ----------
@@ -158,10 +202,10 @@ def get_cmd_names(cmd_name, ctx):
 
     ctx : click.Context
 
+
     Returns
     -------
-    list(str)
-        List containing subcommand names. Ex: ["local", "start-api"]
+
 
     """
     if not ctx:

--- a/samcli/cli/global_config.py
+++ b/samcli/cli/global_config.py
@@ -19,12 +19,18 @@ TELEMETRY_ENABLED_KEY = "telemetryEnabled"
 
 
 class GlobalConfig:
-    """
-    Contains helper methods for global configuration files and values. Handles
+    """Contains helper methods for global configuration files and values. Handles
     configuration file creation, updates, and fetching in a platform-neutral way.
 
     Generally uses '~/.aws-sam/' or 'C:\\Users\\<user>\\AppData\\Roaming\\AWS SAM' as
     the base directory, depending on platform.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, config_dir=None, installation_id=None, telemetry_enabled=None):
@@ -48,13 +54,17 @@ class GlobalConfig:
 
     @property
     def installation_id(self):
-        """
-        Returns the installation UUID for this AWS SAM CLI installation. If the
+        """Returns the installation UUID for this AWS SAM CLI installation. If the
         installation id has not yet been set, it will be set before returning.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
 
         Examples
         --------
-
         >>> gc = GlobalConfig()
         >>> gc.installation_id
         "7b7d4db7-2f54-45ba-bf2f-a2cbc9e74a34"
@@ -62,10 +72,6 @@ class GlobalConfig:
         >>> gc = GlobalConfig()
         >>> gc.installation_id
         None
-
-        Returns
-        -------
-        A string containing the installation UUID, or None in case of an error.
         """
         if self._installation_id:
             return self._installation_id
@@ -77,25 +83,24 @@ class GlobalConfig:
 
     @property
     def telemetry_enabled(self):
-        """
-        Check if telemetry is enabled for this installation. Default value of
+        """Check if telemetry is enabled for this installation. Default value of
         False. It first tries to get value from SAM_CLI_TELEMETRY environment variable. If its not set,
         then it fetches the value from config file.
 
         To enable telemetry, set SAM_CLI_TELEMETRY environment variable equal to integer 1 or string '1'.
         All other values including words like 'True', 'true', 'false', 'False', 'abcd' etc will disable Telemetry
 
-        Examples
-        --------
-
-        >>> gc = GlobalConfig()
-        >>> gc.telemetry_enabled
-        True
+        Parameters
+        ----------
 
         Returns
         -------
-        Boolean flag value. True if telemetry is enabled for this installation,
-        False otherwise.
+
+        Examples
+        --------
+        >>> gc = GlobalConfig()
+        >>> gc.telemetry_enabled
+        True
         """
         if self._telemetry_enabled is not None:
             return self._telemetry_enabled
@@ -114,8 +119,15 @@ class GlobalConfig:
 
     @telemetry_enabled.setter
     def telemetry_enabled(self, value):
-        """
-        Sets the telemetry_enabled flag to the provided boolean value.
+        """Sets the telemetry_enabled flag to the provided boolean value.
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
 
         Examples
         --------
@@ -125,14 +137,6 @@ class GlobalConfig:
         >>> gc.telemetry_enabled = True
         >>> gc.telemetry_enabled
         True
-
-        Raises
-        ------
-        IOError
-            If there are errors opening or writing to the global config file.
-
-        JSONDecodeError
-            If the config file exists, and is not valid JSON.
         """
         self._set_value("telemetryEnabled", value)
         self._telemetry_enabled = value
@@ -160,9 +164,15 @@ class GlobalConfig:
             return self._set_json_cfg(cfg_path, key, value, json_body)
 
     def _create_dir(self):
-        """
-        Creates configuration directory if it does not already exist, otherwise does nothing.
+        """Creates configuration directory if it does not already exist, otherwise does nothing.
         May raise an OSError if we do not have permissions to create the directory.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
@@ -172,14 +182,22 @@ class GlobalConfig:
         return filepath
 
     def _get_or_set_uuid(self, key):
-        """
-        Special logic method for when we want a UUID to always be present, this
+        """Special logic method for when we want a UUID to always be present, this
         method behaves as a getter with side effects. Essentially, if the value
         is not present, we will set it with a generated UUID.
 
         If we have multiple such values in the future, a possible refactor is
         to just be _get_or_set_value, where we also take a default value as a
         parameter.
+
+        Parameters
+        ----------
+        key :
+
+
+        Returns
+        -------
+
         """
         cfg_value = self._get_value(key)
         if cfg_value is not None:
@@ -187,11 +205,25 @@ class GlobalConfig:
         return self._set_value(key, str(uuid.uuid4()))
 
     def _set_json_cfg(self, filepath, key, value, json_body=None):
-        """
-        Special logic method to add a value to a JSON configuration file. This
+        """Special logic method to add a value to a JSON configuration file. This
         method will write a new version of the file in question, so it will
         either write a new file with only the first config value, or if a JSON
         body is provided, it will upsert starting from that JSON body.
+
+        Parameters
+        ----------
+        filepath :
+
+        key :
+
+        value :
+
+        json_body :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         json_body = json_body or {}
         json_body[key] = value

--- a/samcli/cli/main.py
+++ b/samcli/cli/main.py
@@ -25,18 +25,34 @@ global_cfg = GlobalConfig()
 
 
 def common_options(f):
-    """
-    Common CLI options used by all commands. Ex: --debug
-    :param f: Callback function passed by Click
-    :return: Callback function
+    """Common CLI options used by all commands. Ex: --debug
+
+    Parameters
+    ----------
+    f :
+        Callback function passed by Click
+
+    Returns
+    -------
+    type
+        Callback function
+
     """
     f = debug_option(f)
     return f
 
 
 def aws_creds_options(f):
-    """
-    Common CLI options necessary to interact with AWS services
+    """Common CLI options necessary to interact with AWS services
+
+    Parameters
+    ----------
+    f :
+
+
+    Returns
+    -------
+
     """
     f = region_option(f)
     f = profile_option(f)
@@ -70,13 +86,21 @@ TELEMETRY_PROMPT = """
 @click.option("--info", is_flag=True, is_eager=True, callback=print_info, expose_value=False)
 @pass_context
 def cli(ctx):
-    """
-    AWS Serverless Application Model (SAM) CLI
+    """AWS Serverless Application Model (SAM) CLI
 
     The AWS Serverless Application Model extends AWS CloudFormation to provide a simplified way of defining the
     Amazon API Gateway APIs, AWS Lambda functions, and Amazon DynamoDB tables needed by your serverless application.
     You can find more in-depth guide about the SAM specification here:
     https://github.com/awslabs/serverless-application-model.
+
+    Parameters
+    ----------
+    ctx :
+
+
+    Returns
+    -------
+
     """
     if global_cfg.telemetry_enabled is None:
         enabled = True

--- a/samcli/cli/options.py
+++ b/samcli/cli/options.py
@@ -9,10 +9,16 @@ from .context import Context
 
 
 def debug_option(f):
-    """
-    Configures --debug option for CLI
+    """Configures --debug option for CLI
 
-    :param f: Callback Function to be passed to Click
+    Parameters
+    ----------
+    f :
+        Callback Function to be passed to Click
+
+    Returns
+    -------
+
     """
 
     def callback(ctx, param, value):
@@ -31,10 +37,16 @@ def debug_option(f):
 
 
 def region_option(f):
-    """
-    Configures --region option for CLI
+    """Configures --region option for CLI
 
-    :param f: Callback Function to be passed to Click
+    Parameters
+    ----------
+    f :
+        Callback Function to be passed to Click
+
+    Returns
+    -------
+
     """
 
     def callback(ctx, param, value):
@@ -48,10 +60,16 @@ def region_option(f):
 
 
 def profile_option(f):
-    """
-    Configures --profile option for CLI
+    """Configures --profile option for CLI
 
-    :param f: Callback Function to be passed to Click
+    Parameters
+    ----------
+    f :
+        Callback Function to be passed to Click
+
+    Returns
+    -------
+
     """
 
     def callback(ctx, param, value):

--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -21,10 +21,7 @@ VALUE_REGEX_COMMA_DELIM = _value_regex(",")
 
 
 class CfnParameterOverridesType(click.ParamType):
-    """
-    Custom Click options type to accept values for CloudFormation template parameters. You can pass values for
-    parameters as "ParameterKey=KeyPairName,ParameterValue=MyKey ParameterKey=InstanceType,ParameterValue=t1.micro"
-    """
+    """Custom Click options type to accept values for CloudFormation template parameters. You can pass values for"""
 
     __EXAMPLE_1 = "ParameterKey=KeyPairName,ParameterValue=MyKey ParameterKey=InstanceType,ParameterValue=t1.micro"
     __EXAMPLE_2 = "KeyPairName=MyKey InstanceType=t1.micro"
@@ -90,14 +87,6 @@ class CfnParameterOverridesType(click.ParamType):
         Removes wrapping double quotes and any '\ ' characters. They are usually added to preserve spaces when passing
         value thru shell.
 
-        Examples
-        --------
-        >>> _unquote('val\ ue')
-        value
-
-        >>> _unquote("hel\ lo")
-        hello
-
         Parameters
         ----------
         value : str
@@ -105,7 +94,14 @@ class CfnParameterOverridesType(click.ParamType):
 
         Returns
         -------
-        Unquoted string
+
+        Examples
+        --------
+        >>> _unquote('val\ ue')
+        value
+
+        >>> _unquote("hel\ lo")
+        hello
         """
         if value and (value[0] == value[-1] == '"'):
             # Remove quotes only if the string is wrapped in quotes
@@ -115,9 +111,15 @@ class CfnParameterOverridesType(click.ParamType):
 
 
 class CfnMetadataType(click.ParamType):
-    """
-    Custom Click options type to accept values for metadata parameters.
+    """Custom Click options type to accept values for metadata parameters.
     metadata parameters can be of the type KeyName1=string,KeyName2=string or {"string":"string"}
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     _EXAMPLE = 'KeyName1=string,KeyName2=string or {"string":"string"}'
@@ -161,9 +163,15 @@ class CfnMetadataType(click.ParamType):
 
 
 class CfnTags(click.ParamType):
-    """
-    Custom Click options type to accept values for tag parameters.
+    """Custom Click options type to accept values for tag parameters.
     tag parameters can be of the type KeyName1=string KeyName2=string
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     _EXAMPLE = "KeyName1=string KeyName2=string"

--- a/samcli/commands/_utils/custom_options/option_nargs.py
+++ b/samcli/commands/_utils/custom_options/option_nargs.py
@@ -6,9 +6,15 @@ import click
 
 
 class OptionNargs(click.Option):
-    """
-    A custom option class that allows parsing for multiple arguments
+    """A custom option class that allows parsing for multiple arguments
     for an option, when the number of arguments for an option are unknown.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, *args, **kwargs):

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -20,15 +20,26 @@ LOG = logging.getLogger(__name__)
 
 
 def get_or_default_template_file_name(ctx, param, provided_value, include_build):
-    """
-    Default value for the template file name option is more complex than what Click can handle.
+    """Default value for the template file name option is more complex than what Click can handle.
     This method either returns user provided file name or one of the two default options (template.yaml/template.yml)
     depending on the file that exists
 
-    :param ctx: Click Context
-    :param param: Param name
-    :param provided_value: Value provided by Click. It could either be the default value or provided by user.
-    :return: Actual value to be used in the CLI
+    Parameters
+    ----------
+    ctx :
+        Click Context
+    param :
+        Param name
+    provided_value :
+        Value provided by Click. It could either be the default value or provided by user.
+    include_build :
+
+
+    Returns
+    -------
+    type
+        Actual value to be used in the CLI
+
     """
 
     original_template_path = os.path.abspath(provided_value)
@@ -58,12 +69,22 @@ def get_or_default_template_file_name(ctx, param, provided_value, include_build)
 
 
 def guided_deploy_stack_name(ctx, param, provided_value):
-    """
-    Provide a default value for stack name if invoked with a guided deploy.
-    :param ctx: Click Context
-    :param param: Param name
-    :param provided_value: Value provided by Click, it would be the value provided by the user.
-    :return: Actual value to be used in the CLI
+    """Provide a default value for stack name if invoked with a guided deploy.
+
+    Parameters
+    ----------
+    ctx :
+        Click Context
+    param :
+        Param name
+    provided_value :
+        Value provided by Click, it would be the value provided by the user.
+
+    Returns
+    -------
+    type
+        Actual value to be used in the CLI
+
     """
 
     guided = ctx.params.get("guided", False) or ctx.params.get("g", False)
@@ -80,28 +101,50 @@ def guided_deploy_stack_name(ctx, param, provided_value):
 
 
 def template_common_option(f):
-    """
-    Common ClI option for template
+    """Common ClI option for template
 
-    :param f: Callback passed by Click
-    :return: Callback
+    Parameters
+    ----------
+    f :
+        Callback passed by Click
+
+    Returns
+    -------
+    type
+        Callback
+
     """
     return template_click_option()(f)
 
 
 def template_option_without_build(f):
-    """
-    Common ClI option for template
+    """Common ClI option for template
 
-    :param f: Callback passed by Click
-    :return: Callback
+    Parameters
+    ----------
+    f :
+        Callback passed by Click
+
+    Returns
+    -------
+    type
+        Callback
+
     """
     return template_click_option(include_build=False)(f)
 
 
 def template_click_option(include_build=True):
-    """
-    Click Option for template option
+    """Click Option for template option
+
+    Parameters
+    ----------
+    include_build :
+         (Default value = True)
+
+    Returns
+    -------
+
     """
     return click.option(
         "--template-file",

--- a/samcli/commands/_utils/resources.py
+++ b/samcli/commands/_utils/resources.py
@@ -37,9 +37,14 @@ RESOURCES_WITH_LOCAL_PATHS = {
 
 
 def resources_generator():
-    """
-    Generator to yield set of resources and their locations that are supported for package operations
-    :return:
+    """Generator to yield set of resources and their locations that are supported for package operations
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     for resource, locations in dict({**METADATA_WITH_LOCAL_PATHS, **RESOURCES_WITH_LOCAL_PATHS}).items():
         for location in locations:

--- a/samcli/commands/_utils/table_print.py
+++ b/samcli/commands/_utils/table_print.py
@@ -11,12 +11,24 @@ import click
 def pprint_column_names(format_string, format_kwargs, margin=None, table_header=None, color="yellow"):
     """
 
-    :param format_string: format string to be used that has the strings, minimum width to be replaced
-    :param format_kwargs: dictionary that is supplied to the format_string to format the string
-    :param margin: margin that is to be reduced from column width for columnar text.
-    :param table_header: Supplied table header
-    :param color: color supplied for table headers and column names.
-    :return: boilerplate table string
+    Parameters
+    ----------
+    format_string :
+        format string to be used that has the strings, minimum width to be replaced
+    format_kwargs :
+        dictionary that is supplied to the format_string to format the string
+    margin :
+        margin that is to be reduced from column width for columnar text. (Default value = None)
+    table_header :
+        Supplied table header (Default value = None)
+    color :
+        color supplied for table headers and column names. (Default value = "yellow")
+
+    Returns
+    -------
+    type
+        boilerplate table string
+
     """
 
     min_width = 100
@@ -76,32 +88,50 @@ def pprint_column_names(format_string, format_kwargs, margin=None, table_header=
 
 
 def wrapped_text_generator(texts, width, margin):
-    """
+    """Return a generator where the contents are wrapped text to a specified width.
 
-    Return a generator where the contents are wrapped text to a specified width.
+    Parameters
+    ----------
+    texts :
+        list of text that needs to be wrapped at specified width
+    width :
+        width of the text to be wrapped
+    margin :
+        margin to be reduced from width for cleaner UX
 
-    :param texts: list of text that needs to be wrapped at specified width
-    :param width: width of the text to be wrapped
-    :param margin: margin to be reduced from width for cleaner UX
-    :return: generator of wrapped text
+    Returns
+    -------
+    generator
+        generator of wrapped text
+
     """
     for text in texts:
         yield textwrap.wrap(text, width=width - margin)
 
 
 def pprint_columns(columns, width, margin, format_string, format_args, columns_dict, color="yellow"):
-    """
+    """Print columns based on list of columnar text, associated formatting string and associated format arguments.
 
-    Print columns based on list of columnar text, associated formatting string and associated format arguments.
+    Parameters
+    ----------
+    columns :
+        list of columnnar text that go into columns as specified by the format_string
+    width :
+        width of the text to be wrapped
+    margin :
+        margin to be reduced from width for cleaner UX
+    format_string :
+        A format string that has both width and text specifiers set.
+    format_args :
+        list of offset specifiers
+    columns_dict :
+        arguments dictionary that have dummy values per column
+    color :
+        color supplied for rows within the table. (Default value = "yellow")
 
-    :param columns: list of columnnar text that go into columns as specified by the format_string
-    :param width: width of the text to be wrapped
-    :param margin: margin to be reduced from width for cleaner UX
-    :param format_string: A format string that has both width and text specifiers set.
-    :param format_args: list of offset specifiers
-    :param columns_dict: arguments dictionary that have dummy values per column
-    :param color: color supplied for rows within the table.
-    :return:
+    Returns
+    -------
+
     """
     for columns_text in zip_longest(*wrapped_text_generator(columns, width, margin), fillvalue=""):
         counter = count()

--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -20,8 +20,7 @@ class TemplateFailedParsingException(UserException):
 
 
 def get_template_data(template_file):
-    """
-    Read the template file, parse it as JSON/YAML and return the template as a dictionary.
+    """Read the template file, parse it as JSON/YAML and return the template as a dictionary.
 
     Parameters
     ----------
@@ -30,7 +29,8 @@ def get_template_data(template_file):
 
     Returns
     -------
-    Template data as a dictionary
+
+
     """
 
     if not pathlib.Path(template_file).exists():
@@ -44,8 +44,7 @@ def get_template_data(template_file):
 
 
 def move_template(src_template_path, dest_template_path, template_dict):
-    """
-    Move the SAM/CloudFormation template from ``src_template_path`` to ``dest_template_path``. For convenience, this
+    """Move the SAM/CloudFormation template from ``src_template_path`` to ``dest_template_path``. For convenience, this
     method accepts a dictionary of template data ``template_dict`` that will be written to the destination instead of
     reading from the source file.
 
@@ -61,14 +60,17 @@ def move_template(src_template_path, dest_template_path, template_dict):
 
     Parameters
     ----------
-    src_template_path : str
-        Path to the original location of the template
+    src_template_path :
 
-    dest_template_path : str
-        Path to the destination location where updated template should be written to
+    dest_template_path :
 
-    template_dict : dict
-        Dictionary containing template contents. This dictionary will be updated & written to ``dest`` location.
+    template_dict :
+
+
+    Returns
+    -------
+
+
     """
 
     original_root = os.path.dirname(src_template_path)
@@ -83,8 +85,7 @@ def move_template(src_template_path, dest_template_path, template_dict):
 
 
 def _update_relative_paths(template_dict, original_root, new_root):
-    """
-    SAM/CloudFormation template can contain certain properties whose value is a relative path to a local file/folder.
+    """SAM/CloudFormation template can contain certain properties whose value is a relative path to a local file/folder.
     This path is usually relative to the template's location. If the template is being moved from original location
     ``original_root`` to new location ``new_root``, use this method to update these paths to be
     relative to ``new_root``.
@@ -97,22 +98,19 @@ def _update_relative_paths(template_dict, original_root, new_root):
 
     If a property is either an absolute path or a S3 URI, this method will not update them.
 
-
     Parameters
     ----------
     template_dict : dict
         Dictionary containing template contents. This dictionary will be updated & written to ``dest`` location.
-
     original_root : str
         Path to the directory where all paths were originally set relative to. This is usually the directory
         containing the template originally
-
     new_root : str
         Path to the new directory that all paths set relative to after this method completes.
 
     Returns
     -------
-    Updated dictionary
+
 
     """
 
@@ -158,9 +156,21 @@ def _update_relative_paths(template_dict, original_root, new_root):
 
 
 def _update_aws_include_relative_path(template_dict, original_root, new_root):
-    """
-    Update relative paths in "AWS::Include" directive. This directive can be present at any part of the template,
+    """Update relative paths in "AWS::Include" directive. This directive can be present at any part of the template,
     and not just within resources.
+
+    Parameters
+    ----------
+    template_dict :
+
+    original_root :
+
+    new_root :
+
+
+    Returns
+    -------
+
     """
 
     for key, val in template_dict.items():
@@ -186,23 +196,30 @@ def _update_aws_include_relative_path(template_dict, original_root, new_root):
 
 
 def _resolve_relative_to(path, original_root, new_root):
-    """
-    If the given ``path`` is a relative path, then assume it is relative to ``original_root``. This method will
+    """If the given ``path`` is a relative path, then assume it is relative to ``original_root``. This method will
     update the path to be resolve it relative to ``new_root`` and return.
+
+    Parameters
+    ----------
+    path :
+
+    original_root :
+
+    new_root :
+
+
+    Returns
+    -------
 
     Examples
     -------
         # Assume a file called template.txt at location /tmp/original/root/template.txt expressed as relative path
         # We are trying to update it to be relative to /tmp/new/root instead of the /tmp/original/root
-        >>> result = _resolve_relative_to("template.txt",  \
+    >>> result = _resolve_relative_to("template.txt",  \
                                           "/tmp/original/root", \
                                           "/tmp/new/root")
         >>> result
         ../../original/root/template.txt
-
-    Returns
-    -------
-    Updated path if the given path is a relative path. None, if the path is not a relative path.
     """
 
     if not isinstance(path, str) or path.startswith("s3://") or os.path.isabs(path):
@@ -216,8 +233,7 @@ def _resolve_relative_to(path, original_root, new_root):
 
 
 def get_template_parameters(template_file):
-    """
-    Get Parameters from a template file.
+    """Get Parameters from a template file.
 
     Parameters
     ----------
@@ -226,7 +242,8 @@ def get_template_parameters(template_file):
 
     Returns
     -------
-    Template Parameters as a dictionary
+
+
     """
     template_dict = get_template_data(template_file=template_file)
     return template_dict.get("Parameters", dict())

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -141,8 +141,38 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
     parameter_overrides,
     mode,
 ):
-    """
-    Implementation of the ``cli`` method
+    """Implementation of the ``cli`` method
+
+    Parameters
+    ----------
+    # pylint: disable :
+         (Default value = too-many-locals)
+    too-many-statementsfunction_identifier :
+
+    template :
+
+    base_dir :
+
+    build_dir :
+
+    clean :
+
+    use_container :
+
+    manifest_path :
+
+    docker_network :
+
+    skip_pull_image :
+
+    parameter_overrides :
+
+    mode :
+
+
+    Returns
+    -------
+
     """
 
     from samcli.commands.exceptions import UserException

--- a/samcli/commands/build/exceptions.py
+++ b/samcli/commands/build/exceptions.py
@@ -4,6 +4,4 @@ from samcli.commands.exceptions import UserException
 
 
 class InvalidBuildDirException(UserException):
-    """
-    Value provided to --build-dir is invalid
-    """
+    """Value provided to --build-dir is invalid"""

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -176,15 +176,22 @@ class DeployContext:
             click.echo(str(ex))
 
     def merge_parameters(self, template_dict, parameter_overrides):
-        """
-        CloudFormation CreateChangeset requires a value for every parameter
+        """CloudFormation CreateChangeset requires a value for every parameter
         from the template, either specifying a new value or use previous value.
         For convenience, this method will accept new parameter values and
         generates a dict of all parameters in a format that ChangeSet API
         will accept
 
-        :param parameter_overrides:
-        :return:
+        Parameters
+        ----------
+        parameter_overrides :
+            return:
+        template_dict :
+
+
+        Returns
+        -------
+
         """
         parameter_values = []
 

--- a/samcli/commands/exceptions.py
+++ b/samcli/commands/exceptions.py
@@ -6,15 +6,19 @@ import click
 
 
 class ConfigException(click.ClickException):
-    """
-    Exception class when configuration file fails checks.
-    """
+    """ """
 
 
 class UserException(click.ClickException):
-    """
-    Base class for all exceptions that need to be surfaced to the user. Typically, we will display the exception
+    """Base class for all exceptions that need to be surfaced to the user. Typically, we will display the exception
     message to user and return the error code from CLI process
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     exit_code = 1
@@ -26,24 +30,16 @@ class UserException(click.ClickException):
 
 
 class CredentialsError(UserException):
-    """
-    Exception class when credentials that have been passed are invalid.
-    """
+    """ """
 
 
 class SchemasApiException(UserException):
-    """
-    Exception class to wrap all Schemas APIs exceptions.
-    """
+    """ """
 
 
 class RegionError(UserException):
-    """
-    Exception class when no valid region is passed to a client.
-    """
+    """ """
 
 
 class AppTemplateUpdateException(UserException):
-    """
-    Exception class when updates to app templates for init enters an unstable state.
-    """
+    """ """

--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -210,13 +210,21 @@ class InitTemplates:
         raise OSError("Cannot find git, was looking at executables: {}".format(options))
 
     def is_dynamic_schemas_template(self, app_template, runtime, dependency_manager):
-        """
-        Check if provided template is dynamic template e.g: AWS Schemas template.
+        """Check if provided template is dynamic template e.g: AWS Schemas template.
         Currently dynamic templates require different handling e.g: for schema download and merge schema code in sam-app.
-        :param app_template:
-        :param runtime:
-        :param dependency_manager:
-        :return:
+
+        Parameters
+        ----------
+        app_template :
+            param runtime:
+        dependency_manager :
+            return:
+        runtime :
+
+
+        Returns
+        -------
+
         """
         options = self.init_options(runtime, dependency_manager)
         for option in options:

--- a/samcli/commands/init/interactive_event_bridge_flow.py
+++ b/samcli/commands/init/interactive_event_bridge_flow.py
@@ -22,10 +22,16 @@ from samcli.lib.schemas.schemas_constants import (
 
 
 def get_schema_template_details(schemas_api_caller):
-    """
-    Calls schemas APIs to fetch available selection and returns schema details based on user selection.
-    :param schemas_api_caller:
-    :return:
+    """Calls schemas APIs to fetch available selection and returns schema details based on user selection.
+
+    Parameters
+    ----------
+    schemas_api_caller :
+        return:
+
+    Returns
+    -------
+
     """
     registry_name = _get_registry_cli_choice(schemas_api_caller)
     schema_full_name = _get_schema_cli_choice(schemas_api_caller, registry_name)
@@ -43,7 +49,17 @@ def get_schema_template_details(schemas_api_caller):
 
 
 def _get_registry_cli_choice(schemas_api_caller):
-    """ Returns registry choice if one registry is present otherwise prompt for selection """
+    """Returns registry choice if one registry is present otherwise prompt for selection
+
+    Parameters
+    ----------
+    schemas_api_caller :
+
+
+    Returns
+    -------
+
+    """
     registries = _fetch_available_registries(schemas_api_caller, dict(), None)
     registry_pages = registries["registry_pages"]
     # If only one registry don't prompt for choice
@@ -87,7 +103,19 @@ def _prompt_for_registry_choice(
 
 
 def _get_schema_cli_choice(schemas_api_caller, registry_name):
-    """ Returns registry registry choice if one registry is present otherwise prompt for  selection """
+    """Returns registry registry choice if one registry is present otherwise prompt for  selection
+
+    Parameters
+    ----------
+    schemas_api_caller :
+
+    registry_name :
+
+
+    Returns
+    -------
+
+    """
     schemas = _fetch_available_schemas(schemas_api_caller, registry_name, dict(), None)
     schema_pages = schemas["schema_pages"]
     # If only one schema don't prompt for choice
@@ -131,7 +159,23 @@ def _prompt_for_schemas_choice(
 
 
 def _fetch_available_schemas(schemas_api_caller, registry_name, schema_pages, next_token):
-    """ calls schemas api fetch schemas for given registry. Two CLI pages are fetched at a time."""
+    """calls schemas api fetch schemas for given registry. Two CLI pages are fetched at a time.
+
+    Parameters
+    ----------
+    schemas_api_caller :
+
+    registry_name :
+
+    schema_pages :
+
+    next_token :
+
+
+    Returns
+    -------
+
+    """
     list_schemas_response = schemas_api_caller.list_schemas(registry_name, next_token, PAGE_LIMIT)
     schemas = list_schemas_response["schemas"]
 
@@ -144,7 +188,21 @@ def _fetch_available_schemas(schemas_api_caller, registry_name, schema_pages, ne
 
 
 def _fetch_available_registries(schemas_api_caller, registry_pages, next_token):
-    """ calls schemas api to fetch registries. Two CLI pages are fetched at a time. """
+    """calls schemas api to fetch registries. Two CLI pages are fetched at a time.
+
+    Parameters
+    ----------
+    schemas_api_caller :
+
+    registry_pages :
+
+    next_token :
+
+
+    Returns
+    -------
+
+    """
     list_registries_response = schemas_api_caller.list_registries(next_token, PAGE_LIMIT)
     registries = list_registries_response["registries"]
 
@@ -160,8 +218,20 @@ def _fetch_available_registries(schemas_api_caller, registry_pages, next_token):
 
 
 def _construct_cli_page(items, item_per_page):
-    """ Responsible for splitting items into CLI pages. Currently CLI pages are list of dictionary [0:{0:s1, 1:s2: 3:s3}, 1: {4:s4, 5:s5: 6:s6}]
-     We maintain the page detail and item index details. """
+    """Responsible for splitting items into CLI pages. Currently CLI pages are list of dictionary [0:{0:s1, 1:s2: 3:s3}, 1: {4:s4, 5:s5: 6:s6}]
+     We maintain the page detail and item index details.
+
+    Parameters
+    ----------
+    items :
+
+    item_per_page :
+
+
+    Returns
+    -------
+
+    """
     pages = [
         items[i * item_per_page : (i + 1) * item_per_page]
         for i in range((len(items) + item_per_page - 1) // item_per_page)
@@ -176,7 +246,17 @@ def _construct_cli_page(items, item_per_page):
 
 
 def get_schemas_template_parameter(schema_template_details):
-    """ Schemas cookiecutter template parameter mapping """
+    """Schemas cookiecutter template parameter mapping
+
+    Parameters
+    ----------
+    schema_template_details :
+
+
+    Returns
+    -------
+
+    """
     return {
         SCHEMAS_REGISTRY: schema_template_details["registry_name"],
         SCHEMA_NAME: schema_template_details["schema_root_name"],

--- a/samcli/commands/local/cli_common/invoke_context.py
+++ b/samcli/commands/local/cli_common/invoke_context.py
@@ -21,8 +21,7 @@ from .user_exceptions import InvokeContextException, DebugContextException
 
 
 class InvokeContext:
-    """
-    Sets up a context to invoke Lambda functions locally by parsing all command line arguments necessary for the
+    """Sets up a context to invoke Lambda functions locally by parsing all command line arguments necessary for the
     invoke.
 
     ``start-api`` command will also use this class to read and parse invoke related CLI arguments and setup the
@@ -34,6 +33,13 @@ class InvokeContext:
             context.local_lambda_runner.invoke(...)
 
     This class sets up some resources that need to be cleaned up after the context object is used.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(
@@ -149,12 +155,22 @@ class InvokeContext:
 
     @property
     def function_name(self):
-        """
-        Returns name of the function to invoke. If no function identifier is provided, this method will return name of
+        """Returns name of the function to invoke. If no function identifier is provided, this method will return name of
         the only function from the template
 
         :return string: Name of the function
-        :raises InvokeContextException: If function identifier is not provided
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
+        Raises
+        ------
+        InvokeContextException
+            If function identifier is not provided
+
         """
         if self._function_identifier:
             return self._function_identifier
@@ -177,11 +193,17 @@ class InvokeContext:
 
     @property
     def local_lambda_runner(self):
-        """
-        Returns an instance of the runner capable of running Lambda functions locally
+        """Returns an instance of the runner capable of running Lambda functions locally
 
         :return samcli.commands.local.lib.local_lambda.LocalLambdaRunner: Runner configured to run Lambda functions
             locally
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         layer_downloader = LayerDownloader(self._layer_cache_basedir, self.get_cwd())
@@ -200,47 +222,45 @@ class InvokeContext:
 
     @property
     def stdout(self):
-        """
-        Returns stream writer for stdout to output Lambda function logs to
-
-        Returns
-        -------
-        samcli.lib.utils.stream_writer.StreamWriter
-            Stream writer for stdout
-        """
+        """Returns stream writer for stdout to output Lambda function logs to"""
         stream = self._log_file_handle if self._log_file_handle else osutils.stdout()
         return StreamWriter(stream, self._is_debugging)
 
     @property
     def stderr(self):
-        """
-        Returns stream writer for stderr to output Lambda function errors to
-
-        Returns
-        -------
-        samcli.lib.utils.stream_writer.StreamWriter
-            Stream writer for stderr
-        """
+        """Returns stream writer for stderr to output Lambda function errors to"""
         stream = self._log_file_handle if self._log_file_handle else osutils.stderr()
         return StreamWriter(stream, self._is_debugging)
 
     @property
     def template(self):
-        """
-        Returns the template data as dictionary
+        """Returns the template data as dictionary
 
         :return dict: Template data
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         return self._template_dict
 
     def get_cwd(self):
-        """
-        Get the working directory. This is usually relative to the directory that contains the template. If a Docker
+        """Get the working directory. This is usually relative to the directory that contains the template. If a Docker
         volume location is specified, it takes preference
 
         All Lambda function code paths are resolved relative to this working directory
 
         :return string: Working directory
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         cwd = os.path.dirname(os.path.abspath(self._template_file))
@@ -263,12 +283,24 @@ class InvokeContext:
 
     @staticmethod
     def _get_template_data(template_file):
-        """
-        Read the template file, parse it as JSON/YAML and return the template as a dictionary.
+        """Read the template file, parse it as JSON/YAML and return the template as a dictionary.
 
-        :param string template_file: Path to the template to read
-        :return dict: Template data as a dictionary
-        :raises InvokeContextException: If template file was not found or the data was not a JSON/YAML
+        Parameters
+        ----------
+        string :
+            template_file: Path to the template to read
+            :return dict: Template data as a dictionary
+        template_file :
+
+
+        Returns
+        -------
+
+        Raises
+        ------
+        InvokeContextException
+            If template file was not found or the data was not a JSON/YAML
+
         """
 
         try:
@@ -278,13 +310,25 @@ class InvokeContext:
 
     @staticmethod
     def _get_env_vars_value(filename):
-        """
-        If the user provided a file containing values of environment variables, this method will read the file and
+        """If the user provided a file containing values of environment variables, this method will read the file and
         return its value
 
-        :param string filename: Path to file containing environment variable values
-        :return dict: Value of environment variables, if provided. None otherwise
-        :raises InvokeContextException: If the file was not found or not a valid JSON
+        Parameters
+        ----------
+        string :
+            filename: Path to file containing environment variable values
+            :return dict: Value of environment variables, if provided. None otherwise
+        filename :
+
+
+        Returns
+        -------
+
+        Raises
+        ------
+        InvokeContextException
+            If the file was not found or not a valid JSON
+
         """
         if not filename:
             return None
@@ -302,11 +346,20 @@ class InvokeContext:
 
     @staticmethod
     def _setup_log_file(log_file):
-        """
-        Open a log file if necessary and return the file handle. This will create a file if it does not exist
+        """Open a log file if necessary and return the file handle. This will create a file if it does not exist
 
-        :param string log_file: Path to a file where the logs should be written to
-        :return: Handle to the opened log file, if necessary. None otherwise
+        Parameters
+        ----------
+        string :
+            log_file: Path to a file where the logs should be written to
+        log_file :
+
+
+        Returns
+        -------
+        type
+            Handle to the opened log file, if necessary. None otherwise
+
         """
         if not log_file:
             return None
@@ -315,27 +368,29 @@ class InvokeContext:
 
     @staticmethod
     def _get_debug_context(debug_ports, debug_args, debugger_path):
-        """
-        Creates a DebugContext if the InvokeContext is in a debugging mode
+        """Creates a DebugContext if the InvokeContext is in a debugging mode
 
         Parameters
         ----------
-        debug_ports tuple(int)
-             Ports to bind the debugger to
-        debug_args str
+        debug_ports tuple(int) :
+            Ports to bind the debugger to
+        debug_args str :
             Additional arguments passed to the debugger
-        debugger_path str
+        debugger_path str :
             Path to the directory of the debugger to mount on Docker
+        debug_ports :
+
+        debug_args :
+
+        debugger_path :
+
 
         Returns
         -------
         samcli.commands.local.lib.debug_context.DebugContext
             Object representing the DebugContext
 
-        Raises
-        ------
-        samcli.commands.local.cli_common.user_exceptions.DebugContext
-            When the debugger_path is not valid
+
         """
         if debug_ports and debugger_path:
             try:
@@ -354,20 +409,23 @@ class InvokeContext:
 
     @staticmethod
     def _get_container_manager(docker_network, skip_pull_image):
-        """
-        Creates a ContainerManager with specified options
+        """Creates a ContainerManager with specified options
 
         Parameters
         ----------
-        docker_network str
+        docker_network str :
             Docker network identifier
-        skip_pull_image bool
+        skip_pull_image bool :
             Should the manager skip pulling the image
+        docker_network :
+
+        skip_pull_image :
+
 
         Returns
         -------
-        samcli.local.docker.manager.ContainerManager
-            Object representing Docker container manager
+
+
         """
 
         return ContainerManager(docker_network_id=docker_network, skip_pull_image=skip_pull_image)

--- a/samcli/commands/local/cli_common/options.py
+++ b/samcli/commands/local/cli_common/options.py
@@ -9,26 +9,13 @@ from samcli.commands._utils.options import template_click_option, docker_click_o
 
 
 def get_application_dir():
-    """
-
-    Returns
-    -------
-    Path
-        Path representing the application config directory
-    """
+    """ """
     # TODO: Get the config directory directly from `GlobalConfig`
     return Path(click.get_app_dir("AWS SAM", force_posix=True))
 
 
 def get_default_layer_cache_dir():
-    """
-    Default the layer cache directory
-
-    Returns
-    -------
-    str
-        String representing the layer cache directory
-    """
+    """Default the layer cache directory"""
     layer_cache_dir = get_application_dir().joinpath("layers-pkg")
 
     return str(layer_cache_dir)
@@ -36,20 +23,21 @@ def get_default_layer_cache_dir():
 
 def service_common_options(port):
     def construct_options(f):
-        """
-        Common CLI Options that are shared for service related commands ('start-api' and 'start_lambda')
+        """Common CLI Options that are shared for service related commands ('start-api' and 'start_lambda')
 
         Parameters
         ----------
-        f function
+        f function :
             Callback passed by Click
-        port int
+        port int :
             port number to use
+        f :
+
 
         Returns
         -------
-        function
-            The callback function
+
+
         """
         service_options = [
             click.option(
@@ -70,10 +58,16 @@ def service_common_options(port):
 
 
 def invoke_common_options(f):
-    """
-    Common CLI options shared by "local invoke" and "local start-api" commands
+    """Common CLI options shared by "local invoke" and "local start-api" commands
 
-    :param f: Callback passed by Click
+    Parameters
+    ----------
+    f :
+        Callback passed by Click
+
+    Returns
+    -------
+
     """
 
     invoke_options = (

--- a/samcli/commands/local/cli_common/user_exceptions.py
+++ b/samcli/commands/local/cli_common/user_exceptions.py
@@ -6,60 +6,40 @@ from samcli.commands.exceptions import UserException
 
 
 class InvokeContextException(UserException):
-    """
-    Something went wrong invoking the function.
-    """
+    """Something went wrong invoking the function."""
 
 
 class InvalidSamTemplateException(UserException):
-    """
-    The template provided was invalid and not able to transform into a Standard CloudFormation Template
-    """
+    """The template provided was invalid and not able to transform into a Standard CloudFormation Template"""
 
 
 class SamTemplateNotFoundException(UserException):
-    """
-    The SAM Template provided could not be found
-    """
+    """The SAM Template provided could not be found"""
 
 
 class DebugContextException(UserException):
-    """
-    Something went wrong when creating the DebugContext
-    """
+    """Something went wrong when creating the DebugContext"""
 
 
 class ImageBuildException(UserException):
-    """
-    Image failed to build
-    """
+    """Image failed to build"""
 
 
 class CredentialsRequired(UserException):
-    """
-    Credentials were not given when Required
-    """
+    """Credentials were not given when Required"""
 
 
 class ResourceNotFound(UserException):
-    """
-    The Resource requested was not found
-    """
+    """The Resource requested was not found"""
 
 
 class InvalidLayerVersionArn(UserException):
-    """
-    The LayerVersion Arn given in the template is Invalid
-    """
+    """The LayerVersion Arn given in the template is Invalid"""
 
 
 class UnsupportedIntrinsic(UserException):
-    """
-    Value from a template has an Intrinsic that is unsupported
-    """
+    """Value from a template has an Intrinsic that is unsupported"""
 
 
 class NotAvailableInRegion(UserException):
-    """
-    Calling service not available (launched) in specified region
-    """
+    """Calling service not available (launched) in specified region"""

--- a/samcli/commands/local/generate_event/cli.py
+++ b/samcli/commands/local/generate_event/cli.py
@@ -29,6 +29,4 @@ $ sam local generate-event s3 [put/delete] --bucket <bucket> --key <key> | sam l
 @click.command(name="generate-event", cls=GenerateEventCommand, help=HELP_TEXT)
 @pass_context
 def cli(self):
-    """
-    Generate an event for one of the services listed below:
-    """
+    """Generate an event for one of the services listed below:"""

--- a/samcli/commands/local/generate_event/event_generation.py
+++ b/samcli/commands/local/generate_event/event_generation.py
@@ -14,16 +14,7 @@ import samcli.lib.config.samconfig as samconfig
 
 
 class ServiceCommand(click.MultiCommand):
-    """
-    Top level command that defines the service provided
-
-    Methods
-    ----------------
-    get_command(self, ctx, cmd_name):
-        Get the subcommand(s) under a given service name.
-    list_commands(self, ctx):
-        List all of the subcommands
-    """
+    """Top level command that defines the service provided"""
 
     def __init__(self, events_lib, *args, **kwargs):
         """
@@ -47,19 +38,19 @@ class ServiceCommand(click.MultiCommand):
         self.all_cmds = self.events_lib.event_mapping
 
     def get_command(self, ctx, cmd_name):
-        """
-        gets the subcommands under the service name
+        """gets the subcommands under the service name
 
         Parameters
         ----------
         ctx : Context
             the context object passed into the method
         cmd_name : str
-            the service name
+
+
         Returns
         -------
-        EventTypeSubCommand:
-            returns subcommand if successful, None if not.
+
+
         """
 
         if cmd_name not in self.all_cmds:
@@ -67,33 +58,24 @@ class ServiceCommand(click.MultiCommand):
         return EventTypeSubCommand(self.events_lib, cmd_name, self.all_cmds[cmd_name])
 
     def list_commands(self, ctx):
-        """
-        lists the service commands available
+        """lists the service commands available
 
         Parameters
         ----------
-        ctx: Context
-            the context object passed into the method
+        ctx : Context
+
+
         Returns
         -------
-        list
-            returns sorted list of the service commands available
+
+
         """
 
         return sorted(self.all_cmds.keys())
 
 
 class EventTypeSubCommand(click.MultiCommand):
-    """
-    Class that describes the commands underneath a given service type
-
-    Methods
-    ----------------
-    get_command(self, ctx, cmd_name):
-        Get the subcommand(s) under a given service name.
-    list_commands(self, ctx):
-        List all of the subcommands
-    """
+    """Class that describes the commands underneath a given service type"""
 
     TAGS = "tags"
 
@@ -122,19 +104,19 @@ class EventTypeSubCommand(click.MultiCommand):
 
     def get_command(self, ctx, cmd_name):
 
-        """
-        gets the Click Commands underneath a service name
+        """gets the Click Commands underneath a service name
 
         Parameters
         ----------
-        ctx: Context
+        ctx : Context
             context object passed in
-        cmd_name: string
-            the service name
+        cmd_name : string
+
+
         Returns
         -------
-        cmd: Click.Command
-            the Click Commands that can be called from the CLI
+
+
         """
 
         if cmd_name not in self.subcmd_definition:
@@ -173,40 +155,46 @@ class EventTypeSubCommand(click.MultiCommand):
         return cmd
 
     def list_commands(self, ctx):
-        """
-        lists the commands underneath a particular event
+        """lists the commands underneath a particular event
 
         Parameters
         ----------
-        ctx: Context
-            the context object passed in
+        ctx : Context
+
+
         Returns
         -------
-        the sorted list of commands under a service
+
+
         """
         return sorted(self.subcmd_definition.keys())
 
     @track_command
     def cmd_implementation(self, events_lib, top_level_cmd_name, subcmd_name, *args, **kwargs):
-        """
-        calls for value substitution in the event json and returns the
+        """calls for value substitution in the event json and returns the
         customized json as a string
 
         Parameters
         ----------
-        events_lib
-        top_level_cmd_name: string
+        events_lib :
+
+        top_level_cmd_name : string
             the name of the service
-        subcmd_name: string
+        subcmd_name : string
             the name of the event under the service
-        args: tuple
+        args : tuple
             any arguments passed in before kwargs
-        kwargs: dict
-            the keys and values for substitution in the json
+        kwargs : dict
+
+        *args :
+
+        **kwargs :
+
+
         Returns
         -------
-        event: string
-            returns the customized event json as a string
+
+
         """
         event = events_lib.generate_event(top_level_cmd_name, subcmd_name, kwargs)
         click.echo(event)
@@ -214,9 +202,7 @@ class EventTypeSubCommand(click.MultiCommand):
 
 
 class GenerateEventCommand(ServiceCommand):
-    """
-    Class that brings ServiceCommand and EventTypeSubCommand into one for easy execution
-    """
+    """Class that brings ServiceCommand and EventTypeSubCommand into one for easy execution"""
 
     def __init__(self, *args, **kwargs):
         """

--- a/samcli/commands/local/invoke/cli.py
+++ b/samcli/commands/local/invoke/cli.py
@@ -105,8 +105,46 @@ def do_cli(  # pylint: disable=R0914
     force_image_build,
     parameter_overrides,
 ):
-    """
-    Implementation of the ``cli`` method, just separated out for unit testing purposes
+    """Implementation of the ``cli`` method, just separated out for unit testing purposes
+
+    Parameters
+    ----------
+    # pylint: disable :
+         (Default value = R0914ctx)
+    function_identifier :
+
+    template :
+
+    event :
+
+    no_event :
+
+    env_vars :
+
+    debug_port :
+
+    debug_args :
+
+    debugger_path :
+
+    docker_volume_basedir :
+
+    docker_network :
+
+    log_file :
+
+    layer_cache_basedir :
+
+    skip_pull_image :
+
+    force_image_build :
+
+    parameter_overrides :
+
+
+    Returns
+    -------
+
     """
 
     from samcli.commands.exceptions import UserException
@@ -167,11 +205,19 @@ def do_cli(  # pylint: disable=R0914
 
 
 def _get_event(event_file_name):
-    """
-    Read the event JSON data from the given file. If no file is provided, read the event from stdin.
+    """Read the event JSON data from the given file. If no file is provided, read the event from stdin.
 
-    :param string event_file_name: Path to event file, or '-' for stdin
-    :return string: Contents of the event file or stdin
+    Parameters
+    ----------
+    string :
+        event_file_name: Path to event file, or '-' for stdin
+        :return string: Contents of the event file or stdin
+    event_file_name :
+
+
+    Returns
+    -------
+
     """
 
     if event_file_name == STDIN_FILE_NAME:

--- a/samcli/commands/local/lib/debug_context.py
+++ b/samcli/commands/local/lib/debug_context.py
@@ -5,12 +5,20 @@ Information and debug options for a specific runtime.
 
 class DebugContext:
     def __init__(self, debug_ports=None, debugger_path=None, debug_args=None):
-        """
-        Initialize the Debug Context with Lambda debugger options
+        """Initialize the Debug Context with Lambda debugger options
 
-        :param tuple(int) debug_ports: Collection of debugger ports to be exposed from a docker container
-        :param Path debugger_path: Path to a debugger to be launched
-        :param string debug_args: Additional arguments to be passed to the debugger
+        Parameters
+        ----------
+        tuple :
+            (int) debug_ports: Collection of debugger ports to be exposed from a docker container
+        Path :
+            debugger_path: Path to a debugger to be launched
+        string :
+            debug_args: Additional arguments to be passed to the debugger
+
+        Returns
+        -------
+
         """
 
         self.debug_ports = debug_ports

--- a/samcli/commands/local/lib/exceptions.py
+++ b/samcli/commands/local/lib/exceptions.py
@@ -4,12 +4,8 @@ Custom exceptions raised by this local library
 
 
 class NoApisDefined(Exception):
-    """
-    Raised when there are no APIs defined in the template
-    """
+    """ """
 
 
 class OverridesNotWellDefinedError(Exception):
-    """
-    Raised when the overrides file is invalid
-    """
+    """ """

--- a/samcli/commands/local/lib/local_api_service.py
+++ b/samcli/commands/local/lib/local_api_service.py
@@ -13,9 +13,15 @@ LOG = logging.getLogger(__name__)
 
 
 class LocalApiService:
-    """
-    Implementation of Local API service that is capable of serving API defined in a configuration file that invoke a
+    """Implementation of Local API service that is capable of serving API defined in a configuration file that invoke a
     Lambda function.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, lambda_invoke_context, port, host, static_dir):
@@ -41,12 +47,18 @@ class LocalApiService:
         self.stderr_stream = lambda_invoke_context.stderr
 
     def start(self):
-        """
-        Creates and starts the local API Gateway service. This method will block until the service is stopped
+        """Creates and starts the local API Gateway service. This method will block until the service is stopped
         manually using an interrupt. After the service is started, callers can make HTTP requests to the endpoint
         to invoke the Lambda function and receive a response.
 
         NOTE: This is a blocking call that will not return until the thread is interrupted with SIGINT/SIGTERM
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         if not self.api_provider.api.routes:
@@ -82,8 +94,7 @@ class LocalApiService:
 
     @staticmethod
     def _print_routes(routes, host, port):
-        """
-        Helper method to print the APIs that will be mounted. This method is purely for printing purposes.
+        """Helper method to print the APIs that will be mounted. This method is purely for printing purposes.
         This method takes in a list of Route Configurations and prints out the Routes grouped by path.
         Grouping routes by Function Name + Path is the bulk of the logic.
 
@@ -91,14 +102,30 @@ class LocalApiService:
             Mounting Product at http://127.0.0.1:3000/path1/bar [GET, POST, DELETE]
             Mounting Product at http://127.0.0.1:3000/path2/bar [HEAD]
 
-        :param list(Route) routes:
+        Parameters
+        ----------
+        list :
+            Route) routes:
             List of routes grouped by the same function_name and path
-        :param string host:
+        string :
+            host:
             Host name where the service is running
-        :param int port:
+        int :
+            port:
             Port number where the service is running
-        :returns list(string):
+        routes :
+
+        host :
+
+        port :
+
+
+        Returns
+        -------
+        type
+            list(string):
             List of lines that were printed to the console. Helps with testing
+
         """
 
         print_lines = []
@@ -113,14 +140,25 @@ class LocalApiService:
 
     @staticmethod
     def _make_static_dir_path(cwd, static_dir):
-        """
-        This method returns the path to the directory where static files are to be served from. If static_dir is a
+        """This method returns the path to the directory where static files are to be served from. If static_dir is a
         relative path, then it is resolved to be relative to the current working directory. If no static directory is
         provided, or if the resolved directory does not exist, this method will return None
 
-        :param string cwd: Current working directory relative to which we will resolve the static directory
-        :param string static_dir: Path to the static directory
-        :return string: Path to the static directory, if it exists. None, otherwise
+        Parameters
+        ----------
+        string :
+            cwd: Current working directory relative to which we will resolve the static directory
+        string :
+            static_dir: Path to the static directory
+            :return string: Path to the static directory, if it exists. None, otherwise
+        cwd :
+
+        static_dir :
+
+
+        Returns
+        -------
+
         """
         if not static_dir:
             return None

--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -16,9 +16,15 @@ LOG = logging.getLogger(__name__)
 
 
 class LocalLambdaRunner:
-    """
-    Runs Lambda functions locally. This class is a wrapper around the `samcli.local` library which takes care
+    """Runs Lambda functions locally. This class is a wrapper around the `samcli.local` library which takes care
     of actually running the function on a Docker container.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     MAX_DEBUG_TIMEOUT = 36000  # 10 hours in seconds
@@ -57,27 +63,34 @@ class LocalLambdaRunner:
         self._boto3_region = None
 
     def invoke(self, function_name, event, stdout=None, stderr=None):
-        """
-        Find the Lambda function with given name and invoke it. Pass the given event to the function and return
+        """Find the Lambda function with given name and invoke it. Pass the given event to the function and return
         response through the given streams.
 
         This function will block until either the function completes or times out.
 
         Parameters
         ----------
-        function_name str
+        function_name str :
             Name of the Lambda function to invoke
-        event str
+        event str :
             Event data passed to the function. Must be a valid JSON String.
-        stdout samcli.lib.utils.stream_writer.StreamWriter
+        stdout samcli.lib.utils.stream_writer.StreamWriter :
             Stream writer to write the output of the Lambda function to.
-        stderr samcli.lib.utils.stream_writer.StreamWriter
+        stderr samcli.lib.utils.stream_writer.StreamWriter :
             Stream writer to write the Lambda runtime logs to.
+        function_name :
 
-        Raises
-        ------
-        FunctionNotfound
-            When we cannot find a function with the given name
+        event :
+
+        stdout :
+             (Default value = None)
+        stderr :
+             (Default value = None)
+
+        Returns
+        -------
+
+
         """
 
         # Generate the correct configuration based on given inputs
@@ -100,23 +113,23 @@ class LocalLambdaRunner:
         self.local_runtime.invoke(config, event, debug_context=self.debug_context, stdout=stdout, stderr=stderr)
 
     def is_debugging(self):
-        """
-        Are we debugging the invoke?
-
-        Returns
-        -------
-        bool
-            True, if we are debugging the invoke ie. the Docker container will break into the debugger and wait for
-            attach
-        """
+        """Are we debugging the invoke?"""
         return bool(self.debug_context)
 
     def _get_invoke_config(self, function):
-        """
-        Returns invoke configuration to pass to Lambda Runtime to invoke the given function
+        """Returns invoke configuration to pass to Lambda Runtime to invoke the given function
 
-        :param samcli.commands.local.lib.provider.Function function: Lambda function to generate the configuration for
-        :return samcli.local.lambdafn.config.FunctionConfig: Function configuration to pass to Lambda runtime
+        Parameters
+        ----------
+        samcli :
+            commands.local.lib.provider.Function function: Lambda function to generate the configuration for
+            :return samcli.local.lambdafn.config.FunctionConfig: Function configuration to pass to Lambda runtime
+        function :
+
+
+        Returns
+        -------
+
         """
 
         env_vars = self._make_env_vars(function)
@@ -156,10 +169,6 @@ class LocalLambdaRunner:
         samcli.local.lambdafn.env_vars.EnvironmentVariables
             Environment variable configuration for this function
 
-        Raises
-        ------
-        samcli.commands.local.lib.exceptions.OverridesNotWellDefinedError
-            If the environment dict is in the wrong format to process environment vars
 
         """
 
@@ -224,12 +233,18 @@ class LocalLambdaRunner:
         return self._boto3_session_creds
 
     def get_aws_creds(self):
-        """
-        Returns AWS credentials obtained from the shell environment or given profile
+        """Returns AWS credentials obtained from the shell environment or given profile
 
         :return dict: A dictionary containing credentials. This dict has the structure
              {"region": "", "key": "", "secret": "", "sessiontoken": ""}. If credentials could not be resolved,
              this returns None
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         result = {}
 

--- a/samcli/commands/local/lib/local_lambda_service.py
+++ b/samcli/commands/local/lib/local_lambda_service.py
@@ -9,9 +9,15 @@ LOG = logging.getLogger(__name__)
 
 
 class LocalLambdaService:
-    """
-    Implementation of Local Lambda Invoke Service that is capable of serving the invoke path to your Lambda Functions
+    """Implementation of Local Lambda Invoke Service that is capable of serving the invoke path to your Lambda Functions
     that are defined in a SAM file.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, lambda_invoke_context, port, host):
@@ -30,12 +36,18 @@ class LocalLambdaService:
         self.stderr_stream = lambda_invoke_context.stderr
 
     def start(self):
-        """
-        Creates and starts the Local Lambda Invoke service. This method will block until the service is stopped
+        """Creates and starts the Local Lambda Invoke service. This method will block until the service is stopped
         manually using an interrupt. After the service is started, callers can make HTTP requests to the endpoint
         to invoke the Lambda function and receive a response.
 
         NOTE: This is a blocking call that will not return until the thread is interrupted with SIGINT/SIGTERM
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         # We care about passing only stderr to the Service and not stdout because stdout from Docker container

--- a/samcli/commands/local/lib/swagger/integration_uri.py
+++ b/samcli/commands/local/lib/swagger/integration_uri.py
@@ -13,9 +13,7 @@ LOG = logging.getLogger(__name__)
 
 
 class LambdaUri:
-    """
-    Purely static class that helps you parse Lambda Function Integration URI ARN
-    """
+    """Purely static class that helps you parse Lambda Function Integration URI ARN"""
 
     _FN_SUB = "Fn::Sub"
 
@@ -40,8 +38,7 @@ class LambdaUri:
 
     @staticmethod
     def get_function_name(integration_uri):
-        """
-        Gets the name of the function from the Integration URI ARN. This is a best effort service which returns None
+        """Gets the name of the function from the Integration URI ARN. This is a best effort service which returns None
         if function name could not be parsed. This can happen when the ARN is an intrinsic function which is too
         complex or the ARN is not a Lambda integration.
 
@@ -53,8 +50,8 @@ class LambdaUri:
 
         Returns
         -------
-        basestring or None
-            If the function name could be parsed out of the Integration URI ARN. None, otherwise
+
+
         """
 
         arn = LambdaUri._get_function_arn(integration_uri)
@@ -65,8 +62,7 @@ class LambdaUri:
 
     @staticmethod
     def _get_function_arn(uri_data):
-        """
-        Integration URI can be expressed in various shapes and forms. This method normalizes the Integration URI ARN
+        """Integration URI can be expressed in various shapes and forms. This method normalizes the Integration URI ARN
         and returns the Lambda Function ARN. Here are the different forms of Integration URI ARN:
 
         - String:
@@ -101,8 +97,8 @@ class LambdaUri:
 
         Returns
         -------
-        basestring or None
-            Lambda Function ARN extracted from Integration URI. None, if it cannot get function Arn
+
+
         """
 
         if not uri_data:
@@ -129,8 +125,7 @@ class LambdaUri:
 
     @staticmethod
     def _get_function_name_from_arn(function_arn):
-        """
-        Given the integration ARN, extract the Lambda function name from the ARN. If there
+        """Given the integration ARN, extract the Lambda function name from the ARN. If there
         are stage variables, or other unsupported formats, this function will return None.
 
         Parameters
@@ -140,8 +135,8 @@ class LambdaUri:
 
         Returns
         -------
-        basestring or None
-            Function name of this integration. None if the ARN is not parsable
+
+
         """
 
         if not function_arn:
@@ -171,8 +166,7 @@ class LambdaUri:
 
     @staticmethod
     def _resolve_fn_sub(uri_data):
-        """
-        Tries to resolve an Integration URI which contains Fn::Sub intrinsic function. This method tries to resolve
+        """Tries to resolve an Integration URI which contains Fn::Sub intrinsic function. This method tries to resolve
         and produce a string output.
 
         Example:
@@ -212,10 +206,8 @@ class LambdaUri:
 
         Returns
         -------
-        string
-            Integration URI as a string, if we were able to resolve the Sub intrinsic
-        dict
-            Input data is returned unmodified if we are unable to resolve the intrinsic
+
+
         """
 
         # Try the short form of Fn::Sub syntax where the value is the ARN
@@ -253,18 +245,17 @@ class LambdaUri:
 
     @staticmethod
     def _is_sub_intrinsic(data):
-        """
-        Is this input data a Fn::Sub intrinsic function
+        """Is this input data a Fn::Sub intrinsic function
 
         Parameters
         ----------
-        data
+        data :
             Data to check
 
         Returns
         -------
-        bool
-            True if the data Fn::Sub intrinsic function
+
+
         """
         return isinstance(data, dict) and len(data) == 1 and LambdaUri._FN_SUB in data
 

--- a/samcli/commands/local/lib/swagger/parser.py
+++ b/samcli/commands/local/lib/swagger/parser.py
@@ -23,20 +23,11 @@ class SwaggerParser:
         self.swagger = swagger or {}
 
     def get_binary_media_types(self):
-        """
-        Get the list of Binary Media Types from Swagger
-
-        Returns
-        -------
-        list of str
-            List of strings that represent the Binary Media Types for the API, defaulting to empty list is None
-
-        """
+        """Get the list of Binary Media Types from Swagger"""
         return self.swagger.get(self._BINARY_MEDIA_TYPES_EXTENSION_KEY) or []
 
     def get_routes(self):
-        """
-        Parses a swagger document and returns a list of APIs configured in the document.
+        """Parses a swagger document and returns a list of APIs configured in the document.
 
         Swagger documents have the following structure
         {
@@ -60,10 +51,13 @@ class SwaggerParser:
             }
         }
 
+        Parameters
+        ----------
+
         Returns
         -------
-        list of list of samcli.commands.local.apigw.local_apigw_service.Route
-            List of APIs that are configured in the Swagger document
+
+
         """
 
         result = []
@@ -89,8 +83,7 @@ class SwaggerParser:
         return result
 
     def _get_integration_function_name(self, method_config):
-        """
-        Tries to parse the Lambda Function name from the Integration defined in the method configuration.
+        """Tries to parse the Lambda Function name from the Integration defined in the method configuration.
         Integration configuration is defined under the special "x-amazon-apigateway-integration" key. We care only
         about Lambda integrations, which are of type aws_proxy, and ignore the rest. Integration URI is complex and
         hard to parse. Hence we do our best to extract function name out of integration URI. If not possible, we
@@ -103,8 +96,8 @@ class SwaggerParser:
 
         Returns
         -------
-        string or None
-            Lambda function name, if possible. None, if not.
+
+
         """
         if not isinstance(method_config, dict) or self._INTEGRATION_KEY not in method_config:
             return None

--- a/samcli/commands/local/lib/swagger/reader.py
+++ b/samcli/commands/local/lib/swagger/reader.py
@@ -18,8 +18,7 @@ _FN_TRANSFORM = "Fn::Transform"
 
 
 def parse_aws_include_transform(data):
-    """
-    If the input data is an AWS::Include data, then parse and return the location of the included file.
+    """If the input data is an AWS::Include data, then parse and return the location of the included file.
 
     AWS::Include transform data usually has the following format:
     {
@@ -38,8 +37,8 @@ def parse_aws_include_transform(data):
 
     Returns
     -------
-    str
-        Location of the included file, if available. None, otherwise
+
+
     """
 
     if not data:
@@ -60,9 +59,15 @@ def parse_aws_include_transform(data):
 
 
 class SwaggerReader:
-    """
-    Class to read and parse Swagger document from a variety of sources. This class accepts the same data formats as
+    """Class to read and parse Swagger document from a variety of sources. This class accepts the same data formats as
     available in Serverless::Api SAM resource
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, definition_body=None, definition_uri=None, working_dir=None):
@@ -92,14 +97,16 @@ class SwaggerReader:
             raise ValueError("Require value for either DefinitionBody or DefinitionUri")
 
     def read(self):
-        """
-        Gets the Swagger document from either of the given locations. If we fail to retrieve or parse the Swagger
+        """Gets the Swagger document from either of the given locations. If we fail to retrieve or parse the Swagger
         file, this method will return None.
+
+        Parameters
+        ----------
 
         Returns
         -------
-        dict:
-            Swagger document. None, if we cannot retrieve the document
+
+
         """
 
         swagger = None
@@ -115,15 +122,17 @@ class SwaggerReader:
         return swagger
 
     def _read_from_definition_body(self):
-        """
-        Read the Swagger document from DefinitionBody. It could either be an inline Swagger dictionary or an
+        """Read the Swagger document from DefinitionBody. It could either be an inline Swagger dictionary or an
         AWS::Include macro that contains location of the included Swagger. In the later case, we will download and
         parse the Swagger document.
 
+        Parameters
+        ----------
+
         Returns
         -------
-        dict
-            Swagger document, if we were able to parse. None, otherwise
+
+
         """
 
         # Let's try to parse it as AWS::Include Transform first. If not, then fall back to assuming the Swagger document
@@ -138,8 +147,7 @@ class SwaggerReader:
         return self.definition_body
 
     def _download_swagger(self, location):
-        """
-        Download the file from given local or remote location and return it
+        """Download the file from given local or remote location and return it
 
         Parameters
         ----------
@@ -149,8 +157,8 @@ class SwaggerReader:
 
         Returns
         -------
-        dict or None
-            Downloaded and parsed Swagger document. None, if unable to download
+
+
         """
 
         if not location:
@@ -183,28 +191,23 @@ class SwaggerReader:
 
     @staticmethod
     def _download_from_s3(bucket, key, version=None):
-        """
-        Download a file from given S3 location, if available.
+        """Download a file from given S3 location, if available.
 
         Parameters
         ----------
         bucket : str
             S3 Bucket name
-
         key : str
             S3 Bucket Key aka file path
-
         version : str
-            Optional Version ID of the file
+            Optional Version ID of the file (Default value = None)
 
         Returns
         -------
         str
             Contents of the file that was downloaded
 
-        Raises
-        ------
-        botocore.exceptions.ClientError if we were unable to download the file from S3
+
         """
 
         s3 = boto3.client("s3")
@@ -231,8 +234,7 @@ class SwaggerReader:
 
     @staticmethod
     def _parse_s3_location(location):
-        """
-        Parses the given location input as a S3 Location and returns the file's bucket, key and version as separate
+        """Parses the given location input as a S3 Location and returns the file's bucket, key and version as separate
         values. Input can be in two different formats:
 
         1. Dictionary with ``Bucket``, ``Key``, ``Version`` keys
@@ -248,12 +250,8 @@ class SwaggerReader:
 
         Returns
         -------
-        str
-            Name of the S3 Bucket. None, if bucket value was not found
-        str
-            Key of the file from S3. None, if key was not provided
-        str
-            Optional Version ID of the file. None, if version ID is not provided
+
+
         """
 
         bucket, key, version = None, None, None

--- a/samcli/commands/local/local.py
+++ b/samcli/commands/local/local.py
@@ -13,9 +13,7 @@ from .start_lambda.cli import cli as start_lambda_cli
 
 @click.group()
 def cli():
-    """
-    Run your Serverless application locally for quick development & testing
-    """
+    """Run your Serverless application locally for quick development & testing"""
 
 
 # Add individual commands under this group

--- a/samcli/commands/logs/command.py
+++ b/samcli/commands/logs/command.py
@@ -82,8 +82,26 @@ def cli(ctx, name, stack_name, filter, tail, start_time, end_time):  # pylint: d
 
 
 def do_cli(function_name, stack_name, filter_pattern, tailing, start_time, end_time):
-    """
-    Implementation of the ``cli`` method
+    """Implementation of the ``cli`` method
+
+    Parameters
+    ----------
+    function_name :
+
+    stack_name :
+
+    filter_pattern :
+
+    tailing :
+
+    start_time :
+
+    end_time :
+
+
+    Returns
+    -------
+
     """
     from .logs_context import LogsCommandContext
 

--- a/samcli/commands/logs/logs_context.py
+++ b/samcli/commands/logs/logs_context.py
@@ -21,14 +21,20 @@ class InvalidTimestampError(UserException):
 
 
 class LogsCommandContext:
-    """
-    Sets up a context to run the Logs command by parsing the CLI arguments and creating necessary objects to be able
+    """Sets up a context to run the Logs command by parsing the CLI arguments and creating necessary objects to be able
     to fetch and display logs
 
     This class **must** be used inside a ``with`` statement as follows:
 
         with LogsCommandContext(**kwargs) as context:
             context.fetcher.fetch(...)
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(
@@ -101,13 +107,7 @@ class LogsCommandContext:
 
     @property
     def formatter(self):
-        """
-        Creates and returns a Formatter capable of nicely formatting Lambda function logs
-
-        Returns
-        -------
-        LogsFormatter
-        """
+        """Creates and returns a Formatter capable of nicely formatting Lambda function logs"""
         formatter_chain = [
             LambdaLogMsgFormatters.colorize_errors,
             # Format JSON "before" highlighting the keywords. Otherwise, JSON will be invalid from all the
@@ -128,14 +128,16 @@ class LogsCommandContext:
 
     @property
     def log_group_name(self):
-        """
-        Name of the AWS CloudWatch Log Group that we will be querying. It generates the name based on the
+        """Name of the AWS CloudWatch Log Group that we will be querying. It generates the name based on the
         Lambda Function name and stack name provided.
+
+        Parameters
+        ----------
 
         Returns
         -------
-        str
-            Name of the CloudWatch Log Group
+
+
         """
 
         function_id = self._function_name
@@ -152,13 +154,7 @@ class LogsCommandContext:
 
     @property
     def colored(self):
-        """
-        Instance of Colored object to colorize strings
-
-        Returns
-        -------
-        samcli.commands.utils.colors.Colored
-        """
+        """Instance of Colored object to colorize strings"""
         # No colors if we are writing output to a file
         return Colored(colorize=self._must_print_colors)
 
@@ -172,8 +168,7 @@ class LogsCommandContext:
 
     @staticmethod
     def _setup_output_file(output_file):
-        """
-        Open a log file if necessary and return the file handle. This will create a file if it does not exist
+        """Open a log file if necessary and return the file handle. This will create a file if it does not exist
 
         Parameters
         ----------
@@ -182,7 +177,8 @@ class LogsCommandContext:
 
         Returns
         -------
-        Handle to the opened log file, if necessary. None otherwise
+
+
         """
         if not output_file:
             return None
@@ -191,14 +187,12 @@ class LogsCommandContext:
 
     @staticmethod
     def _parse_time(time_str, property_name):
-        """
-        Parse the time from the given string, convert to UTC, and return the datetime object
+        """Parse the time from the given string, convert to UTC, and return the datetime object
 
         Parameters
         ----------
         time_str : str
             The time to parse
-
         property_name : str
             Name of the property where this time came from. Used in the exception raised if time is not parseable
 
@@ -207,10 +201,7 @@ class LogsCommandContext:
         datetime.datetime
             Parsed datetime object
 
-        Raises
-        ------
-        samcli.commands.exceptions.UserException
-            If the string cannot be parsed as a timestamp
+
         """
         if not time_str:
             return None
@@ -223,18 +214,15 @@ class LogsCommandContext:
 
     @staticmethod
     def _get_resource_id_from_stack(cfn_client, stack_name, logical_id):
-        """
-        Given the LogicalID of a resource, call AWS CloudFormation to get physical ID of the resource within
+        """Given the LogicalID of a resource, call AWS CloudFormation to get physical ID of the resource within
         the specified stack.
 
         Parameters
         ----------
-        cfn_client
+        cfn_client :
             CloudFormation client provided by AWS SDK
-
         stack_name : str
             Name of the stack to query
-
         logical_id : str
             LogicalId of the resource
 
@@ -243,10 +231,7 @@ class LogsCommandContext:
         str
             Physical ID of the resource
 
-        Raises
-        ------
-        samcli.commands.exceptions.UserException
-            If the stack or resource does not exist
+
         """
 
         LOG.debug(

--- a/samcli/commands/package/command.py
+++ b/samcli/commands/package/command.py
@@ -14,9 +14,15 @@ SHORT_HELP = "Package an AWS SAM application."
 
 
 def resources_and_properties_help_string():
-    """
-    Total list of resources and their property locations that are supported for `sam package`
+    """Total list of resources and their property locations that are supported for `sam package`
     :return: str
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     return "".join(
         f"\nResource : {resource} | Location : {location}\n".format(resource=resource, location=location)

--- a/samcli/commands/publish/command.py
+++ b/samcli/commands/publish/command.py
@@ -55,7 +55,21 @@ def cli(ctx, template_file, semantic_version):
 
 
 def do_cli(ctx, template, semantic_version):
-    """Publish the application based on command line inputs."""
+    """Publish the application based on command line inputs.
+
+    Parameters
+    ----------
+    ctx :
+
+    template :
+
+    semantic_version :
+
+
+    Returns
+    -------
+
+    """
 
     from serverlessrepo import publish_application
     from serverlessrepo.parser import METADATA, SERVERLESS_REPO_APPLICATION
@@ -95,8 +109,7 @@ def do_cli(ctx, template, semantic_version):
 
 
 def _gen_success_message(publish_output):
-    """
-    Generate detailed success message for published applications.
+    """Generate detailed success message for published applications.
 
     Parameters
     ----------
@@ -105,8 +118,8 @@ def _gen_success_message(publish_output):
 
     Returns
     -------
-    str
-        Detailed success message
+
+
     """
     application_id = publish_output.get("application_id")
     details = json.dumps(publish_output.get("details"), indent=2)
@@ -118,15 +131,18 @@ def _gen_success_message(publish_output):
 
 
 def _print_console_link(region, application_id):
-    """
-    Print link for the application in AWS Serverless Application Repository console.
+    """Print link for the application in AWS Serverless Application Repository console.
 
     Parameters
     ----------
-    region : str
-        AWS region name
-    application_id : str
-        The Amazon Resource Name (ARN) of the application
+    region :
+
+    application_id :
+
+
+    Returns
+    -------
+
 
     """
     if not region:

--- a/samcli/commands/validate/lib/exceptions.py
+++ b/samcli/commands/validate/lib/exceptions.py
@@ -4,6 +4,4 @@ Custom Exceptions for 'sam validate' commands
 
 
 class InvalidSamDocumentException(Exception):
-    """
-    Exception for Invalid Sam Documents
-    """
+    """ """

--- a/samcli/commands/validate/lib/sam_template_validator.py
+++ b/samcli/commands/validate/lib/sam_template_validator.py
@@ -31,24 +31,27 @@ class SamTemplateValidator:
 
         Parameters
         ----------
-        sam_template dict
-            Dictionary representing a SAM Template
-        managed_policy_loader ManagedPolicyLoader
-            Sam ManagedPolicyLoader
+
+        Returns
+        -------
+
+
         """
         self.sam_template = sam_template
         self.managed_policy_loader = managed_policy_loader
         self.sam_parser = parser.Parser()
 
     def is_valid(self):
-        """
-        Runs the SAM Translator to determine if the template provided is valid. This is similar to running a
+        """Runs the SAM Translator to determine if the template provided is valid. This is similar to running a
         ChangeSet in CloudFormation for a SAM Template
 
-        Raises
+        Parameters
+        ----------
+
+        Returns
         -------
-        InvalidSamDocumentException
-             If the template is not valid, an InvalidSamDocumentException is raised
+
+
         """
         managed_policy_map = self.managed_policy_loader.load()
 
@@ -65,10 +68,16 @@ class SamTemplateValidator:
             )
 
     def _replace_local_codeuri(self):
-        """
-        Replaces the CodeUri in AWS::Serverless::Function and DefinitionUri in AWS::Serverless::Api to a fake
+        """Replaces the CodeUri in AWS::Serverless::Function and DefinitionUri in AWS::Serverless::Api to a fake
         S3 Uri. This is to support running the SAM Translator with valid values for these fields. If this in not done,
         the template is invalid in the eyes of SAM Translator (the translator does not support local paths)
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         all_resources = self.sam_template.get("Resources", {})
@@ -99,37 +108,41 @@ class SamTemplateValidator:
 
     @staticmethod
     def is_s3_uri(uri):
-        """
-        Checks the uri and determines if it is a valid S3 Uri
+        """Checks the uri and determines if it is a valid S3 Uri
 
         Parameters
         ----------
-        uri str, required
+        uri str, required :
             Uri to check
+        uri :
+
 
         Returns
         -------
-        bool
-            Returns True if the uri given is an S3 uri, otherwise False
+
 
         """
         return isinstance(uri, str) and uri.startswith("s3://")
 
     @staticmethod
     def _update_to_s3_uri(property_key, resource_property_dict, s3_uri_value="s3://bucket/value"):
-        """
-        Updates the 'property_key' in the 'resource_property_dict' to the value of 's3_uri_value'
+        """Updates the 'property_key' in the 'resource_property_dict' to the value of 's3_uri_value'
 
         Note: The function will mutate the resource_property_dict that is pass in
 
         Parameters
         ----------
-        property_key str, required
-            Key in the resource_property_dict
-        resource_property_dict dict, required
-            Property dictionary of a Resource in the template to replace
-        s3_uri_value str, optional
-            Value to update the value of the property_key to
+        property_key :
+
+        resource_property_dict :
+
+        s3_uri_value :
+             (Default value = "s3://bucket/value")
+
+        Returns
+        -------
+
+
         """
         uri_property = resource_property_dict.get(property_key, ".")
 

--- a/samcli/commands/validate/validate.py
+++ b/samcli/commands/validate/validate.py
@@ -28,8 +28,18 @@ def cli(ctx, template_file):
 
 
 def do_cli(ctx, template):
-    """
-    Implementation of the ``cli`` method, just separated out for unit testing purposes
+    """Implementation of the ``cli`` method, just separated out for unit testing purposes
+
+    Parameters
+    ----------
+    ctx :
+
+    template :
+
+
+    Returns
+    -------
+
     """
     from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
 
@@ -57,12 +67,19 @@ def do_cli(ctx, template):
 
 
 def _read_sam_file(template):
-    """
-        Reads the file (json and yaml supported) provided and returns the dictionary representation of the file.
+    """Reads the file (json and yaml supported) provided and returns the dictionary representation of the file.
 
-        :param str template: Path to the template file
+    Parameters
+    ----------
+    str :
+        template: Path to the template file
         :return dict: Dictionary representing the SAM Template
-        :raises: SamTemplateNotFoundException when the template file does not exist
+    template :
+
+
+    Returns
+    -------
+
     """
 
     from samcli.commands.local.cli_common.user_exceptions import SamTemplateNotFoundException

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -38,10 +38,16 @@ class BuildError(Exception):
 
 
 class ApplicationBuilder:
-    """
-    Class to build an entire application. Currently, this class builds Lambda functions only, but there is nothing that
+    """Class to build an entire application. Currently, this class builds Lambda functions only, but there is nothing that
     is stopping this class from supporting other resource types. Building in context of Lambda functions refer to
     converting source code into artifacts that can be run on AWS Lambda
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self,
@@ -85,14 +91,7 @@ class ApplicationBuilder:
         self._mode = mode
 
     def build(self):
-        """
-        Build the entire application
-
-        Returns
-        -------
-        dict
-            Returns the path to where each resource was built as a map of resource's LogicalId to the path string
-        """
+        """Build the entire application"""
 
         result = {}
 
@@ -106,23 +105,22 @@ class ApplicationBuilder:
         return result
 
     def update_template(self, template_dict, original_template_path, built_artifacts):
-        """
-        Given the path to built artifacts, update the template to point appropriate resource CodeUris to the artifacts
+        """Given the path to built artifacts, update the template to point appropriate resource CodeUris to the artifacts
         folder
 
         Parameters
         ----------
-        template_dict
+        template_dict :
+
         original_template_path : str
             Path where the template file will be written to
-
         built_artifacts : dict
             Map of LogicalId of a resource to the path where the the built artifacts for this resource lives
 
         Returns
         -------
-        dict
-            Updated template
+
+
         """
 
         original_dir = os.path.dirname(original_template_path)
@@ -149,25 +147,22 @@ class ApplicationBuilder:
         return template_dict
 
     def _build_function(self, function_name, codeuri, runtime):
-        """
-        Given the function information, this method will build the Lambda function. Depending on the configuration
+        """Given the function information, this method will build the Lambda function. Depending on the configuration
         it will either build the function in process or by spinning up a Docker container.
 
         Parameters
         ----------
         function_name : str
             Name or LogicalId of the function
-
         codeuri : str
             Path to where the code lives
-
         runtime : str
             AWS Lambda function runtime
 
         Returns
         -------
-        str
-            Path to the location where built artifacts are available
+
+
         """
 
         # Create the arguments to pass to the builder

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -68,27 +68,30 @@ class UnsupportedRuntimeException(Exception):
 
 
 def get_workflow_config(runtime, code_dir, project_dir):
-    """
-    Get a workflow config that corresponds to the runtime provided. This method examines contents of the project
+    """Get a workflow config that corresponds to the runtime provided. This method examines contents of the project
     and code directories to determine the most appropriate workflow for the given runtime. Currently the decision is
     based on the presence of a supported manifest file. For runtimes that have more than one workflow, we choose a
     workflow by examining ``code_dir`` followed by ``project_dir`` for presence of a supported manifest.
 
     Parameters
     ----------
-    runtime str
+    runtime str :
         The runtime of the config
-
-    code_dir str
+    code_dir str :
         Directory where Lambda function code is present
-
-    project_dir str
+    project_dir str :
         Root of the Serverless application project.
+    runtime :
+
+    code_dir :
+
+    project_dir :
+
 
     Returns
     -------
-    namedtuple(Capability)
-        namedtuple that represents the Builder Workflow Config
+
+
     """
 
     selectors_by_runtime = {
@@ -135,18 +138,19 @@ def get_workflow_config(runtime, code_dir, project_dir):
 
 
 def supports_build_in_container(config):
-    """
-    Given a workflow config, this method provides a boolean on whether the workflow can run within a container or not.
+    """Given a workflow config, this method provides a boolean on whether the workflow can run within a container or not.
 
     Parameters
     ----------
-    config namedtuple(Capability)
+    config namedtuple(Capability) :
         Config specifying the particular build workflow
+    config :
+
 
     Returns
     -------
-    tuple(bool, str)
-        True, if this workflow can be built inside a container. False, along with a reason message if it cannot be.
+
+
     """
 
     def _key(c):
@@ -171,9 +175,7 @@ def supports_build_in_container(config):
 
 
 class BasicWorkflowSelector:
-    """
-    Basic workflow selector that returns the first available configuration in the given list of configurations
-    """
+    """Basic workflow selector that returns the first available configuration in the given list of configurations"""
 
     def __init__(self, configs):
 
@@ -183,30 +185,41 @@ class BasicWorkflowSelector:
         self.configs = configs
 
     def get_config(self, code_dir, project_dir):
-        """
-        Returns the first available configuration
+        """Returns the first available configuration
+
+        Parameters
+        ----------
+        code_dir :
+
+        project_dir :
+
+
+        Returns
+        -------
+
         """
         return self.configs[0]
 
 
 class ManifestWorkflowSelector(BasicWorkflowSelector):
-    """
-    Selects a workflow by examining the directories for presence of a supported manifest
-    """
+    """Selects a workflow by examining the directories for presence of a supported manifest"""
 
     def get_config(self, code_dir, project_dir):
-        """
-        Finds a configuration by looking for a manifest in the given directories.
+        """Finds a configuration by looking for a manifest in the given directories.
+
+        Parameters
+        ----------
+        code_dir :
+
+        project_dir :
+
 
         Returns
         -------
         samcli.lib.build.workflow_config.CONFIG
             A supported configuration if one is found
 
-        Raises
-        ------
-        ValueError
-            If none of the supported manifests files are found
+
         """
 
         # Search for manifest first in code directory and then in the project directory.

--- a/samcli/lib/config/samconfig.py
+++ b/samcli/lib/config/samconfig.py
@@ -19,9 +19,7 @@ DEFAULT_ENV = "default"
 
 
 class SamConfig:
-    """
-    Class to interface with `samconfig.toml` file.
-    """
+    """Class to interface with `samconfig.toml` file."""
 
     document = None
 
@@ -41,32 +39,23 @@ class SamConfig:
         self.filepath = Path(config_dir, filename or DEFAULT_CONFIG_FILE_NAME)
 
     def get_all(self, cmd_names, section, env=DEFAULT_ENV):
-        """
-        Gets a value from the configuration file for the given environment, command and section
+        """Gets a value from the configuration file for the given environment, command and section
 
         Parameters
         ----------
         cmd_names : list(str)
             List of representing the entire command. Ex: ["local", "generate-event", "s3", "put"]
-
         section : str
             Specific section within the command to look into Ex: `parameters`
-
         env : str
-            Optional, Name of the environment
+            Optional, Name of the environment (Default value = DEFAULT_ENV)
 
         Returns
         -------
         dict
             Dictionary of configuration options in the file. None, if the config doesn't exist.
 
-        Raises
-        ------
-        KeyError
-            If the config file does *not* have the specific section
 
-        tomlkit.exceptions.TOMLKitError
-            If the configuration file is invalid
         """
 
         env = env or DEFAULT_ENV
@@ -75,8 +64,7 @@ class SamConfig:
         return self.document[env][self._to_key(cmd_names)][section]
 
     def put(self, cmd_names, section, key, value, env=DEFAULT_ENV):
-        """
-        Writes the `key=value` under the given section. You have to call the `flush()` method after `put()` in
+        """Writes the `key=value` under the given section. You have to call the `flush()` method after `put()` in
         order to write the values back to the config file. Otherwise they will be just saved in-memory, available
         for future access, but never saved back to the file.
 
@@ -84,23 +72,19 @@ class SamConfig:
         ----------
         cmd_names : list(str)
             List of representing the entire command. Ex: ["local", "generate-event", "s3", "put"]
-
         section : str
             Specific section within the command to look into Ex: `parameters`
-
         key : str
             Key to write the data under
-
-        value
+        value :
             Value to write. Could be any of the supported TOML types.
-
         env : str
-            Optional, Name of the environment
+            Optional, Name of the environment (Default value = DEFAULT_ENV)
 
-        Raises
-        ------
-        tomlkit.exceptions.TOMLKitError
-            If the data is invalid
+        Returns
+        -------
+
+
         """
 
         if not self.document:
@@ -111,21 +95,11 @@ class SamConfig:
         self.document[env][self._to_key(cmd_names)][section].update({key: value})
 
     def flush(self):
-        """
-        Write the data back to file
-
-        Raises
-        ------
-        tomlkit.exceptions.TOMLKitError
-            If the data is invalid
-
-        """
+        """Write the data back to file"""
         self._write()
 
     def sanity_check(self):
-        """
-        Sanity check the contents of samconfig
-        """
+        """Sanity check the contents of samconfig"""
         try:
             self._read()
         except tomlkit.exceptions.TOMLKitError:
@@ -141,9 +115,17 @@ class SamConfig:
 
     @staticmethod
     def config_dir(template_file_path=None):
-        """
-        SAM Config file is always relative to the SAM Template. If it the template is not
+        """SAM Config file is always relative to the SAM Template. If it the template is not
         given, then it is relative to cwd()
+
+        Parameters
+        ----------
+        template_file_path :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         if template_file_path:
             return os.path.dirname(template_file_path)

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -76,11 +76,18 @@ class Deployer:
         self.deploy_color = DeployColor()
 
     def has_stack(self, stack_name):
-        """
-        Checks if a CloudFormation stack with given name exists
+        """Checks if a CloudFormation stack with given name exists
 
-        :param stack_name: Name or ID of the stack
-        :return: True if stack exists. False otherwise
+        Parameters
+        ----------
+        stack_name :
+            Name or ID of the stack
+
+        Returns
+        -------
+        type
+            True if stack exists. False otherwise
+
         """
         try:
             resp = self._client.describe_stacks(StackName=stack_name)
@@ -119,15 +126,30 @@ class Deployer:
     def create_changeset(
         self, stack_name, cfn_template, parameter_values, capabilities, role_arn, notification_arns, s3_uploader, tags
     ):
-        """
-        Call Cloudformation to create a changeset and wait for it to complete
+        """Call Cloudformation to create a changeset and wait for it to complete
 
-        :param stack_name: Name or ID of stack
-        :param cfn_template: CloudFormation template string
-        :param parameter_values: Template parameters object
-        :param capabilities: Array of capabilities passed to CloudFormation
-        :param tags: Array of tags passed to CloudFormation
-        :return:
+        Parameters
+        ----------
+        stack_name :
+            Name or ID of stack
+        cfn_template :
+            CloudFormation template string
+        parameter_values :
+            Template parameters object
+        capabilities :
+            Array of capabilities passed to CloudFormation
+        tags :
+            Array of tags passed to CloudFormation
+        role_arn :
+
+        notification_arns :
+
+        s3_uploader :
+
+
+        Returns
+        -------
+
         """
         if not self.has_stack(stack_name):
             changeset_type = "CREATE"
@@ -198,12 +220,22 @@ class Deployer:
         table_header=DESCRIBE_CHANGESET_TABLE_HEADER_NAME,
     )
     def describe_changeset(self, change_set_id, stack_name, **kwargs):
-        """
-        Call Cloudformation to describe a changeset
+        """Call Cloudformation to describe a changeset
 
-        :param change_set_id: ID of the changeset
-        :param stack_name: Name of the CloudFormation stack
-        :return: dictionary of changes described in the changeset.
+        Parameters
+        ----------
+        change_set_id :
+            ID of the changeset
+        stack_name :
+            Name of the CloudFormation stack
+        **kwargs :
+
+
+        Returns
+        -------
+        type
+            dictionary of changes described in the changeset.
+
         """
         paginator = self._client.get_paginator("describe_change_set")
         response_iterator = paginator.paginate(ChangeSetName=change_set_id, StackName=stack_name)
@@ -251,12 +283,20 @@ class Deployer:
         return changes
 
     def wait_for_changeset(self, changeset_id, stack_name):
-        """
-        Waits until the changeset creation completes
+        """Waits until the changeset creation completes
 
-        :param changeset_id: ID or name of the changeset
-        :param stack_name:   Stack name
-        :return: Latest status of the create-change-set operation
+        Parameters
+        ----------
+        changeset_id :
+            ID or name of the changeset
+        stack_name :
+            Stack name
+
+        Returns
+        -------
+        type
+            Latest status of the create-change-set operation
+
         """
         sys.stdout.write("\nWaiting for changeset to be created..\n")
         sys.stdout.flush()
@@ -285,12 +325,20 @@ class Deployer:
             )
 
     def execute_changeset(self, changeset_id, stack_name):
-        """
-        Calls CloudFormation to execute changeset
+        """Calls CloudFormation to execute changeset
 
-        :param changeset_id: ID of the changeset
-        :param stack_name: Name or ID of the stack
-        :return: Response from execute-change-set call
+        Parameters
+        ----------
+        changeset_id :
+            ID of the changeset
+        stack_name :
+            Name or ID of the stack
+
+        Returns
+        -------
+        type
+            Response from execute-change-set call
+
         """
         try:
             return self._client.execute_change_set(ChangeSetName=changeset_id, StackName=stack_name)
@@ -298,10 +346,18 @@ class Deployer:
             raise DeployFailedError(stack_name=stack_name, msg=str(ex))
 
     def get_last_event_time(self, stack_name):
-        """
-        Finds the last event time stamp thats present for the stack, if not get the current time
-        :param stack_name: Name or ID of the stack
-        :return: unix epoch
+        """Finds the last event time stamp thats present for the stack, if not get the current time
+
+        Parameters
+        ----------
+        stack_name :
+            Name or ID of the stack
+
+        Returns
+        -------
+        type
+            unix epoch
+
         """
         try:
             return utc_to_timestamp(
@@ -316,11 +372,20 @@ class Deployer:
         table_header=DESCRIBE_STACK_EVENTS_TABLE_HEADER_NAME,
     )
     def describe_stack_events(self, stack_name, time_stamp_marker, **kwargs):
-        """
-        Calls CloudFormation to get current stack events
-        :param stack_name: Name or ID of the stack
-        :param time_stamp_marker: last event time on the stack to start streaming events from.
-        :return:
+        """Calls CloudFormation to get current stack events
+
+        Parameters
+        ----------
+        stack_name :
+            Name or ID of the stack
+        time_stamp_marker :
+            last event time on the stack to start streaming events from.
+        **kwargs :
+
+
+        Returns
+        -------
+
         """
 
         stack_change_in_progress = True

--- a/samcli/lib/generated_sample_events/events.py
+++ b/samcli/lib/generated_sample_events/events.py
@@ -12,16 +12,7 @@ from chevron import renderer
 
 class Events:
 
-    """
-    Events library class that loads and customizes event json files
-
-    Methods
-    ---------------
-    expose_event_metadata(self):
-        return the event mapping file
-    generate-event(self, service_name, event_type, values_to_sub):
-        load in and substitute values into json file (if necessary)
-    """
+    """Events library class that loads and customizes event json files"""
 
     def __init__(self):
         """
@@ -34,23 +25,23 @@ class Events:
             self.event_mapping = json.load(f)
 
     def encode(self, tags, encoding, values_to_sub):
-        """
-        reads the encoding type from the event-mapping.json
+        """reads the encoding type from the event-mapping.json
         and determines whether a value needs encoding
 
         Parameters
         ----------
-        tags: dict
+        tags : dict
             the values of a particular event that can be substituted
             within the event json
-        encoding: string
+        encoding : string
             string that helps navigate to the encoding field of the json
-        values_to_sub: dict
-            key/value pairs that will be substituted into the json
+        values_to_sub : dict
+
+
         Returns
         -------
-        values_to_sub: dict
-            the encoded (if need be) values to substitute into the json.
+
+
         """
 
         for tag in tags:
@@ -62,52 +53,54 @@ class Events:
         return values_to_sub
 
     def url_encode(self, value):
-        """
-        url encodes the value passed in
+        """url encodes the value passed in
 
         Parameters
         ----------
-        value: string
-            the value that needs to be encoded in the json
+        value : string
+
+
         Returns
         -------
-        string: the url encoded value
+
+
         """
 
         return quote(value)
 
     def base64_utf_encode(self, value):
-        """
-        base64 utf8 encodes the value passed in
+        """base64 utf8 encodes the value passed in
 
         Parameters
         ----------
-        value: string
-            value that needs to be encoded in the json
+        value : string
+
+
         Returns
         -------
-        string: the base64_utf encoded value
+
+
         """
 
         return base64.b64encode(value.encode("utf8")).decode("utf-8")
 
     def generate_event(self, service_name, event_type, values_to_sub):
-        """
-        opens the event json, substitutes the values in, and
+        """opens the event json, substitutes the values in, and
         returns the customized event json
 
         Parameters
         ----------
-        service_name: string
+        service_name : string
             name of the top level service (S3, apigateway, etc)
-        event_type: string
+        event_type : string
             name of the event underneath the service
-        values_to_sub: dict
-            key/value pairs to substitute into the json
+        values_to_sub : dict
+
+
         Returns
         -------
-        renderer.render(): string
-            string version of the custom event json
+
+
         """
 
         # set variables for easy calling

--- a/samcli/lib/init/__init__.py
+++ b/samcli/lib/init/__init__.py
@@ -27,26 +27,28 @@ def generate_project(
 
     Parameters
     ----------
-    location: Path, optional
+    location : Path, optional
         Git, HTTP, Local path or Zip containing cookiecutter template
         (the default is None, which means no custom template)
-    runtime: str
-        Lambda Runtime
-    dependency_manager: str, optional
-        Dependency Manager for the Lambda Runtime Project
-    output_dir: str, optional
+    runtime : str
+        Lambda Runtime (Default value = None)
+    dependency_manager : str, optional
+        Dependency Manager for the Lambda Runtime Project (Default value = None)
+    output_dir : str, optional
         Output directory where project should be generated
         (the default is ".", which implies current folder)
-    name: str
-        Name of the project
+    name : str
+        Name of the project (Default value = None)
     no_input : bool, optional
         Whether to prompt for input or to accept default values
         (the default is False, which prompts the user for values it doesn't know for baking)
+    extra_context :
+         (Default value = None)
 
-    Raises
-    ------
-    GenerateProjectFailedError
-        If the process of baking a project fails
+    Returns
+    -------
+
+
     """
 
     template = None

--- a/samcli/lib/init/arbitrary_project.py
+++ b/samcli/lib/init/arbitrary_project.py
@@ -28,8 +28,7 @@ BAD_LOCATION_ERROR_MSG = (
 
 
 def generate_non_cookiecutter_project(location, output_dir):
-    """
-    Uses Cookiecutter APIs to download a project at given ``location`` to the ``output_dir``.
+    """Uses Cookiecutter APIs to download a project at given ``location`` to the ``output_dir``.
     This does *not* run cookiecutter on the downloaded project.
 
     Parameters
@@ -37,10 +36,8 @@ def generate_non_cookiecutter_project(location, output_dir):
     location : str
         Path to where the project is. This supports all formats of location cookiecutter supports
         (ex: zip, git, ssh, hg, local zipfile)
-
         NOTE: This value *cannot* be a local directory. We didn't see a value in simply copying the directory
         contents to ``output_dir`` without any processing.
-
     output_dir : str
         Directory where the project should be downloaded to
 
@@ -49,9 +46,7 @@ def generate_non_cookiecutter_project(location, output_dir):
     str
         Name of the directory where the project was downloaded to.
 
-    Raises
-    ------
-    cookiecutter.exception.CookiecutterException if download failed for some reason
+
     """
 
     LOG.debug("Downloading project from %s to %s", location, output_dir)
@@ -85,8 +80,7 @@ def generate_non_cookiecutter_project(location, output_dir):
 
 
 def _download_and_copy(download_fn, output_dir):
-    """
-    Runs the download function to download files into a temporary directory and then copy the files over to
+    """Runs the download function to download files into a temporary directory and then copy the files over to
     the ``output_dir``
 
     Parameters
@@ -94,13 +88,13 @@ def _download_and_copy(download_fn, output_dir):
     download_fn : function
         Method to be called to download. It needs to accept a parameter called `clone_to_dir`. This will be
         set to the temporary directory
-
     output_dir : str
         Path to the directory where files will be copied to
 
     Returns
     -------
-    output_dir
+
+
     """
 
     with osutils.mkdir_temp() as tempdir:

--- a/samcli/lib/init/templates/cookiecutter-aws-sam-hello-golang/tests/test_bake_project.py
+++ b/samcli/lib/init/templates/cookiecutter-aws-sam-hello-golang/tests/test_bake_project.py
@@ -6,9 +6,16 @@ import subprocess
 
 @contextmanager
 def inside_dir(dirpath):
-    """
-    Execute code from inside the given directory
-    :param dirpath: String, path of the directory the command is being run.
+    """Execute code from inside the given directory
+
+    Parameters
+    ----------
+    dirpath :
+        String, path of the directory the command is being run.
+
+    Returns
+    -------
+
     """
     old_path = os.getcwd()
     try:

--- a/samcli/lib/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/hello_world/app.py
+++ b/samcli/lib/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/hello_world/app.py
@@ -8,21 +8,17 @@ def lambda_handler(event, context):
 
     Parameters
     ----------
-    event: dict, required
+    event : dict, required
         API Gateway Lambda Proxy Input Format
-
         Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
-
-    context: object, required
+    context : object, required
         Lambda Context runtime methods and attributes
-
         Context doc: https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
 
     Returns
-    ------
-    API Gateway Lambda Proxy Output Format: dict
+    -------
 
-        Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+
     """
 
     # try:

--- a/samcli/lib/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
+++ b/samcli/lib/init/templates/cookiecutter-aws-sam-hello-python/{{cookiecutter.project_name}}/tests/unit/test_handler.py
@@ -7,7 +7,7 @@ from hello_world import app
 
 @pytest.fixture()
 def apigw_event():
-    """ Generates API GW Event"""
+    """Generates API GW Event"""
 
     return {
         "body": '{ "test": "body"}',

--- a/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
+++ b/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
@@ -170,8 +170,7 @@ class IntrinsicsSymbolTable:
         }
 
     def resolve_symbols(self, logical_id, resource_attribute, ignore_errors=False):
-        """
-        This function resolves all the symbols given a logical id and a resource_attribute for Fn::GetAtt and Ref.
+        """This function resolves all the symbols given a logical id and a resource_attribute for Fn::GetAtt and Ref.
         This boils Ref into a type of Fn:GetAtt to simplify the implementation.
         For example:
             {"Ref": "AWS::REGION"} => resolve_symbols("AWS::REGION", "REF")
@@ -183,18 +182,20 @@ class IntrinsicsSymbolTable:
 
         Then the default_type_resolver is checked, which has common attributes and functions for each types.
         Then the common_attribute_resolver is run, which has functions that are common for each attribute.
-        Parameters
-        -----------
-        logical_id: str
-            The logical id of the resource in question or a pseudo type.
-        resource_attribute: str
-            The resource attribute of the resource in question or Ref for psuedo types.
-        ignore_errors: bool
-            An optional flags to not return errors. This used in sub
 
-        Return
+        Parameters
+        ----------
+        logical_id :
+
+        resource_attribute :
+
+        ignore_errors :
+             (Default value = False)
+
+        Returns
         -------
-        This resolves the attribute
+
+
         """
         # pylint: disable-msg=too-many-return-statements
         translated = self.get_translation(logical_id, resource_attribute)
@@ -234,20 +235,20 @@ class IntrinsicsSymbolTable:
         )
 
     def arn_resolver(self, logical_id, service_name="lambda"):
-        """
-        This function resolves Arn in the format
+        """This function resolves Arn in the format
             arn:{partition_name}:{service_name}:{aws_region}:{account_id}:{function_name}
 
         Parameters
-        -----------
-        logical_id: str
-            This the reference to the function name used
-        service_name: str
-            This is the service name used such as lambda or sns
+        ----------
+        logical_id :
 
-        Return
+        service_name :
+             (Default value = "lambda")
+
+        Returns
         -------
-        The resolved Arn
+
+
         """
         aws_region = self.handle_pseudo_region()
         account_id = (
@@ -269,19 +270,18 @@ class IntrinsicsSymbolTable:
         )
 
     def get_translation(self, logical_id, resource_attributes=IntrinsicResolver.REF):
-        """
-        This gets the logical_id_translation of the logical id and resource_attributes.
+        """This gets the logical_id_translation of the logical id and resource_attributes.
 
         Parameters
         ----------
-        logical_id: str
+        logical_id : str
             This is the logical id of the resource in question
-        resource_attributes: str
+        resource_attributes : str
             This is the attribute required. By default, it is a REF type
 
         Returns
-        --------
-        This returns the translated item if it already exists
+        -------
+
 
         """
         logical_id_item = self.logical_id_translator.get(logical_id, {})
@@ -294,39 +294,50 @@ class IntrinsicsSymbolTable:
 
     @staticmethod
     def get_availability_zone(region):
-        """
-        This gets the availability zone from the the specified region
+        """This gets the availability zone from the the specified region
 
         Parameters
-        -----------
-        region: str
-            The specified region from the SymbolTable region
+        ----------
+        region :
 
-        Return
+
+        Returns
         -------
-        The list of availability zones for the specified region
+
+
         """
         return IntrinsicsSymbolTable.REGIONS.get(region)
 
     @staticmethod
     def handle_pseudo_account_id():
-        """
-        This gets a default account id from SamBaseProvider.
-        Return
+        """This gets a default account id from SamBaseProvider.
+
+        Parameters
+        ----------
+
+        Returns
         -------
-        A pseudo account id
+        type
+            -------
+            A pseudo account id
+
         """
         return IntrinsicsSymbolTable.DEFAULT_PSEUDO_PARAM_VALUES.get(IntrinsicsSymbolTable.AWS_ACCOUNT_ID)
 
     def handle_pseudo_region(self):
-        """
-        Gets the region from the environment and defaults to a the default region from the global variables.
+        """Gets the region from the environment and defaults to a the default region from the global variables.
 
         This is only run if it is not specified by the logical_id_translator as a default.
 
-        Return
+        Parameters
+        ----------
+
+        Returns
         -------
-        The region from the environment or a default one
+        type
+            -------
+            The region from the environment or a default one
+
         """
         return (
             self.logical_id_translator.get(IntrinsicsSymbolTable.AWS_REGION)
@@ -335,13 +346,19 @@ class IntrinsicsSymbolTable:
         )
 
     def handle_pseudo_url_prefix(self):
-        """
-        This gets the AWS::UrlSuffix for the intrinsic with the china and regular prefix.
+        """This gets the AWS::UrlSuffix for the intrinsic with the china and regular prefix.
 
         This is only run if it is not specified by the logical_id_translator as a default.
-        Return
+
+        Parameters
+        ----------
+
+        Returns
         -------
-        The url prefix of amazonaws.com or amazonaws.com.cn
+        type
+            -------
+            The url prefix of amazonaws.com or amazonaws.com.cn
+
         """
         aws_region = self.handle_pseudo_region()
         if self.CHINA_PREFIX in aws_region:
@@ -349,14 +366,19 @@ class IntrinsicsSymbolTable:
         return self.DEFAULT_URL_PREFIX
 
     def handle_pseudo_partition(self):
-        """
-        This resolves AWS::Partition so that the correct partition is returned depending on the region.
+        """This resolves AWS::Partition so that the correct partition is returned depending on the region.
 
         This is only run if it is not specified by the logical_id_translator as a default.
 
-        Return
+        Parameters
+        ----------
+
+        Returns
         -------
-        A pseudo partition like aws-cn or aws or aws-gov
+        type
+            -------
+            A pseudo partition like aws-cn or aws or aws-gov
+
         """
         aws_region = self.handle_pseudo_region()
         if self.CHINA_PREFIX in aws_region:
@@ -367,38 +389,41 @@ class IntrinsicsSymbolTable:
 
     @staticmethod
     def handle_pseudo_stack_id():
-        """
-        This resolves AWS::StackId by using the SamBaseProvider as the default value.
+        """This resolves AWS::StackId by using the SamBaseProvider as the default value.
 
         This is only run if it is not specified by the logical_id_translator as a default.
 
-        Return
+        Parameters
+        ----------
+
+        Returns
         -------
-        A randomized string
+        type
+            -------
+            A randomized string
+
         """
         return IntrinsicsSymbolTable.DEFAULT_PSEUDO_PARAM_VALUES.get(IntrinsicsSymbolTable.AWS_STACK_ID)
 
     @staticmethod
     def handle_pseudo_stack_name():
-        """
-        This resolves AWS::StackName by using the SamBaseProvider as the default value.
+        """This resolves AWS::StackName by using the SamBaseProvider as the default value.
 
         This is only run if it is not specified by the logical_id_translator as a default.
 
-        Return
+        Parameters
+        ----------
+
+        Returns
         -------
-        A randomized string
+        type
+            -------
+            A randomized string
+
         """
         return IntrinsicsSymbolTable.DEFAULT_PSEUDO_PARAM_VALUES.get(IntrinsicsSymbolTable.AWS_STACK_NAME)
 
     @staticmethod
     def handle_pseudo_no_value():
-        """
-        This resolves AWS::NoValue so that it returns the python None
-
-        Returns
-        --------
-        None
-        :return:
-        """
+        """This resolves AWS::NoValue so that it returns the python None"""
         return None

--- a/samcli/lib/logs/event.py
+++ b/samcli/lib/logs/event.py
@@ -10,9 +10,7 @@ LOG = logging.getLogger(__name__)
 
 
 class LogEvent:
-    """
-    Data object representing a CloudWatch Log Event
-    """
+    """Data object representing a CloudWatch Log Event"""
 
     log_group_name = None
     log_stream_name = None

--- a/samcli/lib/logs/fetcher.py
+++ b/samcli/lib/logs/fetcher.py
@@ -13,9 +13,15 @@ LOG = logging.getLogger(__name__)
 
 
 class LogsFetcher:
-    """
-    Fetch logs from a CloudWatch Logs group with the ability to scope to a particular time, filter by
+    """Fetch logs from a CloudWatch Logs group with the ability to scope to a particular time, filter by
     a pattern, and in the future possibly multiplex from from multiple streams together.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, cw_client=None):
@@ -30,30 +36,24 @@ class LogsFetcher:
         self.cw_client = cw_client
 
     def fetch(self, log_group_name, start=None, end=None, filter_pattern=None):
-        """
-        Fetch logs from all streams under the given CloudWatch Log Group and yields in the output. Optionally, caller
+        """Fetch logs from all streams under the given CloudWatch Log Group and yields in the output. Optionally, caller
         can filter the logs using a pattern or a start/end time.
 
         Parameters
         ----------
-        log_group_name : string
-            Name of CloudWatch Logs Group to query.
+        log_group_name :
 
-        start : datetime.datetime
-            Optional start time for logs.
+        start :
+             (Default value = None)
+        end :
+             (Default value = None)
+        filter_pattern :
+             (Default value = None)
 
-        end : datetime.datetime
-            Optional end time for logs.
+        Returns
+        -------
 
-        filter_pattern : str
-            Expression to filter the logs by. This is passed directly to CloudWatch, so any expression supported by
-            CloudWatch Logs API is supported here.
 
-        Yields
-        ------
-
-        samcli.lib.logs.event.LogEvent
-            Object containing the information from each log event returned by CloudWatch Logs
         """
 
         kwargs = {"logGroupName": log_group_name, "interleaved": True}
@@ -82,8 +82,7 @@ class LogsFetcher:
                 break
 
     def tail(self, log_group_name, start=None, filter_pattern=None, max_retries=1000, poll_interval=0.3):
-        """
-        ** This is a long blocking call **
+        """** This is a long blocking call **
 
         Fetches logs from CloudWatch logs similar to the ``fetch`` method, but instead of stopping after all logs have
         been fetched, this method continues to poll CloudWatch for new logs. So this essentially simulates the
@@ -94,28 +93,21 @@ class LogsFetcher:
 
         Parameters
         ----------
-        log_group_name : str
-            Name of CloudWatch Logs Group to query.
+        log_group_name :
 
-        start : datetime.datetime
-            Optional start time for logs. Defaults to '5m ago'
+        start :
+             (Default value = None)
+        filter_pattern :
+             (Default value = None)
+        max_retries :
+             (Default value = 1000)
+        poll_interval :
+             (Default value = 0.3)
 
-        filter_pattern : str
-            Expression to filter the logs by. This is passed directly to CloudWatch, so any expression supported by
-            CloudWatch Logs API is supported here.
+        Returns
+        -------
 
-        max_retries : int
-            When logs are not available, this value determines the number of times to retry fetching logs before giving
-            up. This counter is reset every time new logs are available.
 
-        poll_interval : float
-            Number of fractional seconds wait before polling again. Defaults to 300milliseconds.
-            If no new logs available, this method will stop polling after ``max_retries * poll_interval`` seconds
-
-        Yields
-        ------
-        samcli.lib.logs.event.LogEvent
-            Object containing the information from each log event returned by CloudWatch Logs
         """
 
         # On every poll, startTime of the API call is the timestamp of last record observed

--- a/samcli/lib/logs/formatter.py
+++ b/samcli/lib/logs/formatter.py
@@ -16,9 +16,7 @@ except ImportError:
 
 
 class LogsFormatter:
-    """
-    Formats log messages returned by CloudWatch Logs service.
-    """
+    """Formats log messages returned by CloudWatch Logs service."""
 
     def __init__(self, colored, formatter_chain=None):
         """
@@ -48,16 +46,11 @@ class LogsFormatter:
                 ----------
                 event : samcli.lib.logs.event.LogEvent
                     Log event to format
-
                 colored : samcli.lib.utils.colors.Colored
                     Instance of ``Colored`` object to add colors to the message
 
                 Returns
                 -------
-                samcli.lib.logs.event.LogEvent
-                    Object representing the log event that has been formatted. It could be the same event object passed
-                    via input.
-                \"""
 
                 # Do your formatting
 
@@ -81,8 +74,7 @@ class LogsFormatter:
         self.formatter_chain.append(LogsFormatter._pretty_print_event)
 
     def do_format(self, event_iterable):
-        """
-        Formats the given CloudWatch Logs Event dictionary as necessary and returns an iterable that will
+        """Formats the given CloudWatch Logs Event dictionary as necessary and returns an iterable that will
         return the formatted string. This can be used to parse and format the events based on context
         ie. In Lambda Function logs, a formatter may wish to color the "ERROR" keywords red,
         or highlight a filter keyword separately etc.
@@ -98,8 +90,8 @@ class LogsFormatter:
 
         Returns
         -------
-        iterable of string
-            Iterable that returns a formatted event as a string.
+
+
         """
 
         for operation in self.formatter_chain:
@@ -112,8 +104,18 @@ class LogsFormatter:
 
     @staticmethod
     def _pretty_print_event(event, colored):
-        """
-        Basic formatter to convert an event object to string
+        """Basic formatter to convert an event object to string
+
+        Parameters
+        ----------
+        event :
+
+        colored :
+
+
+        Returns
+        -------
+
         """
         event.timestamp = colored.yellow(event.timestamp)
         event.log_stream_name = colored.cyan(event.log_stream_name)
@@ -122,18 +124,34 @@ class LogsFormatter:
 
 
 class LambdaLogMsgFormatters:
-    """
-    Format logs printed by AWS Lambda functions.
+    """Format logs printed by AWS Lambda functions.
 
     This class is a collection of static methods that can be used within a formatter chain.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     @staticmethod
     def colorize_errors(event, colored):
-        """
-        Highlights some commonly known Lambda error cases in red:
+        """Highlights some commonly known Lambda error cases in red:
             - Nodejs process crashes
             - Lambda function timeouts
+
+        Parameters
+        ----------
+        event :
+
+        colored :
+
+
+        Returns
+        -------
+
         """
 
         nodejs_crash_msg = "Process exited before completing request"
@@ -146,16 +164,24 @@ class LambdaLogMsgFormatters:
 
 
 class KeywordHighlighter:
-    """
-    Highlight certain keywords in the log line
-    """
+    """Highlight certain keywords in the log line"""
 
     def __init__(self, keyword=None):
         self.keyword = keyword
 
     def highlight_keywords(self, event, colored):
-        """
-        Highlight the keyword in the log statement by drawing an underline
+        """Highlight the keyword in the log statement by drawing an underline
+
+        Parameters
+        ----------
+        event :
+
+        colored :
+
+
+        Returns
+        -------
+
         """
         if self.keyword:
             highlight = colored.underline(self.keyword)
@@ -165,15 +191,23 @@ class KeywordHighlighter:
 
 
 class JSONMsgFormatter:
-    """
-    Pretty print JSONs within a message
-    """
+    """Pretty print JSONs within a message"""
 
     @staticmethod
     def format_json(event, colored):
-        """
-        If the event message is a JSON string, then pretty print the JSON with 2 indents and sort the keys. This makes
+        """If the event message is a JSON string, then pretty print the JSON with 2 indents and sort the keys. This makes
         it very easy to visually parse and search JSON data
+
+        Parameters
+        ----------
+        event :
+
+        colored :
+
+
+        Returns
+        -------
+
         """
 
         try:

--- a/samcli/lib/logs/provider.py
+++ b/samcli/lib/logs/provider.py
@@ -4,14 +4,11 @@ Discover & provide the log group name
 
 
 class LogGroupProvider:
-    """
-    Resolve the name of log group given the name of the resource
-    """
+    """Resolve the name of log group given the name of the resource"""
 
     @staticmethod
     def for_lambda_function(function_name):
-        """
-        Returns the CloudWatch Log Group Name created by default for the AWS Lambda function with given name
+        """Returns the CloudWatch Log Group Name created by default for the AWS Lambda function with given name
 
         Parameters
         ----------
@@ -20,7 +17,7 @@ class LogGroupProvider:
 
         Returns
         -------
-        str
-            Default Log Group name used by this function
+
+
         """
         return "/aws/lambda/{}".format(function_name)

--- a/samcli/lib/package/s3_uploader.py
+++ b/samcli/lib/package/s3_uploader.py
@@ -33,16 +33,20 @@ LOG = logging.getLogger(__name__)
 
 
 class S3Uploader:
-    """
-    Class to upload objects to S3 bucket that use versioning. If bucket
+    """Class to upload objects to S3 bucket that use versioning. If bucket
     does not already use versioning, this class will turn on versioning.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     @property
     def artifact_metadata(self):
-        """
-        Metadata to attach to the object(s) uploaded by the uploader.
-        """
+        """Metadata to attach to the object(s) uploaded by the uploader."""
         return self._artifact_metadata
 
     @artifact_metadata.setter
@@ -62,11 +66,20 @@ class S3Uploader:
         self._artifact_metadata = None
 
     def upload(self, file_name, remote_path):
-        """
-        Uploads given file to S3
-        :param file_name: Path to the file that will be uploaded
-        :param remote_path:  be uploaded
-        :return: VersionId of the latest upload
+        """Uploads given file to S3
+
+        Parameters
+        ----------
+        file_name :
+            Path to the file that will be uploaded
+        remote_path :
+            be uploaded
+
+        Returns
+        -------
+        type
+            VersionId of the latest upload
+
         """
 
         if self.prefix:
@@ -107,12 +120,20 @@ class S3Uploader:
             raise ex
 
     def upload_with_dedup(self, file_name, extension=None):
-        """
-        Makes and returns name of the S3 object based on the file's MD5 sum
+        """Makes and returns name of the S3 object based on the file's MD5 sum
 
-        :param file_name: file to upload
-        :param extension: String of file extension to append to the object
-        :return: S3 URL of the uploaded object
+        Parameters
+        ----------
+        file_name :
+            file to upload
+        extension :
+            String of file extension to append to the object (Default value = None)
+
+        Returns
+        -------
+        type
+            S3 URL of the uploaded object
+
         """
 
         # This construction of remote_path is critical to preventing duplicate
@@ -127,11 +148,18 @@ class S3Uploader:
         return self.upload(file_name, remote_path)
 
     def file_exists(self, remote_path):
-        """
-        Check if the file we are trying to upload already exists in S3
+        """Check if the file we are trying to upload already exists in S3
 
-        :param remote_path:
-        :return: True, if file exists. False, otherwise
+        Parameters
+        ----------
+        remote_path :
+            return: True, if file exists. False, otherwise
+
+        Returns
+        -------
+        type
+            True, if file exists. False, otherwise
+
         """
 
         try:
@@ -172,9 +200,19 @@ class S3Uploader:
             return md5.hexdigest()
 
     def to_path_style_s3_url(self, key, version=None):
-        """
-            This link describes the format of Path Style URLs
+        """This link describes the format of Path Style URLs
             http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro
+
+        Parameters
+        ----------
+        key :
+
+        version :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         base = self.s3.meta.endpoint_url
         result = "{0}/{1}/{2}".format(base, self.bucket_name, key)

--- a/samcli/lib/providers/api_collector.py
+++ b/samcli/lib/providers/api_collector.py
@@ -42,29 +42,35 @@ class ApiCollector:
             yield logical_id, self._get_routes(logical_id)
 
     def add_routes(self, logical_id, routes):
-        """
-        Stores the given routes tagged under the given logicalId
+        """Stores the given routes tagged under the given logicalId
+
         Parameters
         ----------
-        logical_id : str
-            LogicalId of the AWS::Serverless::Api or AWS::ApiGateway::RestApi resource
-        routes : list of samcli.commands.local.agiw.local_apigw_service.Route
-            List of routes available in this resource
+        logical_id :
+
+        routes :
+
+
+        Returns
+        -------
+
+
         """
         self._get_routes(logical_id).extend(routes)
 
     def _get_routes(self, logical_id):
-        """
-        Returns the properties of resource with given logical ID. If a resource is not found, then it returns an
+        """Returns the properties of resource with given logical ID. If a resource is not found, then it returns an
         empty data.
+
         Parameters
         ----------
         logical_id : str
-            Logical ID of the resource
+
+
         Returns
         -------
-        samcli.commands.local.lib.Routes
-            Properties object for this resource.
+
+
         """
 
         return self._route_per_resource[logical_id]
@@ -78,12 +84,17 @@ class ApiCollector:
         self._routes = routes
 
     def all_routes(self):
-        """
-        Gets all the routes within the _route_per_resource
+        """Gets all the routes within the _route_per_resource
 
-        Return
+        Parameters
+        ----------
+
+        Returns
         -------
-        All the routes within the _route_per_resource
+        type
+            -------
+            All the routes within the _route_per_resource
+
         """
         routes = []
         for logical_id in self._route_per_resource.keys():
@@ -91,16 +102,21 @@ class ApiCollector:
         return routes
 
     def get_api(self):
-        """
-        Creates the api using the parts from the ApiCollector. The routes are also deduped so that there is no
+        """Creates the api using the parts from the ApiCollector. The routes are also deduped so that there is no
         duplicate routes with the same function name, path, but different method.
 
         The normalised_routes are the routes that have been processed. By default, this will get all the routes.
         However, it can be changed to override the default value of normalised routes such as in SamApiProvider
 
-        Return
+        Parameters
+        ----------
+
+        Returns
         -------
-        An Api object with all the properties
+        type
+            -------
+            An Api object with all the properties
+
         """
         api = Api()
         routes = self.dedupe_function_routes(self.routes)
@@ -114,20 +130,19 @@ class ApiCollector:
 
     @staticmethod
     def normalize_cors_methods(routes, cors):
-        """
-        Adds OPTIONS method to all the route methods if cors exists
+        """Adds OPTIONS method to all the route methods if cors exists
 
         Parameters
-        -----------
-        routes: list(samcli.local.apigw.local_apigw_service.Route)
-            List of Routes
+        ----------
+        routes :
 
-        cors: samcli.commands.local.lib.provider.Cors
-            the cors object for the api
+        cors :
 
-        Return
+
+        Returns
         -------
-        A list of routes without duplicate routes with the same function_name and method
+
+
         """
 
         def add_options_to_route(route):
@@ -139,15 +154,22 @@ class ApiCollector:
 
     @staticmethod
     def dedupe_function_routes(routes):
-        """
-        Remove duplicate routes that have the same function_name and method
+        """Remove duplicate routes that have the same function_name and method
 
         route: list(Route)
             List of Routes
 
-       Return
-       -------
-       A list of routes without duplicate routes with the same function_name and method
+        Parameters
+        ----------
+        routes :
+
+
+        Returns
+        -------
+        type
+            -------
+            A list of routes without duplicate routes with the same function_name and method
+
         """
         grouped_routes = {}
 
@@ -162,19 +184,19 @@ class ApiCollector:
         return list(grouped_routes.values())
 
     def add_binary_media_types(self, logical_id, binary_media_types):
-        """
-        Stores the binary media type configuration for the API with given logical ID
+        """Stores the binary media type configuration for the API with given logical ID
+
         Parameters
         ----------
+        logical_id :
 
-        logical_id : str
-            LogicalId of the AWS::Serverless::Api resource
+        binary_media_types :
 
-        api: samcli.commands.local.lib.provider.Api
-            Instance of the Api which will save all the api configurations
 
-        binary_media_types : list of str
-            List of binary media types supported by this resource
+        Returns
+        -------
+
+
         """
 
         binary_media_types = binary_media_types or []
@@ -189,17 +211,18 @@ class ApiCollector:
 
     @staticmethod
     def normalize_binary_media_type(value):
-        """
-        Converts binary media types values to the canonical format. Ex: image~1gif -> image/gif. If the value is not
+        """Converts binary media types values to the canonical format. Ex: image~1gif -> image/gif. If the value is not
         a string, then this method just returns None
+
         Parameters
         ----------
         value : str
-            Value to be normalized
+
+
         Returns
         -------
-        str or None
-            Normalized value. If the input was not a string, then None is returned
+
+
         """
 
         if not isinstance(value, string_types):

--- a/samcli/lib/providers/api_provider.py
+++ b/samcli/lib/providers/api_provider.py
@@ -14,22 +14,21 @@ LOG = logging.getLogger(__name__)
 
 class ApiProvider(AbstractApiProvider):
     def __init__(self, template_dict, parameter_overrides=None, cwd=None):
-        """
-        Initialize the class with template data. The template_dict is assumed
-        to be valid, normalized and a dictionary. template_dict should be normalized by running any and all
-        pre-processing before passing to this class.
-        This class does not perform any syntactic validation of the template.
+        """Initialize the class with template data. The template_dict is assumed
+            to be valid, normalized and a dictionary. template_dict should be normalized by running any and all
+            pre-processing before passing to this class.
+            This class does not perform any syntactic validation of the template.
 
-        After the class is initialized, changes to ``template_dict`` will not be reflected in here.
-        You will need to explicitly update the class with new template, if necessary.
+            After the class is initialized, changes to ``template_dict`` will not be reflected in here.
+            You will need to explicitly update the class with new template, if necessary.
 
         Parameters
         ----------
-        template_dict : dict
-            Template as a dictionary
 
-        cwd : str
-            Optional working directory with respect to which we will resolve relative path to Swagger file
+        Returns
+        -------
+
+
         """
         self.template_dict = SamBaseProvider.get_template(template_dict, parameter_overrides)
         self.resources = self.template_dict.get("Resources", {})
@@ -43,26 +42,33 @@ class ApiProvider(AbstractApiProvider):
         LOG.debug("%d APIs found in the template", len(self.routes))
 
     def get_all(self):
-        """
-        Yields all the Apis in the current Provider
+        """Yields all the Apis in the current Provider
 
         :yields api: an Api object with routes and properties
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         yield self.api
 
     def _extract_api(self, resources):
-        """
-        Extracts all the routes by running through the one providers. The provider that has the first type matched
+        """Extracts all the routes by running through the one providers. The provider that has the first type matched
         will be run across all the resources
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        resources : dict
+
+
         Returns
-        ---------
-        An Api from the parsed template
+        -------
+
+
         """
 
         collector = ApiCollector()
@@ -72,17 +78,17 @@ class ApiProvider(AbstractApiProvider):
 
     @staticmethod
     def find_api_provider(resources):
-        """
-        Finds the ApiProvider given the first api type of the resource
+        """Finds the ApiProvider given the first api type of the resource
 
         Parameters
-        -----------
-        resources: dict
-            The dictionary containing the different resources within the template
-
-        Return
         ----------
-        Instance of the ApiProvider that will be run on the template with a default of SamApiProvider
+        resources :
+
+
+        Returns
+        -------
+
+
         """
         for _, resource in resources.items():
             if resource.get(CfnBaseApiProvider.RESOURCE_TYPE) in SamApiProvider.TYPES:

--- a/samcli/lib/providers/cfn_api_provider.py
+++ b/samcli/lib/providers/cfn_api_provider.py
@@ -20,23 +20,21 @@ class CfnApiProvider(CfnBaseApiProvider):
     TYPES = [APIGATEWAY_RESTAPI, APIGATEWAY_STAGE, APIGATEWAY_RESOURCE, APIGATEWAY_METHOD]
 
     def extract_resources(self, resources, collector, cwd=None):
-        """
-        Extract the Route Object from a given resource and adds it to the RouteCollector.
+        """Extract the Route Object from a given resource and adds it to the RouteCollector.
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        resources :
 
-        collector: samcli.commands.local.lib.route_collector.RouteCollector
-            Instance of the API collector that where we will save the API information
+        collector :
 
-        cwd : str
-            Optional working directory with respect to which we will resolve relative path to Swagger file
+        cwd :
+             (Default value = None)
 
-        Return
+        Returns
         -------
-        Returns a list of routes
+
+
         """
 
         for logical_id, resource in resources.items():
@@ -56,20 +54,24 @@ class CfnApiProvider(CfnBaseApiProvider):
         return all_apis
 
     def _extract_cloud_formation_route(self, logical_id, api_resource, collector, cwd=None):
-        """
-        Extract APIs from AWS::ApiGateway::RestApi resource by reading and parsing Swagger documents. The result is
+        """Extract APIs from AWS::ApiGateway::RestApi resource by reading and parsing Swagger documents. The result is
         added to the collector.
 
         Parameters
         ----------
-        logical_id : str
-            Logical ID of the resource
+        logical_id :
 
-        api_resource : dict
-            Resource definition, including its properties
+        api_resource :
 
-        collector : ApiCollector
-            Instance of the API collector that where we will save the API information
+        collector :
+
+        cwd :
+             (Default value = None)
+
+        Returns
+        -------
+
+
         """
         properties = api_resource.get("Properties", {})
         body = properties.get("Body")
@@ -84,18 +86,21 @@ class CfnApiProvider(CfnBaseApiProvider):
 
     @staticmethod
     def _extract_cloud_formation_stage(resources, stage_resource, collector):
-        """
-        Extract the stage from AWS::ApiGateway::Stage resource by reading and adds it to the collector.
+        """Extract the stage from AWS::ApiGateway::Stage resource by reading and adds it to the collector.
+
         Parameters
-       ----------
-        resources: dict
-            All Resource definition, including its properties
+        ----------
+        resources :
 
-        stage_resource : dict
-            Stage Resource definition, including its properties
+        stage_resource :
 
-        collector : ApiCollector
-            Instance of the API collector that where we will save the API information
+        collector :
+
+
+        Returns
+        -------
+
+
         """
         properties = stage_resource.get("Properties", {})
         stage_name = properties.get("StageName")
@@ -116,22 +121,23 @@ class CfnApiProvider(CfnBaseApiProvider):
         collector.stage_variables = stage_variables
 
     def _extract_cloud_formation_method(self, resources, logical_id, method_resource, collector):
-        """
-        Extract APIs from AWS::ApiGateway::Method and work backwards up the tree to resolve and find the true path.
+        """Extract APIs from AWS::ApiGateway::Method and work backwards up the tree to resolve and find the true path.
 
         Parameters
         ----------
-        resources: dict
-            All Resource definition, including its properties
+        resources :
 
-        logical_id : str
-            Logical ID of the resource
+        logical_id :
 
-        method_resource : dict
-            Resource definition, including its properties
+        method_resource :
 
-        collector : ApiCollector
-            Instance of the API collector that where we will save the API information
+        collector :
+
+
+        Returns
+        -------
+
+
         """
 
         properties = method_resource.get("Properties", {})
@@ -163,19 +169,21 @@ class CfnApiProvider(CfnBaseApiProvider):
         collector.add_routes(rest_api_id, [routes])
 
     def resolve_resource_path(self, resources, resource, current_path):
-        """
-        Extract path from the Resource object by going up the tree
+        """Extract path from the Resource object by going up the tree
 
         Parameters
         ----------
-        resources: dict
-            Dictionary containing all the resources to resolve
+        resources :
 
-        resource : dict
-            AWS::ApiGateway::Resource definition and its properties
+        resource :
 
-        current_path : str
-            Current path resolved so far
+        current_path :
+
+
+        Returns
+        -------
+
+
         """
 
         properties = resource.get("Properties", {})
@@ -191,8 +199,7 @@ class CfnApiProvider(CfnBaseApiProvider):
 
     @staticmethod
     def _get_integration_function_name(integration):
-        """
-        Tries to parse the Lambda Function name from the Integration defined in the method configuration. Integration
+        """Tries to parse the Lambda Function name from the Integration defined in the method configuration. Integration
         configuration. We care only about Lambda integrations, which are of type aws_proxy, and ignore the rest.
         Integration URI is complex and hard to parse. Hence we do our best to extract function name out of
         integration URI. If not possible, we return None.
@@ -201,11 +208,13 @@ class CfnApiProvider(CfnBaseApiProvider):
         ----------
         method_config : dict
             Dictionary containing the method configuration which might contain integration settings
+        integration :
+
 
         Returns
         -------
-        string or None
-            Lambda function name, if possible. None, if not.
+
+
         """
 
         if integration and isinstance(integration, dict):

--- a/samcli/lib/providers/cfn_base_api_provider.py
+++ b/samcli/lib/providers/cfn_base_api_provider.py
@@ -11,49 +11,46 @@ class CfnBaseApiProvider:
     RESOURCE_TYPE = "Type"
 
     def extract_resources(self, resources, collector, cwd=None):
-        """
-        Extract the Route Object from a given resource and adds it to the RouteCollector.
+        """Extract the Route Object from a given resource and adds it to the RouteCollector.
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        resources :
 
-        collector: samcli.commands.local.lib.route_collector.RouteCollector
-            Instance of the API collector that where we will save the API information
+        collector :
 
-        cwd : str
-            Optional working directory with respect to which we will resolve relative path to Swagger file
+        cwd :
+             (Default value = None)
 
-        Return
+        Returns
         -------
-        Returns a list of routes
+
+
         """
         raise NotImplementedError("not implemented")
 
     def extract_swagger_route(self, logical_id, body, uri, binary_media, collector, cwd=None):
-        """
-        Parse the Swagger documents and adds it to the ApiCollector.
+        """Parse the Swagger documents and adds it to the ApiCollector.
 
         Parameters
         ----------
-        logical_id : str
-            Logical ID of the resource
+        logical_id :
 
-        body : dict
-            The body of the RestApi
+        body :
 
-        uri : str or dict
-            The url to location of the RestApi
+        uri :
 
-        binary_media: list
-            The link to the binary media
+        binary_media :
 
-        collector: samcli.commands.local.lib.route_collector.RouteCollector
-            Instance of the Route collector that where we will save the route information
+        collector :
 
-        cwd : str
-            Optional working directory with respect to which we will resolve relative path to Swagger file
+        cwd :
+             (Default value = None)
+
+        Returns
+        -------
+
+
         """
         reader = SwaggerReader(definition_body=body, definition_uri=uri, working_dir=cwd)
         swagger = reader.read()

--- a/samcli/lib/providers/exceptions.py
+++ b/samcli/lib/providers/exceptions.py
@@ -4,9 +4,7 @@ Exceptions used by providers
 
 
 class InvalidLayerReference(Exception):
-    """
-    Raised when the LayerVersion LogicalId does not exist in the template
-    """
+    """ """
 
     def __init__(self):
         super(InvalidLayerReference, self).__init__(

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -36,9 +36,7 @@ Function = namedtuple(
 
 
 class LayerVersion:
-    """
-    Represents the LayerVersion Resource for AWS Lambda
-    """
+    """Represents the LayerVersion Resource for AWS Lambda"""
 
     LAYER_NAME_DELIMETER = "-"
 
@@ -63,20 +61,22 @@ class LayerVersion:
 
     @staticmethod
     def _compute_layer_version(is_defined_within_template, arn):
-        """
-        Parses out the Layer version from the arn
+        """Parses out the Layer version from the arn
 
         Parameters
         ----------
-        is_defined_within_template bool
+        is_defined_within_template bool :
             True if the resource is a Ref to a resource otherwise False
-        arn str
+        arn str :
             ARN of the Resource
+        is_defined_within_template :
+
+        arn :
+
 
         Returns
         -------
-        int
-            The Version of the LayerVersion
+
 
         """
 
@@ -93,23 +93,26 @@ class LayerVersion:
 
     @staticmethod
     def _compute_layer_name(is_defined_within_template, arn):
-        """
-        Computes a unique name based on the LayerVersion Arn
+        """Computes a unique name based on the LayerVersion Arn
 
         Format:
         <Name of the LayerVersion>-<Version of the LayerVersion>-<sha256 of the arn>
 
         Parameters
         ----------
-        is_defined_within_template bool
+        is_defined_within_template bool :
             True if the resource is a Ref to a resource otherwise False
-        arn str
+        arn str :
             ARN of the Resource
+        is_defined_within_template :
+
+        arn :
+
 
         Returns
         -------
-        str
-            A unique name that represents the LayerVersion
+
+
         """
 
         # If the Layer is defined in the template, the arn will represent the LogicalId of the LayerVersion Resource,
@@ -132,16 +135,18 @@ class LayerVersion:
 
     @property
     def name(self):
-        """
-        A unique name from the arn or logical id of the Layer
+        """A unique name from the arn or logical id of the Layer
 
         A LayerVersion Arn example:
         arn:aws:lambda:region:account-id:layer:layer-name:version
 
+        Parameters
+        ----------
+
         Returns
         -------
-        str
-            A name of the Layer that is used on the system to uniquely identify the layer
+
+
         """
         return self._name
 
@@ -170,24 +175,36 @@ class LayerVersion:
 
 
 class FunctionProvider:
-    """
-    Abstract base class of the function provider.
-    """
+    """Abstract base class of the function provider."""
 
     def get(self, name):
-        """
-        Given name of the function, this method must return the Function object
+        """Given name of the function, this method must return the Function object
 
-        :param string name: Name of the function
-        :return Function: namedtuple containing the Function information
+        Parameters
+        ----------
+        string :
+            name: Name of the function
+            :return Function: namedtuple containing the Function information
+        name :
+
+
+        Returns
+        -------
+
         """
         raise NotImplementedError("not implemented")
 
     def get_all(self):
-        """
-        Yields all the Lambda functions available in the provider.
+        """Yields all the Lambda functions available in the provider.
 
         :yields Function: namedtuple containing the function information
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         raise NotImplementedError("not implemented")
 
@@ -234,15 +251,19 @@ _CorsTuple.__new__.__defaults__ = (
 class Cors(_CorsTuple):
     @staticmethod
     def cors_to_headers(cors):
-        """
-        Convert CORS object to headers dictionary
+        """Convert CORS object to headers dictionary
+
         Parameters
         ----------
-        cors list(samcli.commands.local.lib.provider.Cors)
-            CORS configuration objcet
+        cors list(samcli.commands.local.lib.provider.Cors) :
+
+        cors :
+
+
         Returns
         -------
-            Dictionary with CORS headers
+
+
         """
         if not cors:
             return {}
@@ -258,14 +279,18 @@ class Cors(_CorsTuple):
 
 
 class AbstractApiProvider:
-    """
-    Abstract base class to return APIs and the functions they route to
-    """
+    """Abstract base class to return APIs and the functions they route to"""
 
     def get_all(self):
-        """
-        Yields all the APIs available.
+        """Yields all the APIs available.
 
         :yields Api: namedtuple containing the API information
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         raise NotImplementedError("not implemented")

--- a/samcli/lib/providers/sam_api_provider.py
+++ b/samcli/lib/providers/sam_api_provider.py
@@ -24,19 +24,20 @@ class SamApiProvider(CfnBaseApiProvider):
     IMPLICIT_API_RESOURCE_ID = "ServerlessRestApi"
 
     def extract_resources(self, resources, collector, cwd=None):
-        """
-        Extract the Route Object from a given resource and adds it to the RouteCollector.
+        """Extract the Route Object from a given resource and adds it to the RouteCollector.
 
         Parameters
         ----------
-        resources: dict
-            The dictionary containing the different resources within the template
+        resources :
 
-        collector: samcli.commands.local.lib.route_collector.ApiCollector
-            Instance of the API collector that where we will save the API information
+        collector :
 
-        cwd : str
-            Optional working directory with respect to which we will resolve relative path to Swagger file
+        cwd :
+             (Default value = None)
+
+        Returns
+        -------
+
 
         """
         # AWS::Serverless::Function is currently included when parsing of Apis because when SamBaseProvider is run on
@@ -53,23 +54,23 @@ class SamApiProvider(CfnBaseApiProvider):
         collector.routes = self.merge_routes(collector)
 
     def _extract_from_serverless_api(self, logical_id, api_resource, collector, cwd=None):
-        """
-        Extract APIs from AWS::Serverless::Api resource by reading and parsing Swagger documents. The result is added
+        """Extract APIs from AWS::Serverless::Api resource by reading and parsing Swagger documents. The result is added
         to the collector.
 
         Parameters
         ----------
-        logical_id : str
-            Logical ID of the resource
+        logical_id :
 
-        api_resource : dict
-            Resource definition, including its properties
+        api_resource :
 
-        collector: samcli.commands.local.lib.route_collector.RouteCollector
-            Instance of the API collector that where we will save the API information
+        collector :
 
-        cwd : str
-            Optional working directory with respect to which we will resolve relative path to Swagger file
+        cwd :
+             (Default value = None)
+
+        Returns
+        -------
+
 
         """
 
@@ -92,14 +93,18 @@ class SamApiProvider(CfnBaseApiProvider):
         collector.cors = cors
 
     def extract_cors(self, cors_prop):
-        """
-        Extract Cors property from AWS::Serverless::Api resource by reading and parsing Swagger documents. The result
+        """Extract Cors property from AWS::Serverless::Api resource by reading and parsing Swagger documents. The result
         is added to the Api.
 
         Parameters
         ----------
-        cors_prop : dict
-            Resource properties for Cors
+        cors_prop :
+
+
+        Returns
+        -------
+
+
         """
         cors = None
         if cors_prop and isinstance(cors_prop, dict):
@@ -134,17 +139,19 @@ class SamApiProvider(CfnBaseApiProvider):
 
     @staticmethod
     def _get_cors_prop(cors_dict, prop_name):
-        """
-        Extract cors properties from dictionary and remove extra quotes.
+        """Extract cors properties from dictionary and remove extra quotes.
 
         Parameters
         ----------
-        cors_dict : dict
-            Resource properties for Cors
+        cors_dict :
 
-        Return
-        ------
-        A string with the extra quotes removed
+        prop_name :
+
+
+        Returns
+        -------
+
+
         """
         prop = cors_dict.get(prop_name)
         if prop:
@@ -157,17 +164,17 @@ class SamApiProvider(CfnBaseApiProvider):
 
     @staticmethod
     def normalize_cors_allow_methods(allow_methods):
-        """
-        Normalize cors AllowMethods and Options to the methods if it's missing.
+        """Normalize cors AllowMethods and Options to the methods if it's missing.
 
         Parameters
         ----------
-        allow_methods : str
-            The allow_methods string provided in the query
+        allow_methods :
 
-        Return
+
+        Returns
         -------
-        A string with normalized route
+
+
         """
         if allow_methods == "*":
             return ",".join(sorted(Route.ANY_HTTP_METHODS))
@@ -185,19 +192,21 @@ class SamApiProvider(CfnBaseApiProvider):
         return ",".join(sorted(normalized_methods))
 
     def _extract_routes_from_function(self, logical_id, function_resource, collector):
-        """
-        Fetches a list of routes configured for this SAM Function resource.
+        """Fetches a list of routes configured for this SAM Function resource.
 
         Parameters
         ----------
-        logical_id : str
-            Logical ID of the resourc
+        logical_id :
 
-        function_resource : dict
-            Contents of the function resource including its properties
+        function_resource :
 
-        collector: samcli.commands.local.lib.route_collector.RouteCollector
-            Instance of the API collector that where we will save the API information
+        collector :
+
+
+        Returns
+        -------
+
+
         """
 
         resource_properties = function_resource.get("Properties", {})
@@ -205,20 +214,22 @@ class SamApiProvider(CfnBaseApiProvider):
         self.extract_routes_from_events(logical_id, serverless_function_events, collector)
 
     def extract_routes_from_events(self, function_logical_id, serverless_function_events, collector):
-        """
-        Given an AWS::Serverless::Function Event Dictionary, extract out all 'route' events and store  within the
+        """Given an AWS::Serverless::Function Event Dictionary, extract out all 'route' events and store  within the
         collector
 
         Parameters
         ----------
-        function_logical_id : str
-            LogicalId of the AWS::Serverless::Function
+        function_logical_id :
 
-        serverless_function_events : dict
-            Event Dictionary of a AWS::Serverless::Function
+        serverless_function_events :
 
-        collector: samcli.commands.local.lib.route_collector.RouteCollector
-            Instance of the Route collector that where we will save the route information
+        collector :
+
+
+        Returns
+        -------
+
+
         """
         count = 0
         for _, event in serverless_function_events.items():
@@ -232,12 +243,23 @@ class SamApiProvider(CfnBaseApiProvider):
 
     @staticmethod
     def _convert_event_route(lambda_logical_id, event_properties):
-        """
-        Converts a AWS::Serverless::Function's Event Property to an Route configuration usable by the provider.
+        """Converts a AWS::Serverless::Function's Event Property to an Route configuration usable by the provider.
 
-        :param str lambda_logical_id: Logical Id of the AWS::Serverless::Function
-        :param dict event_properties: Dictionary of the Event's Property
-        :return tuple: tuple of route resource name and route
+        Parameters
+        ----------
+        str :
+            lambda_logical_id: Logical Id of the AWS::Serverless::Function
+        dict :
+            event_properties: Dictionary of the Event's Property
+            :return tuple: tuple of route resource name and route
+        lambda_logical_id :
+
+        event_properties :
+
+
+        Returns
+        -------
+
         """
         path = event_properties.get(SamApiProvider._EVENT_PATH)
         method = event_properties.get(SamApiProvider._EVENT_METHOD)
@@ -261,21 +283,20 @@ class SamApiProvider(CfnBaseApiProvider):
 
     @staticmethod
     def merge_routes(collector):
-        """
-        Quite often, an API is defined both in Implicit and Explicit Route definitions. In such cases, Implicit API
+        """Quite often, an API is defined both in Implicit and Explicit Route definitions. In such cases, Implicit API
         definition wins because that conveys clear intent that the API is backed by a function. This method will
         merge two such list of routes with the right order of precedence. If a Path+Method combination is defined
         in both the places, only one wins.
 
         Parameters
         ----------
-        collector: samcli.commands.local.lib.route_collector.RouteCollector
+        collector : samcli.commands.local.lib.route_collector.RouteCollector
             Collector object that holds all the APIs specified in the template
 
         Returns
         -------
-        list of samcli.local.apigw.local_apigw_service.Route
-            List of routes obtained by combining both the input lists.
+
+
         """
 
         implicit_routes = []

--- a/samcli/lib/providers/sam_base_provider.py
+++ b/samcli/lib/providers/sam_base_provider.py
@@ -13,28 +13,24 @@ LOG = logging.getLogger(__name__)
 
 
 class SamBaseProvider:
-    """
-    Base class for SAM Template providers
-    """
+    """Base class for SAM Template providers"""
 
     @staticmethod
     def get_template(template_dict, parameter_overrides=None):
-        """
-        Given a SAM template dictionary, return a cleaned copy of the template where SAM plugins have been run
+        """Given a SAM template dictionary, return a cleaned copy of the template where SAM plugins have been run
         and parameter values have been substituted.
 
         Parameters
         ----------
         template_dict : dict
             unprocessed SAM template dictionary
-
-        parameter_overrides: dict
-            Optional dictionary of values for template parameters
+        parameter_overrides : dict
+            Optional dictionary of values for template parameters (Default value = None)
 
         Returns
         -------
-        dict
-            Processed SAM template
+
+
         """
         template_dict = template_dict or {}
         if template_dict:
@@ -51,22 +47,20 @@ class SamBaseProvider:
 
     @staticmethod
     def _get_parameter_values(template_dict, parameter_overrides):
-        """
-        Construct a final list of values for CloudFormation template parameters based on user-supplied values,
+        """Construct a final list of values for CloudFormation template parameters based on user-supplied values,
         default values provided in template, and sane defaults for pseudo-parameters.
 
         Parameters
         ----------
         template_dict : dict
             SAM template dictionary
-
         parameter_overrides : dict
             User-supplied values for CloudFormation template parameters
 
         Returns
         -------
-        dict
-            Values for template parameters to substitute in template with
+
+
         """
 
         default_values = SamBaseProvider._get_default_parameter_values(template_dict)
@@ -82,8 +76,7 @@ class SamBaseProvider:
 
     @staticmethod
     def _get_default_parameter_values(sam_template):
-        """
-        Method to read default values for template parameters and return it
+        """Method to read default values for template parameters and return it
         Example:
         If the template contains the following parameters defined
         Parameters:
@@ -99,8 +92,18 @@ class SamBaseProvider:
             Param1: "default_value1",
             Param2: "default_value2"
         }
-        :param dict sam_template: SAM template
-        :return dict: Default values for parameters
+
+        Parameters
+        ----------
+        dict :
+            sam_template: SAM template
+            :return dict: Default values for parameters
+        sam_template :
+
+
+        Returns
+        -------
+
         """
 
         default_values = {}

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -12,11 +12,17 @@ LOG = logging.getLogger(__name__)
 
 
 class SamFunctionProvider(FunctionProvider):
-    """
-    Fetches and returns Lambda Functions from a SAM Template. The SAM template passed to this provider is assumed
+    """Fetches and returns Lambda Functions from a SAM Template. The SAM template passed to this provider is assumed
     to be valid, normalized and a dictionary.
 
     It may or may not contain a function.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     _SERVERLESS_FUNCTION = "AWS::Serverless::Function"
@@ -50,15 +56,27 @@ class SamFunctionProvider(FunctionProvider):
         self.functions = self._extract_functions(self.resources)
 
     def get(self, name):
-        """
-        Returns the function given name or LogicalId of the function. Every SAM resource has a logicalId, but it may
+        """Returns the function given name or LogicalId of the function. Every SAM resource has a logicalId, but it may
         also have a function name. This method searches only for LogicalID and returns the function that matches
         it.
 
-        :param string name: Name of the function
-        :return Function: namedtuple containing the Function information if function is found.
-                          None, if function is not found
-        :raises ValueError If name is not given
+        Parameters
+        ----------
+        string :
+            name: Name of the function
+            :return Function: namedtuple containing the Function information if function is found.
+            None, if function is not found
+        name :
+
+
+        Returns
+        -------
+
+        Raises
+        ------
+        ValueError
+            If name is not given
+
         """
 
         if not name:
@@ -67,10 +85,16 @@ class SamFunctionProvider(FunctionProvider):
         return self.functions.get(name)
 
     def get_all(self):
-        """
-        Yields all the Lambda functions available in the SAM Template.
+        """Yields all the Lambda functions available in the SAM Template.
 
         :yields Function: namedtuple containing the function information
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         for _, function in self.functions.items():
@@ -78,13 +102,21 @@ class SamFunctionProvider(FunctionProvider):
 
     @staticmethod
     def _extract_functions(resources):
-        """
-        Extracts and returns function information from the given dictionary of SAM/CloudFormation resources. This
+        """Extracts and returns function information from the given dictionary of SAM/CloudFormation resources. This
         method supports functions defined with AWS::Serverless::Function and AWS::Lambda::Function
 
-        :param dict resources: Dictionary of SAM/CloudFormation resources
-        :return dict(string : samcli.commands.local.lib.provider.Function): Dictionary of function LogicalId to the
+        Parameters
+        ----------
+        dict :
+            resources: Dictionary of SAM/CloudFormation resources
+            :return dict(string : samcli.commands.local.lib.provider.Function): Dictionary of function LogicalId to the
             Function configuration object
+        resources :
+
+
+        Returns
+        -------
+
         """
 
         result = {}
@@ -108,13 +140,26 @@ class SamFunctionProvider(FunctionProvider):
 
     @staticmethod
     def _convert_sam_function_resource(name, resource_properties, layers):
-        """
-        Converts a AWS::Serverless::Function resource to a Function configuration usable by the provider.
+        """Converts a AWS::Serverless::Function resource to a Function configuration usable by the provider.
 
-        :param string name: LogicalID of the resource NOTE: This is *not* the function name because not all functions
+        Parameters
+        ----------
+        string :
+            name: LogicalID of the resource NOTE: This is *not* the function name because not all functions
             declare a name
-        :param dict resource_properties: Properties of this resource
-        :return samcli.commands.local.lib.provider.Function: Function configuration
+        dict :
+            resource_properties: Properties of this resource
+            :return samcli.commands.local.lib.provider.Function: Function configuration
+        name :
+
+        resource_properties :
+
+        layers :
+
+
+        Returns
+        -------
+
         """
 
         codeuri = SamFunctionProvider._extract_sam_function_codeuri(name, resource_properties, "CodeUri")
@@ -135,22 +180,27 @@ class SamFunctionProvider(FunctionProvider):
 
     @staticmethod
     def _extract_sam_function_codeuri(name, resource_properties, code_property_key):
-        """
-        Extracts the SAM Function CodeUri from the Resource Properties
+        """Extracts the SAM Function CodeUri from the Resource Properties
 
         Parameters
         ----------
-        name str
+        name str :
             LogicalId of the resource
-        resource_properties dict
+        resource_properties dict :
             Dictionary representing the Properties of the Resource
-        code_property_key str
+        code_property_key str :
             Property Key of the code on the Resource
+        name :
+
+        resource_properties :
+
+        code_property_key :
+
 
         Returns
         -------
-        str
-            Representing the local code path
+
+
         """
         codeuri = resource_properties.get(code_property_key, SamFunctionProvider._DEFAULT_CODEURI)
         # CodeUri can be a dictionary of S3 Bucket/Key or a S3 URI, neither of which are supported
@@ -166,13 +216,26 @@ class SamFunctionProvider(FunctionProvider):
 
     @staticmethod
     def _convert_lambda_function_resource(name, resource_properties, layers):  # pylint: disable=invalid-name
-        """
-        Converts a AWS::Serverless::Function resource to a Function configuration usable by the provider.
+        """Converts a AWS::Serverless::Function resource to a Function configuration usable by the provider.
 
-        :param string name: LogicalID of the resource NOTE: This is *not* the function name because not all functions
+        Parameters
+        ----------
+        string :
+            name: LogicalID of the resource NOTE: This is *not* the function name because not all functions
             declare a name
-        :param dict resource_properties: Properties of this resource
-        :return samcli.commands.local.lib.provider.Function: Function configuration
+        dict :
+            resource_properties: Properties of this resource
+            :return samcli.commands.local.lib.provider.Function: Function configuration
+        name :
+
+        resource_properties :
+
+        layers :
+
+
+        Returns
+        -------
+
         """
 
         # CodeUri is set to "." in order to get code locally from current directory. AWS::Lambda::Function's ``Code``
@@ -195,20 +258,23 @@ class SamFunctionProvider(FunctionProvider):
 
     @staticmethod
     def _extract_lambda_function_code(resource_properties, code_property_key):
-        """
-        Extracts the Lambda Function Code from the Resource Properties
+        """Extracts the Lambda Function Code from the Resource Properties
 
         Parameters
         ----------
-        resource_properties dict
+        resource_properties dict :
             Dictionary representing the Properties of the Resource
-        code_property_key str
+        code_property_key str :
             Property Key of the code on the Resource
+        resource_properties :
+
+        code_property_key :
+
 
         Returns
         -------
-        str
-            Representing the local code path
+
+
         """
 
         codeuri = resource_properties.get(code_property_key, SamFunctionProvider._DEFAULT_CODEURI)
@@ -220,23 +286,23 @@ class SamFunctionProvider(FunctionProvider):
 
     @staticmethod
     def _parse_layer_info(list_of_layers, resources):
-        """
-        Creates a list of Layer objects that are represented by the resources and the list of layers
+        """Creates a list of Layer objects that are represented by the resources and the list of layers
 
         Parameters
         ----------
-        list_of_layers List(str)
+        list_of_layers List(str) :
             List of layers that are defined within the Layers Property on a function
-        resources dict
+        resources dict :
             The Resources dictionary defined in a template
+        list_of_layers :
+
+        resources :
+
 
         Returns
         -------
-        List(samcli.commands.local.lib.provider.Layer)
-            List of the Layer objects created from the template and layer list defined on the function. The order
-            of the layers does not change.
 
-            I.E: list_of_layers = ["layer1", "layer2"] the return would be [Layer("layer1"), Layer("layer2")]
+
         """
         layers = []
         for layer in list_of_layers:

--- a/samcli/lib/samlib/resource_metadata_normalizer.py
+++ b/samcli/lib/samlib/resource_metadata_normalizer.py
@@ -16,15 +16,18 @@ LOG = logging.getLogger(__name__)
 class ResourceMetadataNormalizer:
     @staticmethod
     def normalize(template_dict):
-        """
-        Normalize all Resources in the template with the Metadata Key on the resource.
+        """Normalize all Resources in the template with the Metadata Key on the resource.
 
         This method will mutate the template
 
         Parameters
         ----------
-        template_dict dict
-            Dictionary representing the template
+        template_dict :
+
+
+        Returns
+        -------
+
 
         """
         resources = template_dict.get(RESOURCES_KEY, {})
@@ -38,21 +41,24 @@ class ResourceMetadataNormalizer:
 
     @staticmethod
     def _replace_property(property_key, property_value, resource, logical_id):
-        """
-        Replace a property with an asset on a given resource
+        """Replace a property with an asset on a given resource
 
         This method will mutate the template
 
         Parameters
         ----------
-        property str
-            The property to replace on the resource
-        property_value str
-            The new value of the property
-        resource dict
-            Dictionary representing the Resource to change
-        logical_id str
-            LogicalId of the Resource
+        property_key :
+
+        property_value :
+
+        resource :
+
+        logical_id :
+
+
+        Returns
+        -------
+
 
         """
         if property_key and property_value:

--- a/samcli/lib/samlib/wrapper.py
+++ b/samcli/lib/samlib/wrapper.py
@@ -117,9 +117,7 @@ class SamTranslatorWrapper:
 
 
 class _SamParserReimplemented:
-    """
-    Re-implementation (almost copy) of Parser class from SAM Translator
-    """
+    """Re-implementation (almost copy) of Parser class from SAM Translator"""
 
     def parse(self, sam_template, sam_plugins):
         self._validate(sam_template)
@@ -140,9 +138,18 @@ class _SamParserReimplemented:
             raise InvalidDocumentException(document_errors)
 
     def _validate(self, sam_template):
-        """ Validates the template and parameter values and raises exceptions if there's an issue
+        """Validates the template and parameter values and raises exceptions if there's an issue
 
-        :param dict sam_template: SAM template
+        Parameters
+        ----------
+        dict :
+            sam_template: SAM template
+        sam_template :
+
+
+        Returns
+        -------
+
         """
 
         if (

--- a/samcli/lib/schemas/cli_paginator.py
+++ b/samcli/lib/schemas/cli_paginator.py
@@ -6,14 +6,26 @@ import click
 
 
 def do_paginate_cli(pages, page_to_be_rendered, items_per_page, is_last_page, cli_display_message):
-    """
-    Responsible for displaying a generic CLI page with available user choices for pagination/seletion
-    :param pages:
-    :param page_to_be_rendered:
-    :param items_per_page:
-    :param is_last_page:
-    :param cli_display_message:
-    :return: User decision on displayed page
+    """Responsible for displaying a generic CLI page with available user choices for pagination/seletion
+
+    Parameters
+    ----------
+    pages :
+        param page_to_be_rendered:
+    items_per_page :
+        param is_last_page:
+    cli_display_message :
+        return: User decision on displayed page
+    page_to_be_rendered :
+
+    is_last_page :
+
+
+    Returns
+    -------
+    type
+        User decision on displayed page
+
     """
     options = pages.get(page_to_be_rendered)
     choice_num = page_to_be_rendered * items_per_page + 1

--- a/samcli/lib/schemas/schemas_aws_config.py
+++ b/samcli/lib/schemas/schemas_aws_config.py
@@ -9,9 +9,15 @@ from samcli.commands.local.cli_common.user_exceptions import ResourceNotFound
 
 
 def get_aws_configuration_choice():
-    """
-    Allow user to select their AWS Connection configuration (profile/region)
+    """Allow user to select their AWS Connection configuration (profile/region)
     :return: AWS profile and region dictionary
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
     session = Session()
     profile = session.profile_name

--- a/samcli/lib/schemas/schemas_code_manager.py
+++ b/samcli/lib/schemas/schemas_code_manager.py
@@ -11,14 +11,25 @@ from samcli.local.common.runtime_template import SAM_RUNTIME_TO_SCHEMAS_CODE_LAN
 
 
 def do_download_source_code_binding(runtime, schema_template_details, schemas_api_caller, download_location):
-    """
-    Downloads source code binding for given registry and schema version,
+    """Downloads source code binding for given registry and schema version,
     generating the code bindings if they haven't been generated first
-    :param runtime: Lambda runtime
-    :param schema_template_details: e.g: registry_name, schema_name, schema_version
-    :param schemas_api_caller:
-    :param download_dir:
-    :return: directory location where code is downloaded
+
+    Parameters
+    ----------
+    runtime :
+        Lambda runtime
+    schema_template_details :
+        e.g: registry_name, schema_name, schema_version
+    schemas_api_caller :
+        param download_dir:
+    download_location :
+
+
+    Returns
+    -------
+    type
+        directory location where code is downloaded
+
     """
     registry_name = schema_template_details["registry_name"]
     schema_name = schema_template_details["schema_full_name"]
@@ -47,13 +58,22 @@ def do_download_source_code_binding(runtime, schema_template_details, schemas_ap
 
 
 def do_extract_and_merge_schemas_code(download_location, output_dir, project_name, template_location):
-    """
-    Unzips schemas generated code and merge it with cookiecutter genertaed source.
-    :param download_location:
-    :param output_dir:
-    :param project_name:
-    :param template_location:
-    :return:
+    """Unzips schemas generated code and merge it with cookiecutter genertaed source.
+
+    Parameters
+    ----------
+    download_location :
+        param output_dir:
+    project_name :
+        param template_location:
+    output_dir :
+
+    template_location :
+
+
+    Returns
+    -------
+
     """
     click.echo("Merging code bindings...")
     cookiecutter_json_path = os.path.join(template_location, "cookiecutter.json")

--- a/samcli/lib/telemetry/metrics.py
+++ b/samcli/lib/telemetry/metrics.py
@@ -26,8 +26,7 @@ def send_installed_metric():
 
 
 def track_command(func):
-    """
-    Decorator to track execution of a command. This method executes the function, gathers all relevant metrics,
+    """Decorator to track execution of a command. This method executes the function, gathers all relevant metrics,
     reports the metrics and returns.
 
     If you have a Click command, you can track as follows:
@@ -38,6 +37,14 @@ def track_command(func):
         @track_command
         def hello_command():
             print('hello')
+
+    Parameters
+    ----------
+    func :
+
+
+    Returns
+    -------
 
     """
 
@@ -101,24 +108,25 @@ def track_command(func):
 
 
 def _timer():
-    """
-    Timer to measure the elapsed time between two calls in milliseconds. When you first call this method,
+    """Timer to measure the elapsed time between two calls in milliseconds. When you first call this method,
     we will automatically start the timer. The return value is another method that, when called, will end the timer
     and return the duration between the two calls.
 
     ..code:
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+
     >>> import time
     >>> duration_fn = _timer()
     >>> time.sleep(5)  # Say, you sleep for 5 seconds in between calls
     >>> duration_ms = duration_fn()
     >>> print(duration_ms)
         5010
-
-    Returns
-    -------
-    function
-        Call this method to end the timer and return duration in milliseconds
-
     """
     start = default_timer()
 

--- a/samcli/lib/telemetry/telemetry.py
+++ b/samcli/lib/telemetry/telemetry.py
@@ -19,14 +19,7 @@ LOG = logging.getLogger(__name__)
 
 class Telemetry:
     def __init__(self, url=None):
-        """
-        Initialize the Telemetry object.
-
-        Parameters
-        ----------
-        url : str
-            Optional, URL where the metrics should be published to
-        """
+        """Initialize the Telemetry object."""
         self._session_id = self._default_session_id()
 
         if not self._session_id:
@@ -37,36 +30,40 @@ class Telemetry:
         LOG.debug("Telemetry endpoint configured to be %s", self._url)
 
     def emit(self, metric_name, attrs):
-        """
-        Emits the metric with given name and the attributes and send it immediately to the HTTP backend. This method
+        """Emits the metric with given name and the attributes and send it immediately to the HTTP backend. This method
         will return immediately without waiting for response from the backend. Before sending, this method will
         also update ``attrs`` with some common attributes used by all metrics.
 
         Parameters
         ----------
-        metric_name : str
-            Name of the metric to publish
+        metric_name :
 
-        attrs : dict
-            Attributes sent along with the metric
+        attrs :
+
+
+        Returns
+        -------
+
+
         """
         attrs = self._add_common_metric_attributes(attrs)
 
         self._send({metric_name: attrs})
 
     def _send(self, metric, wait_for_response=False):
-        """
-        Serializes the metric data to JSON and sends to the backend.
+        """Serializes the metric data to JSON and sends to the backend.
 
         Parameters
         ----------
+        metric :
 
-        metric : dict
-            Dictionary of metric data to send to backend.
+        wait_for_response :
+             (Default value = False)
 
-        wait_for_response : bool
-            If set to True, this method will wait until the HTTP server returns a response. If not, it will return
-            immediately after the request is sent.
+        Returns
+        -------
+
+
         """
 
         if not self._url:
@@ -102,9 +99,7 @@ class Telemetry:
         return attrs
 
     def _default_session_id(self):
-        """
-        Get the default SessionId from Click Context.
-        """
+        """Get the default SessionId from Click Context."""
         ctx = Context.get_current_context()
         if ctx:
             return ctx.session_id
@@ -112,16 +107,18 @@ class Telemetry:
         return None
 
     def _get_execution_environment(self):
-        """
-        Returns the environment in which SAM CLI is running. Possible options are:
+        """Returns the environment in which SAM CLI is running. Possible options are:
 
         CLI (default) - SAM CLI was executed from terminal or a script.
         IDEToolkit    - SAM CLI was executed by IDE Toolkit
         CodeBuild     - SAM CLI was executed from within CodeBuild
 
+        Parameters
+        ----------
+
         Returns
         -------
-        str
-            Name of the environment where SAM CLI is executed in.
+
+
         """
         return "CLI"

--- a/samcli/lib/utils/codeuri.py
+++ b/samcli/lib/utils/codeuri.py
@@ -11,20 +11,20 @@ PRESENT_DIR = "."
 
 
 def resolve_code_path(cwd, codeuri):
-    """
-    Returns path to the function code resolved based on current working directory.
+    """Returns path to the function code resolved based on current working directory.
 
     Parameters
     ----------
-    cwd str
+    cwd str :
         Current working directory
-    codeuri
+    codeuri :
         CodeURI of the function. This should contain the path to the function code
+    cwd :
+
 
     Returns
     -------
-    str
-        Absolute path to the function code
+
 
     """
     LOG.debug("Resolving code path. Cwd=%s, CodeUri=%s", cwd, codeuri)

--- a/samcli/lib/utils/colors.py
+++ b/samcli/lib/utils/colors.py
@@ -6,8 +6,7 @@ import click
 
 
 class Colored:
-    """
-    Helper class to add ANSI colors and decorations to text. Given a string, ANSI colors are added with special prefix
+    """Helper class to add ANSI colors and decorations to text. Given a string, ANSI colors are added with special prefix
     and suffix characters that are specially interpreted by Terminals to display colors.
 
         Ex: "message" -> add red color -> \x1b[31mmessage\x1b[0m
@@ -21,6 +20,13 @@ class Colored:
         - Transparently turn off colors: In cases when the string is not written to Terminal (ex: log file) the ANSI
             color codes should not be written. This class supports the scenario by allowing you to turn off colors.
             Calls to methods like `red()` will simply return the input string.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, colorize=True):
@@ -35,30 +41,102 @@ class Colored:
         self.colorize = colorize
 
     def red(self, msg):
-        """Color the input red"""
+        """Color the input red
+
+        Parameters
+        ----------
+        msg :
+
+
+        Returns
+        -------
+
+        """
         return self._color(msg, "red")
 
     def green(self, msg):
-        """Color the input green"""
+        """Color the input green
+
+        Parameters
+        ----------
+        msg :
+
+
+        Returns
+        -------
+
+        """
         return self._color(msg, "green")
 
     def cyan(self, msg):
-        """Color the input cyan"""
+        """Color the input cyan
+
+        Parameters
+        ----------
+        msg :
+
+
+        Returns
+        -------
+
+        """
         return self._color(msg, "cyan")
 
     def white(self, msg):
-        """Color the input white"""
+        """Color the input white
+
+        Parameters
+        ----------
+        msg :
+
+
+        Returns
+        -------
+
+        """
         return self._color(msg, "white")
 
     def yellow(self, msg):
-        """Color the input yellow"""
+        """Color the input yellow
+
+        Parameters
+        ----------
+        msg :
+
+
+        Returns
+        -------
+
+        """
         return self._color(msg, "yellow")
 
     def underline(self, msg):
-        """Underline the input"""
+        """Underline the input
+
+        Parameters
+        ----------
+        msg :
+
+
+        Returns
+        -------
+
+        """
         return click.style(msg, underline=True) if self.colorize else msg
 
     def _color(self, msg, color):
-        """Internal helper method to add colors to input"""
+        """Internal helper method to add colors to input
+
+        Parameters
+        ----------
+        msg :
+
+        color :
+
+
+        Returns
+        -------
+
+        """
         kwargs = {"fg": color}
         return click.style(msg, **kwargs) if self.colorize else msg

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -17,23 +17,20 @@ LOG = logging.getLogger(__name__)
 
 @contextmanager
 def mkdir_temp(mode=0o755, ignore_errors=False):
-    """
-    Context manager that makes a temporary directory and yields it name. Directory is deleted
+    """Context manager that makes a temporary directory and yields it name. Directory is deleted
     after the context exits
 
     Parameters
     ----------
     mode : octal
         Permissions to apply to the directory. Defaults to '755' because don't want directories world writable
-
     ignore_errors : boolean
         If true, we will log a debug statement on failure to clean up the temp directory, rather than failing.
         Defaults to False
 
     Returns
     -------
-    str
-        Path to the directory
+
 
     """
 
@@ -57,26 +54,12 @@ def _rmtree_callback(function, path, excinfo):
 
 
 def stdout():
-    """
-    Returns the stdout as a byte stream in a Py2/PY3 compatible manner
-
-    Returns
-    -------
-    io.BytesIO
-        Byte stream of Stdout
-    """
+    """Returns the stdout as a byte stream in a Py2/PY3 compatible manner"""
     return sys.stdout.buffer
 
 
 def stderr():
-    """
-    Returns the stderr as a byte stream in a Py2/PY3 compatible manner
-
-    Returns
-    -------
-    io.BytesIO
-        Byte stream of stderr
-    """
+    """Returns the stderr as a byte stream in a Py2/PY3 compatible manner"""
     return sys.stderr.buffer
 
 
@@ -103,19 +86,22 @@ def tempfile_platform_independent():
 # NOTE: Py3.8 or higher has a ``dir_exist_ok=True`` parameter to provide this functionality.
 #       This method can be removed if we stop supporting Py37
 def copytree(source, destination, ignore=None):
-    """
-    Similar to shutil.copytree except that it removes the limitation that the destination directory should
+    """Similar to shutil.copytree except that it removes the limitation that the destination directory should
     be present.
-    :type source: str
-    :param source:
+
+    Parameters
+    ----------
+    source :
         Path to the source folder to copy
-    :type destination: str
-    :param destination:
+    destination :
         Path to destination folder
-    :type ignore: function
-    :param ignore:
+    ignore :
         A function that returns a set of file names to ignore, given a list of available file names. Similar to the
-        ``ignore`` property of ``shutils.copytree`` method
+        ``ignore`` property of ``shutils.copytree`` method (Default value = None)
+
+    Returns
+    -------
+
     """
 
     if not os.path.exists(destination):

--- a/samcli/lib/utils/progressbar.py
+++ b/samcli/lib/utils/progressbar.py
@@ -6,20 +6,22 @@ import click
 
 
 def progressbar(length, label):
-    """
-    Creates a progressbar
+    """Creates a progressbar
 
     Parameters
     ----------
-    length int
+    length int :
         Length of the ProgressBar
-    label str
+    label str :
         Label to give to the progressbar
+    length :
+
+    label :
+
 
     Returns
     -------
-    click.progressbar
-        Progressbar
+
 
     """
     return click.progressbar(length=length, label=label, show_pos=True)

--- a/samcli/lib/utils/sam_logging.py
+++ b/samcli/lib/utils/sam_logging.py
@@ -7,19 +7,25 @@ import logging
 class SamCliLogger:
     @staticmethod
     def configure_logger(logger, formatter, level):
-        """
-        Configure a Logger with the formatter provided.
+        """Configure a Logger with the formatter provided.
 
         Parameters
         ----------
-        logger logging.getLogger
+        logger logging.getLogger :
             Logger to configure
-        formatter logging.formatter
+        formatter logging.formatter :
             Formatter for the logger
+        logger :
+
+        formatter :
+
+        level :
+
 
         Returns
         -------
-        None
+
+
         """
         log_stream_handler = logging.StreamHandler()
         log_stream_handler.setLevel(logging.DEBUG)
@@ -31,19 +37,21 @@ class SamCliLogger:
 
     @staticmethod
     def configure_null_logger(logger):
-        """
-        Configure a Logger with a NullHandler
+        """Configure a Logger with a NullHandler
 
         Useful for libraries that do not follow: https://docs.python.org/3.6/howto/logging.html#configuring-logging-for-a-library
 
         Parameters
         ----------
-        logger logging.getLogger
+        logger logging.getLogger :
             Logger to configure
+        logger :
+
 
         Returns
         -------
-        None
+
+
         """
         logger.propagate = False
         logger.addHandler(logging.NullHandler())

--- a/samcli/lib/utils/stream_writer.py
+++ b/samcli/lib/utils/stream_writer.py
@@ -5,27 +5,22 @@ This class acts like a wrapper around output streams to provide any flexibility 
 
 class StreamWriter:
     def __init__(self, stream, auto_flush=False):
-        """
-        Instatiates new StreamWriter to the specified stream
-
-        Parameters
-        ----------
-        stream io.RawIOBase
-            Stream to wrap
-        auto_flush bool
-            Whether to autoflush the stream upon writing
-        """
+        """Instatiates new StreamWriter to the specified stream"""
         self._stream = stream
         self._auto_flush = auto_flush
 
     def write(self, output):
-        """
-        Writes specified text to the underlying stream
+        """Writes specified text to the underlying stream
 
         Parameters
         ----------
-        output bytes-like object
-            Bytes to write
+        output :
+
+
+        Returns
+        -------
+
+
         """
         self._stream.write(output)
 

--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -9,17 +9,17 @@ from contextlib import contextmanager
 
 @contextmanager
 def create_tarball(tar_paths):
-    """
-    Context Manger that creates the tarball of the Docker Context to use for building the image
+    """Context Manger that creates the tarball of the Docker Context to use for building the image
 
     Parameters
     ----------
-    tar_paths dict(str, str)
-        Key representing a full path to the file or directory and the Value representing the path within the tarball
+    tar_paths :
 
-    Yields
-    ------
-        The tarball file
+
+    Returns
+    -------
+
+
     """
     tarballfile = TemporaryFile()
 

--- a/samcli/lib/utils/time.py
+++ b/samcli/lib/utils/time.py
@@ -9,8 +9,7 @@ from dateutil.tz import tzutc
 
 
 def timestamp_to_iso(timestamp):
-    """
-    Convert Unix Epoch Timestamp to ISO formatted time string:
+    """Convert Unix Epoch Timestamp to ISO formatted time string:
         Ex: 1234567890 -> 2018-07-05T03:09:43.842000
 
     Parameters
@@ -20,16 +19,15 @@ def timestamp_to_iso(timestamp):
 
     Returns
     -------
-    str
-        ISO formatted time string
+
+
     """
 
     return to_datetime(timestamp).isoformat()
 
 
 def to_datetime(timestamp):
-    """
-    Convert Unix Epoch Timestamp to Python's ``datetime.datetime`` object
+    """Convert Unix Epoch Timestamp to Python's ``datetime.datetime`` object
 
     Parameters
     ----------
@@ -38,8 +36,8 @@ def to_datetime(timestamp):
 
     Returns
     -------
-    datetime.datetime
-        Datetime representation of timestamp
+
+
     """
 
     timestamp_secs = int(timestamp) / 1000.0
@@ -47,8 +45,7 @@ def to_datetime(timestamp):
 
 
 def to_timestamp(some_time):
-    """
-    Converts the given datetime value to Unix timestamp
+    """Converts the given datetime value to Unix timestamp
 
     Parameters
     ----------
@@ -57,8 +54,8 @@ def to_timestamp(some_time):
 
     Returns
     -------
-    int
-        Unix timestamp of the given time
+
+
     """
 
     # `total_seconds()` returns elaped microseconds as a float. Get just milliseconds and discard the rest.
@@ -66,18 +63,25 @@ def to_timestamp(some_time):
 
 
 def utc_to_timestamp(utc):
-    """
-    Converts utc timestamp with tz_info set to utc to Unix timestamp
-    :param utc: datetime.datetime
-    :return: UNIX timestamp
+    """Converts utc timestamp with tz_info set to utc to Unix timestamp
+
+    Parameters
+    ----------
+    utc :
+        datetime.datetime
+
+    Returns
+    -------
+    type
+        UNIX timestamp
+
     """
 
     return to_timestamp(utc.replace(tzinfo=None))
 
 
 def to_utc(some_time):
-    """
-    Convert the given date to UTC, if the date contains a timezone.
+    """Convert the given date to UTC, if the date contains a timezone.
 
     Parameters
     ----------
@@ -86,8 +90,8 @@ def to_utc(some_time):
 
     Returns
     -------
-    datetime.datetime
-        Converted datetime object
+
+
     """
 
     # Convert timezone aware objects to UTC
@@ -99,8 +103,7 @@ def to_utc(some_time):
 
 
 def parse_date(date_string):
-    """
-    Parse the given string as datetime object. This parser supports in almost any string formats.
+    """Parse the given string as datetime object. This parser supports in almost any string formats.
 
     For relative times, like `10min ago`, this parser computes the actual time relative to current UTC time. This
     allows time to always be in UTC if an explicit time zone is not provided.
@@ -112,8 +115,8 @@ def parse_date(date_string):
 
     Returns
     -------
-    datetime.datetime
-        Parsed datetime object. None, if the string cannot be parsed.
+
+
     """
 
     parser_settings = {

--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -48,12 +48,20 @@ class Route:
         return route_hash
 
     def normalize_method(self, methods):
-        """
-        Normalizes Http Methods. Api Gateway allows a Http Methods of ANY. This is a special verb to denote all
+        """Normalizes Http Methods. Api Gateway allows a Http Methods of ANY. This is a special verb to denote all
         supported Http Methods on Api Gateway.
 
-        :param list methods: Http methods
-        :return list: Either the input http_method or one of the _ANY_HTTP_METHODS (normalized Http Methods)
+        Parameters
+        ----------
+        list :
+            methods: Http methods
+            :return list: Either the input http_method or one of the _ANY_HTTP_METHODS (normalized Http Methods)
+        methods :
+
+
+        Returns
+        -------
+
         """
         methods = [method.upper() for method in methods]
         if "ANY" in methods:
@@ -94,9 +102,7 @@ class LocalApigwService(BaseLocalService):
         self.stderr = stderr
 
     def create(self):
-        """
-        Creates a Flask Application that can be started.
-        """
+        """Creates a Flask Application that can be started."""
 
         self._app = Flask(
             __name__,
@@ -119,13 +125,25 @@ class LocalApigwService(BaseLocalService):
         self._construct_error_handling()
 
     def _generate_route_keys(self, methods, path):
-        """
-        Generates the key to the _dict_of_routes based on the list of methods
+        """Generates the key to the _dict_of_routes based on the list of methods
         and path supplied
 
-        :param list(str) methods: List of HTTP Methods
-        :param str path: Path off the base url
-        :return: str of Path:Method
+        Parameters
+        ----------
+        list :
+            str) methods: List of HTTP Methods
+        str :
+            path: Path off the base url
+        methods :
+
+        path :
+
+
+        Returns
+        -------
+        type
+            str of Path:Method
+
         """
         for method in methods:
             yield self._route_key(method, path)
@@ -135,9 +153,7 @@ class LocalApigwService(BaseLocalService):
         return "{}:{}".format(path, method)
 
     def _construct_error_handling(self):
-        """
-        Updates the Flask app with Error Handlers for different Error Codes
-        """
+        """Updates the Flask app with Error Handlers for different Error Codes"""
         # Both path and method not present
         self._app.register_error_handler(404, ServiceErrorResponses.route_not_found)
         # Path is present, but method not allowed
@@ -146,8 +162,7 @@ class LocalApigwService(BaseLocalService):
         self._app.register_error_handler(500, ServiceErrorResponses.lambda_failure_response)
 
     def _request_handler(self, **kwargs):
-        """
-        We handle all requests to the host:port. The general flow of handling a request is as follows
+        """We handle all requests to the host:port. The general flow of handling a request is as follows
 
         * Fetch request from the Flask Global state. This is where Flask places the request and is per thread so
           multiple requests are still handled correctly
@@ -161,12 +176,15 @@ class LocalApigwService(BaseLocalService):
 
         Parameters
         ----------
-        kwargs dict
+        kwargs dict :
             Keyword Args that are passed to the function from Flask. This happens when we have path parameters
+        **kwargs :
+
 
         Returns
         -------
-        Response object
+
+
         """
 
         route = self._get_current_route(request)
@@ -213,11 +231,20 @@ class LocalApigwService(BaseLocalService):
         return self.service_response(body, headers, status_code)
 
     def _get_current_route(self, flask_request):
-        """
-        Get the route (Route) based on the current request
+        """Get the route (Route) based on the current request
 
-        :param request flask_request: Flask Request
-        :return: Route matching the endpoint and method of the request
+        Parameters
+        ----------
+        request :
+            flask_request: Flask Request
+        flask_request :
+
+
+        Returns
+        -------
+        type
+            Route matching the endpoint and method of the request
+
         """
         method, endpoint = self.get_request_methods_endpoints(flask_request)
 
@@ -238,10 +265,20 @@ class LocalApigwService(BaseLocalService):
         return route
 
     def get_request_methods_endpoints(self, flask_request):
-        """
-        Separated out for testing requests in request handler
-        :param request flask_request: Flask Request
-        :return: the request's endpoint and method
+        """Separated out for testing requests in request handler
+
+        Parameters
+        ----------
+        request :
+            flask_request: Flask Request
+        flask_request :
+
+
+        Returns
+        -------
+        type
+            the request's endpoint and method
+
         """
         endpoint = flask_request.endpoint
         method = flask_request.method
@@ -250,11 +287,24 @@ class LocalApigwService(BaseLocalService):
     # Consider moving this out to its own class. Logic is started to get dense and looks messy @jfuss
     @staticmethod
     def _parse_lambda_output(lambda_output, binary_types, flask_request):
-        """
-        Parses the output from the Lambda Container
+        """Parses the output from the Lambda Container
 
-        :param str lambda_output: Output from Lambda Invoke
-        :return: Tuple(int, dict, str, bool)
+        Parameters
+        ----------
+        str :
+            lambda_output: Output from Lambda Invoke
+        lambda_output :
+
+        binary_types :
+
+        flask_request :
+
+
+        Returns
+        -------
+        type
+            Tuple(int, dict, str, bool)
+
         """
         # pylint: disable-msg=too-many-statements
         json_output = json.loads(lambda_output)
@@ -313,23 +363,30 @@ class LocalApigwService(BaseLocalService):
 
     @staticmethod
     def _should_base64_decode_body(binary_types, flask_request, lamba_response_headers, is_base_64_encoded):
-        """
-        Whether or not the body should be decoded from Base64 to Binary
+        """Whether or not the body should be decoded from Base64 to Binary
 
         Parameters
         ----------
-        binary_types list(basestring)
+        binary_types list(basestring) :
             Corresponds to self.binary_types (aka. what is parsed from SAM Template
-        flask_request flask.request
+        flask_request flask.request :
             Flask request
-        lamba_response_headers werkzeug.datastructures.Headers
+        lamba_response_headers werkzeug.datastructures.Headers :
             Headers Lambda returns
-        is_base_64_encoded bool
+        is_base_64_encoded bool :
             True if the body is Base64 encoded
+        binary_types :
+
+        flask_request :
+
+        lamba_response_headers :
+
+        is_base_64_encoded :
+
 
         Returns
         -------
-        True if the body from the request should be converted to binary, otherwise false
+
 
         """
         best_match_mimetype = flask_request.accept_mimetypes.best_match(lamba_response_headers.get_all("Content-Type"))
@@ -339,22 +396,25 @@ class LocalApigwService(BaseLocalService):
 
     @staticmethod
     def _merge_response_headers(headers, multi_headers):
-        """
-        Merge multiValueHeaders headers with headers
+        """Merge multiValueHeaders headers with headers
 
         * If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
         * If the same key-value pair is specified in both, the value will only appear once.
 
         Parameters
         ----------
-        headers dict
+        headers dict :
             Headers map from the lambda_response_headers
-        multi_headers dict
+        multi_headers dict :
             multiValueHeaders map from the lambda_response_headers
+        headers :
+
+        multi_headers :
+
 
         Returns
         -------
-        Merged list in accordance to the AWS documentation within a Flask Headers object
+
 
         """
 
@@ -372,11 +432,28 @@ class LocalApigwService(BaseLocalService):
 
     @staticmethod
     def _construct_event(flask_request, port, binary_types, stage_name=None, stage_variables=None):
-        """
-        Helper method that constructs the Event to be passed to Lambda
+        """Helper method that constructs the Event to be passed to Lambda
 
-        :param request flask_request: Flask Request
-        :return: String representing the event
+        Parameters
+        ----------
+        request :
+            flask_request: Flask Request
+        flask_request :
+
+        port :
+
+        binary_types :
+
+        stage_name :
+             (Default value = None)
+        stage_variables :
+             (Default value = None)
+
+        Returns
+        -------
+        type
+            String representing the event
+
         """
         # pylint: disable-msg=too-many-locals
 
@@ -428,17 +505,16 @@ class LocalApigwService(BaseLocalService):
 
     @staticmethod
     def _query_string_params(flask_request):
-        """
-        Constructs an APIGW equivalent query string dictionary
+        """Constructs an APIGW equivalent query string dictionary
 
         Parameters
         ----------
-        flask_request request
-            Request from Flask
+        flask_request :
 
-        Returns dict (str: str), dict (str: list of str)
+
+        Returns
         -------
-            Empty dict if no query params where in the request otherwise returns a dictionary of key to value
+
 
         """
         query_string_dict = {}
@@ -461,21 +537,18 @@ class LocalApigwService(BaseLocalService):
 
     @staticmethod
     def _event_headers(flask_request, port):
-        """
-        Constructs an APIGW equivalent headers dictionary
+        """Constructs an APIGW equivalent headers dictionary
 
         Parameters
         ----------
-        flask_request request
-            Request from Flask
-        int port
-            Forwarded Port
-        cors_headers dict
-            Dict of the Cors properties
+        flask_request :
 
-        Returns dict (str: str), dict (str: list of str)
+        port :
+
+
+        Returns
         -------
-            Returns a dictionary of key to list of strings
+
 
         """
         headers_dict = {}
@@ -496,19 +569,22 @@ class LocalApigwService(BaseLocalService):
 
     @staticmethod
     def _should_base64_encode(binary_types, request_mimetype):
-        """
-        Whether or not to encode the data from the request to Base64
+        """Whether or not to encode the data from the request to Base64
 
         Parameters
         ----------
-        binary_types list(basestring)
+        binary_types list(basestring) :
             Corresponds to self.binary_types (aka. what is parsed from SAM Template
-        request_mimetype str
+        request_mimetype str :
             Mimetype for the request
+        binary_types :
+
+        request_mimetype :
+
 
         Returns
         -------
-            True if the data should be encoded to Base64 otherwise False
+
 
         """
         return request_mimetype in binary_types or "*/*" in binary_types

--- a/samcli/local/apigw/path_converter.py
+++ b/samcli/local/apigw/path_converter.py
@@ -34,16 +34,24 @@ FLASK_TO_APIGW_REGEX = re.compile(FLASK_CAPTURE_ALL_PATH_REGEX)
 class PathConverter:
     @staticmethod
     def convert_path_to_flask(path):
-        """
-        Converts a Path from an Api Gateway defined path to one that is accepted by Flask
+        """Converts a Path from an Api Gateway defined path to one that is accepted by Flask
 
         Examples:
 
         '/id/{id}' => '/id/<id>'
         '/{proxy+}' => '/<path:proxy>'
 
-        :param str path: Path to convert to Flask defined path
-        :return str: Path representing a Flask path
+        Parameters
+        ----------
+        str :
+            path: Path to convert to Flask defined path
+            :return str: Path representing a Flask path
+        path :
+
+
+        Returns
+        -------
+
         """
         proxy_sub_path = APIGW_TO_FLASK_REGEX.sub(FLASK_CAPTURE_ALL_PATH, path)
 
@@ -52,16 +60,24 @@ class PathConverter:
 
     @staticmethod
     def convert_path_to_api_gateway(path):
-        """
-        Converts a Path from a Flask defined path to one that is accepted by Api Gateway
+        """Converts a Path from a Flask defined path to one that is accepted by Api Gateway
 
         Examples:
 
         '/id/<id>' => '/id/{id}'
         '/<path:proxy>' => '/{proxy+}'
 
-        :param str path: Path to convert to Api Gateway defined path
-        :return str: Path representing an Api Gateway path
+        Parameters
+        ----------
+        str :
+            path: Path to convert to Api Gateway defined path
+            :return str: Path representing an Api Gateway path
+        path :
+
+
+        Returns
+        -------
+
         """
         proxy_sub_path = FLASK_TO_APIGW_REGEX.sub(PROXY_PATH_PARAMS, path)
 

--- a/samcli/local/apigw/service_error_responses.py
+++ b/samcli/local/apigw/service_error_responses.py
@@ -14,31 +14,55 @@ class ServiceErrorResponses:
 
     @staticmethod
     def lambda_failure_response(*args):
-        """
-        Helper function to create a Lambda Failure Response
+        """Helper function to create a Lambda Failure Response
 
         :return: A Flask Response
+
+        Parameters
+        ----------
+        *args :
+
+
+        Returns
+        -------
+
         """
         response_data = jsonify(ServiceErrorResponses._LAMBDA_FAILURE)
         return make_response(response_data, ServiceErrorResponses.HTTP_STATUS_CODE_502)
 
     @staticmethod
     def lambda_not_found_response(*args):
-        """
-        Constructs a Flask Response for when a Lambda function is not found for an endpoint
+        """Constructs a Flask Response for when a Lambda function is not found for an endpoint
 
         :return: a Flask Response
+
+        Parameters
+        ----------
+        *args :
+
+
+        Returns
+        -------
+
         """
         response_data = jsonify(ServiceErrorResponses._NO_LAMBDA_INTEGRATION)
         return make_response(response_data, ServiceErrorResponses.HTTP_STATUS_CODE_502)
 
     @staticmethod
     def route_not_found(*args):
-        """
-        Constructs a Flask Response for when a API Route (path+method) is not found. This is usually
+        """Constructs a Flask Response for when a API Route (path+method) is not found. This is usually
         HTTP 404 but with API Gateway this is a HTTP 403 (https://forums.aws.amazon.com/thread.jspa?threadID=2166840)
 
         :return: a Flask Response
+
+        Parameters
+        ----------
+        *args :
+
+
+        Returns
+        -------
+
         """
         response_data = jsonify(ServiceErrorResponses._MISSING_AUTHENTICATION)
         return make_response(response_data, ServiceErrorResponses.HTTP_STATUS_CODE_403)

--- a/samcli/local/docker/container.py
+++ b/samcli/local/docker/container.py
@@ -14,13 +14,19 @@ LOG = logging.getLogger(__name__)
 
 
 class Container:
-    """
-    Represents an instance of a Docker container with a specific configuration. The container is not actually created
+    """Represents an instance of a Docker container with a specific configuration. The container is not actually created
     or executed until the appropriate methods are called. Each container instance is uniquely identified by an ID that
     the Docker Daemon creates when the container is started.
 
     NOTE: This class does not download container images. It should be pulled separately and made available before
           creating a container with this class
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     # This frame type value is coming directly from Docker Attach Stream API spec
@@ -74,12 +80,18 @@ class Container:
         self.id = None
 
     def create(self):
-        """
-        Calls Docker API to creates the Docker container instance. Creating the container does *not* run the container.
+        """Calls Docker API to creates the Docker container instance. Creating the container does *not* run the container.
         Use ``start`` method to run the container
 
         :return string: ID of the created container
         :raise RuntimeError: If this method is called after a container already has been created
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         if self.is_created():
@@ -140,9 +152,7 @@ class Container:
         return self.id
 
     def delete(self):
-        """
-        Removes a container that was created earlier.
-        """
+        """Removes a container that was created earlier."""
         if not self.is_created():
             LOG.debug("Container was not created. Skipping deletion")
             return
@@ -164,15 +174,19 @@ class Container:
         self.id = None
 
     def start(self, input_data=None):
-        """
-        Calls Docker API to start the container. The container must be created at the first place to run.
+        """Calls Docker API to start the container. The container must be created at the first place to run.
         It waits for the container to complete, fetches both stdout and stderr logs and returns through the
         given streams.
 
         Parameters
         ----------
-        input_data
-            Optional. Input data sent to the container through container's stdin.
+        input_data :
+             (Default value = None)
+
+        Returns
+        -------
+
+
         """
 
         if input_data:
@@ -224,17 +238,21 @@ class Container:
 
     @staticmethod
     def _write_container_output(output_itr, stdout=None, stderr=None):
-        """
-        Based on the data returned from the Container output, via the iterator, write it to the appropriate streams
+        """Based on the data returned from the Container output, via the iterator, write it to the appropriate streams
 
         Parameters
         ----------
-        output_itr: Iterator
-            Iterator returned by the Docker Attach command
-        stdout: samcli.lib.utils.stream_writer.StreamWriter, optional
-            Stream writer to write stdout data from Container into
-        stderr: samcli.lib.utils.stream_writer.StreamWriter, optional
-            Stream writer to write stderr data from the Container into
+        output_itr :
+
+        stdout :
+             (Default value = None)
+        stderr :
+             (Default value = None)
+
+        Returns
+        -------
+
+
         """
 
         # Iterator returns a tuple of (stdout, stderr)
@@ -247,34 +265,60 @@ class Container:
 
     @property
     def network_id(self):
-        """
-        Gets the ID of the network this container connects to
+        """Gets the ID of the network this container connects to
         :return string: ID of the network
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         return self._network_id
 
     @network_id.setter
     def network_id(self, value):
-        """
-        Set the ID of network that this container should connect to
+        """Set the ID of network that this container should connect to
 
-        :param string value: Value of the network ID
+        Parameters
+        ----------
+        string :
+            value: Value of the network ID
+        value :
+
+
+        Returns
+        -------
+
         """
         self._network_id = value
 
     @property
     def image(self):
-        """
-        Returns the image used by this container
+        """Returns the image used by this container
 
         :return string: Name of the container image
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         return self._image
 
     def is_created(self):
-        """
-        Checks if a container exists?
+        """Checks if a container exists?
 
         :return bool: True if the container was created
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         return self.id is not None

--- a/samcli/local/docker/lambda_build_container.py
+++ b/samcli/local/docker/lambda_build_container.py
@@ -12,10 +12,16 @@ LOG = logging.getLogger(__name__)
 
 
 class LambdaBuildContainer(Container):
-    """
-    Class to manage Build containers that are capable of building AWS Lambda functions.
+    """Class to manage Build containers that are capable of building AWS Lambda functions.
     This container mounts necessary folders, issues a command to the Lambda Builder CLI,
     and if the build was successful, copies back artifacts to the host filesystem
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     _LAMBCI_IMAGE_REPO_NAME = "lambci/lambda"
@@ -147,21 +153,19 @@ class LambdaBuildContainer(Container):
 
     @staticmethod
     def _get_container_dirs(source_dir, manifest_dir):
-        """
-        Provides paths to directories within the container that is required by the builder
+        """Provides paths to directories within the container that is required by the builder
 
         Parameters
         ----------
         source_dir : str
             Path to the function source code
-
         manifest_dir : str
             Path to the directory containing manifest
 
         Returns
         -------
-        dict
-            Contains paths to source, artifacts, scratch & manifest directories
+
+
         """
         base = "/tmp/samcli"
         result = {
@@ -180,8 +184,7 @@ class LambdaBuildContainer(Container):
 
     @staticmethod
     def _convert_to_container_dirs(host_paths_to_convert, host_to_container_path_mapping):
-        """
-        Use this method to convert a list of host paths to a list of equivalent paths within the container
+        """Use this method to convert a list of host paths to a list of equivalent paths within the container
         where the given host path is mounted. This is necessary when SAM CLI needs to pass path information to
         the Lambda Builder running within the container.
 
@@ -195,14 +198,13 @@ class LambdaBuildContainer(Container):
         ----------
         host_paths_to_convert : list
             List of paths in host that needs to be converted
-
         host_to_container_path_mapping : dict
             Mapping of paths in host to the equivalent paths within the container
 
         Returns
         -------
-        list
-            Equivalent paths within the container
+
+
         """
 
         if not host_paths_to_convert:

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -12,10 +12,16 @@ LOG = logging.getLogger(__name__)
 
 
 class LambdaContainer(Container):
-    """
-    Represents a Lambda runtime container. This class knows how to setup entry points, environment variables,
+    """Represents a Lambda runtime container. This class knows how to setup entry points, environment variables,
     exposed ports etc specific to Lambda runtime container. The container management functionality (create/start/stop)
     is provided by the base class
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     _IMAGE_REPO_NAME = "lambci/lambda"
@@ -96,13 +102,21 @@ class LambdaContainer(Container):
 
     @staticmethod
     def _get_exposed_ports(debug_options):
-        """
-        Return Docker container port binding information. If a debug port tuple is given, then we will ask Docker to
+        """Return Docker container port binding information. If a debug port tuple is given, then we will ask Docker to
         bind every given port to same port both inside and outside the container ie. Runtime process is started in debug mode with
         at given port inside the container and exposed to the host machine at the same port
 
-        :param DebugContext debug_options: Debugging options for the function (includes debug port, args, and path)
-        :return dict: Dictionary containing port binding information. None, if debug_port was not given
+        Parameters
+        ----------
+        DebugContext :
+            debug_options: Debugging options for the function (includes debug port, args, and path)
+            :return dict: Dictionary containing port binding information. None, if debug_port was not given
+        debug_options :
+
+
+        Returns
+        -------
+
         """
         if not debug_options:
             return None
@@ -119,11 +133,22 @@ class LambdaContainer(Container):
 
     @staticmethod
     def _get_additional_options(runtime, debug_options):
-        """
-        Return additional Docker container options. Used by container debug mode to enable certain container
+        """Return additional Docker container options. Used by container debug mode to enable certain container
         security options.
-        :param DebugContext debug_options: DebugContext for the runtime of the container.
-        :return dict: Dictionary containing additional arguments to be passed to container creation.
+
+        Parameters
+        ----------
+        DebugContext :
+            debug_options: DebugContext for the runtime of the container.
+            :return dict: Dictionary containing additional arguments to be passed to container creation.
+        runtime :
+
+        debug_options :
+
+
+        Returns
+        -------
+
         """
         if not debug_options:
             return None
@@ -140,11 +165,20 @@ class LambdaContainer(Container):
 
     @staticmethod
     def _get_additional_volumes(debug_options):
-        """
-        Return additional volumes to be mounted in the Docker container. Used by container debug for mapping
+        """Return additional volumes to be mounted in the Docker container. Used by container debug for mapping
         debugger executable into the container.
-        :param DebugContext debug_options: DebugContext for the runtime of the container.
-        :return dict: Dictionary containing volume map passed to container creation.
+
+        Parameters
+        ----------
+        DebugContext :
+            debug_options: DebugContext for the runtime of the container.
+            :return dict: Dictionary containing volume map passed to container creation.
+        debug_options :
+
+
+        Returns
+        -------
+
         """
         if not debug_options or not debug_options.debugger_path:
             return None
@@ -153,36 +187,52 @@ class LambdaContainer(Container):
 
     @staticmethod
     def _get_image(image_builder, runtime, layers):
-        """
-        Returns the name of Docker Image for the given runtime
+        """Returns the name of Docker Image for the given runtime
 
         Parameters
         ----------
-        image_builder samcli.local.docker.lambda_image.LambdaImage
+        image_builder samcli.local.docker.lambda_image.LambdaImage :
             LambdaImage that can be used to build the image needed for starting the container
-        runtime str
+        runtime str :
             Name of the Lambda runtime
-        layers list(str)
+        layers list(str) :
             List of layers
+        image_builder :
+
+        runtime :
+
+        layers :
+
 
         Returns
         -------
-        str
-            Name of Docker Image for the given runtime
+
+
         """
         return image_builder.build(runtime, layers)
 
     @staticmethod
     def _get_debug_settings(runtime, debug_options=None):  # pylint: disable=too-many-branches
-        """
-        Returns the entry point for the container. The default value for the entry point is already configured in the
+        """Returns the entry point for the container. The default value for the entry point is already configured in the
         Dockerfile. We override this default specifically when enabling debugging. The overridden entry point includes
         a few extra flags to start the runtime in debug mode.
 
-        :param string runtime: Lambda function runtime name.
-        :param DebugContext debug_options: Optional. Debug context for the function (includes port, args, and path).
-        :return list: List containing the new entry points. Each element in the list is one portion of the command.
+        Parameters
+        ----------
+        string :
+            runtime: Lambda function runtime name.
+        DebugContext :
+            debug_options: Optional. Debug context for the function (includes port, args, and path).
+            :return list: List containing the new entry points. Each element in the list is one portion of the command.
             ie. if command is ``node index.js arg1 arg2``, then this list will be ["node", "index.js", "arg1", "arg2"]
+        runtime :
+
+        debug_options :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
 
         if not debug_options:

--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -18,24 +18,30 @@ DebugSettings = namedtuple("DebugSettings", ["entrypoint", "debug_env_vars"])
 class LambdaDebugSettings:
     @staticmethod
     def get_debug_settings(debug_port, debug_args_list, runtime, options):
-        """
-        Get Debug settings based on the Runtime
+        """Get Debug settings based on the Runtime
 
         Parameters
         ----------
-        debug_port int
+        debug_port int :
             Port to open for debugging in the container
-        debug_args_list list(str)
+        debug_args_list list(str) :
             Additional debug args
-        runtime str
+        runtime str :
             Lambda Function runtime
-        options dict
+        options dict :
             Additonal options needed (i.e delve Path)
+        debug_port :
+
+        debug_args_list :
+
+        runtime :
+
+        options :
+
 
         Returns
         -------
-        tuple:DebugSettings (list, dict)
-            Tuple of debug entrypoint and debug env vars
+
 
         """
 

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -37,11 +37,19 @@ class Runtime(Enum):
 
     @classmethod
     def has_value(cls, value):
-        """
-        Checks if the enum has this value
+        """Checks if the enum has this value
 
-        :param string value: Value to check
-        :return bool: True, if enum has the value
+        Parameters
+        ----------
+        string :
+            value: Value to check
+            :return bool: True, if enum has the value
+        value :
+
+
+        Returns
+        -------
+
         """
         return any(value == item.value for item in cls)
 
@@ -71,20 +79,23 @@ class LambdaImage:
         self.docker_client = docker_client or docker.from_env()
 
     def build(self, runtime, layers):
-        """
-        Build the image if one is not already on the system that matches the runtime and layers
+        """Build the image if one is not already on the system that matches the runtime and layers
 
         Parameters
         ----------
-        runtime str
+        runtime str :
             Name of the Lambda runtime
-        layers list(samcli.commands.local.lib.provider.Layer)
+        layers list(samcli.commands.local.lib.provider.Layer) :
             List of layers
+        runtime :
+
+        layers :
+
 
         Returns
         -------
-        str
-            The image to be used (REPOSITORY:TAG)
+
+
         """
         base_image = "{}:{}".format(self._DOCKER_LAMBDA_REPO_NAME, runtime)
 
@@ -118,21 +129,23 @@ class LambdaImage:
 
     @staticmethod
     def _generate_docker_image_version(layers, runtime):
-        """
-        Generate the Docker TAG that will be used to create the image
+        """Generate the Docker TAG that will be used to create the image
 
         Parameters
         ----------
-        layers list(samcli.commands.local.lib.provider.Layer)
+        layers list(samcli.commands.local.lib.provider.Layer) :
             List of the layers
-
-        runtime str
+        runtime str :
             Runtime of the image to create
+        layers :
+
+        runtime :
+
 
         Returns
         -------
-        str
-            String representing the TAG to be attached to the image
+
+
         """
 
         # Docker has a concept of a TAG on an image. This is plus the REPOSITORY is a way to determine
@@ -145,26 +158,27 @@ class LambdaImage:
         )
 
     def _build_image(self, base_image, docker_tag, layers):
-        """
-        Builds the image
+        """Builds the image
 
         Parameters
         ----------
-        base_image str
+        base_image str :
             Base Image to use for the new image
-        docker_tag
+        docker_tag :
             Docker tag (REPOSITORY:TAG) to use when building the image
-        layers list(samcli.commands.local.lib.provider.Layer)
+        layers list(samcli.commands.local.lib.provider.Layer) :
             List of Layers to be use to mount in the image
+        base_image :
+
+        layers :
+
 
         Returns
         -------
         None
 
-        Raises
-        ------
-        samcli.commands.local.cli_common.user_exceptions.ImageBuildException
-            When docker fails to build the image
+
+
         """
         dockerfile_content = self._generate_dockerfile(base_image, layers)
 
@@ -194,8 +208,7 @@ class LambdaImage:
 
     @staticmethod
     def _generate_dockerfile(base_image, layers):
-        """
-        Generate the Dockerfile contents
+        """Generate the Dockerfile contents
 
         A generated Dockerfile will look like the following:
         ```
@@ -207,15 +220,18 @@ class LambdaImage:
 
         Parameters
         ----------
-        base_image str
+        base_image str :
             Base Image to use for the new image
-        layers list(samcli.commands.local.lib.provider.Layer)
+        layers list(samcli.commands.local.lib.provider.Layer) :
             List of Layers to be use to mount in the image
+        base_image :
+
+        layers :
+
 
         Returns
         -------
-        str
-            String representing the Dockerfile contents for the image
+
 
         """
         dockerfile_content = "FROM {}\n".format(base_image)

--- a/samcli/local/docker/manager.py
+++ b/samcli/local/docker/manager.py
@@ -14,10 +14,16 @@ LOG = logging.getLogger(__name__)
 
 
 class ContainerManager:
-    """
-    This class knows how to interface with Docker to create, execute and manage the container's life cycle. It can
+    """This class knows how to interface with Docker to create, execute and manage the container's life cycle. It can
     run multiple containers in parallel, and also comes with the ability to reuse existing containers in order to
     serve requests faster. It is also thread-safe.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     def __init__(self, docker_network_id=None, docker_client=None, skip_pull_image=False):
@@ -35,14 +41,7 @@ class ContainerManager:
 
     @property
     def is_docker_reachable(self):
-        """
-        Checks if Docker daemon is running. This is required for us to invoke the function locally
-
-        Returns
-        -------
-        bool
-            True, if Docker is available, False otherwise
-        """
+        """Checks if Docker daemon is running. This is required for us to invoke the function locally"""
         try:
             self.docker_client.ping()
 
@@ -54,14 +53,30 @@ class ContainerManager:
             return False
 
     def run(self, container, input_data=None, warm=False):
-        """
-        Create and run a Docker container based on the given configuration.
+        """Create and run a Docker container based on the given configuration.
 
-        :param samcli.local.docker.container.Container container: Container to create and run
-        :param input_data: Optional. Input data sent to the container through container's stdin.
-        :param bool warm: Indicates if an existing container can be reused. Defaults False ie. a new container will
+        Parameters
+        ----------
+        samcli :
+            local.docker.container.Container container: Container to create and run
+        input_data :
+            Optional. Input data sent to the container through container's stdin. (Default value = None)
+        bool :
+            warm: Indicates if an existing container can be reused. Defaults False ie. a new container will
             be created for every request.
-        :raises DockerImagePullFailedException: If the Docker image was not available in the server
+        container :
+
+        warm :
+             (Default value = False)
+
+        Returns
+        -------
+
+        Raises
+        ------
+        DockerImagePullFailedException
+            If the Docker image was not available in the server
+
         """
 
         if warm:
@@ -95,28 +110,39 @@ class ContainerManager:
         container.start(input_data=input_data)
 
     def stop(self, container):
-        """
-        Stop and delete the container
+        """Stop and delete the container
 
-        :param samcli.local.docker.container.Container container: Container to stop
+        Parameters
+        ----------
+        samcli :
+            local.docker.container.Container container: Container to stop
+        container :
+
+
+        Returns
+        -------
+
         """
         container.delete()
 
     def pull_image(self, image_name, stream=None):
-        """
-        Ask Docker to pull the container image with given name.
+        """Ask Docker to pull the container image with given name.
 
         Parameters
         ----------
-        image_name str
+        image_name str :
             Name of the image
-        stream samcli.lib.utils.stream_writer.StreamWriter
+        stream samcli.lib.utils.stream_writer.StreamWriter :
             Optional stream writer to output to. Defaults to stderr
+        image_name :
 
-        Raises
-        ------
-        DockerImagePullFailedException
-            If the Docker image was not available in the server
+        stream :
+             (Default value = None)
+
+        Returns
+        -------
+
+
         """
         stream_writer = stream or StreamWriter(sys.stderr)
 
@@ -139,11 +165,19 @@ class ContainerManager:
         stream_writer.write("\n")
 
     def has_image(self, image_name):
-        """
-        Is the container image with given name available?
+        """Is the container image with given name available?
 
-        :param string image_name: Name of the image
-        :return bool: True, if image is available. False, otherwise
+        Parameters
+        ----------
+        string :
+            image_name: Name of the image
+            :return bool: True, if image is available. False, otherwise
+        image_name :
+
+
+        Returns
+        -------
+
         """
 
         try:

--- a/samcli/local/docker/utils.py
+++ b/samcli/local/docker/utils.py
@@ -9,17 +9,18 @@ import pathlib
 
 
 def to_posix_path(code_path):
-    """
-    Change the code_path to be of unix-style if running on windows when supplied with an absolute windows path.
+    """Change the code_path to be of unix-style if running on windows when supplied with an absolute windows path.
 
     Parameters
     ----------
     code_path : str
-        Directory in the host operating system that should be mounted within the container.
+
+
     Returns
     -------
     str
-        Posix equivalent of absolute windows style path.
+
+
     Examples
     --------
     >>> to_posix_path('/Users/UserName/sam-app')

--- a/samcli/local/events/api_event.py
+++ b/samcli/local/events/api_event.py
@@ -41,10 +41,16 @@ class ContextIdentity:
         self.account_id = account_id
 
     def to_dict(self):
-        """
-        Constructs an dictionary representation of the Identity Object to be used in serializing to JSON
+        """Constructs an dictionary representation of the Identity Object to be used in serializing to JSON
 
         :return: dict representing the object
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         json_dict = {
             "apiKey": self.api_key,
@@ -103,10 +109,16 @@ class RequestContext:
         self.path = path
 
     def to_dict(self):
-        """
-        Constructs an dictionary representation of the RequestContext Object to be used in serializing to JSON
+        """Constructs an dictionary representation of the RequestContext Object to be used in serializing to JSON
 
         :return: dict representing the object
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         identity_dict = {}
         if self.identity:
@@ -193,10 +205,16 @@ class ApiGatewayLambdaEvent:
         self.is_base_64_encoded = is_base_64_encoded
 
     def to_dict(self):
-        """
-        Constructs an dictionary representation of the ApiGatewayLambdaEvent Object to be used in serializing to JSON
+        """Constructs an dictionary representation of the ApiGatewayLambdaEvent Object to be used in serializing to JSON
 
         :return: dict representing the object
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         request_context_dict = {}
         if self.request_context:

--- a/samcli/local/lambda_service/lambda_error_responses.py
+++ b/samcli/local/lambda_service/lambda_error_responses.py
@@ -37,18 +37,19 @@ class LambdaErrorResponses:
 
     @staticmethod
     def resource_not_found(function_name):
-        """
-        Creates a Lambda Service ResourceNotFound Response
+        """Creates a Lambda Service ResourceNotFound Response
 
         Parameters
         ----------
-        function_name str
+        function_name str :
             Name of the function that was requested to invoke
+        function_name :
+
 
         Returns
         -------
-        Flask.Response
-            A response object representing the ResourceNotFound Error
+
+
         """
         exception_tuple = LambdaErrorResponses.ResourceNotFoundException
 
@@ -63,18 +64,19 @@ class LambdaErrorResponses:
 
     @staticmethod
     def invalid_request_content(message):
-        """
-        Creates a Lambda Service InvalidRequestContent Response
+        """Creates a Lambda Service InvalidRequestContent Response
 
         Parameters
         ----------
-        message str
+        message str :
             Message to be added to the body of the response
+        message :
+
 
         Returns
         -------
-        Flask.Response
-            A response object representing the InvalidRequestContent Error
+
+
         """
         exception_tuple = LambdaErrorResponses.InvalidRequestContentException
 
@@ -86,18 +88,19 @@ class LambdaErrorResponses:
 
     @staticmethod
     def unsupported_media_type(content_type):
-        """
-        Creates a Lambda Service UnsupportedMediaType Response
+        """Creates a Lambda Service UnsupportedMediaType Response
 
         Parameters
         ----------
-        content_type str
+        content_type str :
             Content Type of the request that was made
+        content_type :
+
 
         Returns
         -------
-        Flask.Response
-            A response object representing the UnsupportedMediaType Error
+
+
         """
         exception_tuple = LambdaErrorResponses.UnsupportedMediaTypeException
 
@@ -111,18 +114,19 @@ class LambdaErrorResponses:
 
     @staticmethod
     def generic_service_exception(*args):
-        """
-        Creates a Lambda Service Generic ServiceException Response
+        """Creates a Lambda Service Generic ServiceException Response
 
         Parameters
         ----------
-        args list
+        args list :
             List of arguments Flask passes to the method
+        *args :
+
 
         Returns
         -------
-        Flask.Response
-            A response object representing the GenericServiceException Error
+
+
         """
         exception_tuple = LambdaErrorResponses.ServiceException
 
@@ -134,18 +138,19 @@ class LambdaErrorResponses:
 
     @staticmethod
     def not_implemented_locally(message):
-        """
-        Creates a Lambda Service NotImplementedLocally Response
+        """Creates a Lambda Service NotImplementedLocally Response
 
         Parameters
         ----------
-        message str
+        message str :
             Message to be added to the body of the response
+        message :
+
 
         Returns
         -------
-        Flask.Response
-            A response object representing the NotImplementedLocally Error
+
+
         """
         exception_tuple = LambdaErrorResponses.NotImplementedException
 
@@ -157,18 +162,19 @@ class LambdaErrorResponses:
 
     @staticmethod
     def generic_path_not_found(*args):
-        """
-        Creates a Lambda Service Generic PathNotFound Response
+        """Creates a Lambda Service Generic PathNotFound Response
 
         Parameters
         ----------
-        args list
+        args list :
             List of arguments Flask passes to the method
+        *args :
+
 
         Returns
         -------
-        Flask.Response
-            A response object representing the GenericPathNotFound Error
+
+
         """
         exception_tuple = LambdaErrorResponses.PathNotFoundException
 
@@ -182,18 +188,19 @@ class LambdaErrorResponses:
 
     @staticmethod
     def generic_method_not_allowed(*args):
-        """
-        Creates a Lambda Service Generic MethodNotAllowed Response
+        """Creates a Lambda Service Generic MethodNotAllowed Response
 
         Parameters
         ----------
-        args list
+        args list :
             List of arguments Flask passes to the method
+        *args :
+
 
         Returns
         -------
-        Flask.Response
-            A response object representing the GenericMethodNotAllowed Error
+
+
         """
         exception_tuple = LambdaErrorResponses.MethodNotAllowedException
 
@@ -207,38 +214,42 @@ class LambdaErrorResponses:
 
     @staticmethod
     def _construct_error_response_body(error_type, error_message):
-        """
-        Constructs a string to be used in the body of the Response that conforms
+        """Constructs a string to be used in the body of the Response that conforms
         to the structure of the Lambda Service Responses
 
         Parameters
         ----------
-        error_type str
+        error_type str :
             The type of error
-        error_message str
+        error_message str :
             Message of the error that occured
+        error_type :
+
+        error_message :
+
 
         Returns
         -------
-        str
-            str representing the response body
+
+
         """
         # OrderedDict is used to make testing in Py2 and Py3 consistent
         return json.dumps(OrderedDict([("Type", error_type), ("Message", error_message)]))
 
     @staticmethod
     def _construct_headers(error_type):
-        """
-        Constructs Headers for the Local Lambda Error Response
+        """Constructs Headers for the Local Lambda Error Response
 
         Parameters
         ----------
-        error_type str
+        error_type str :
             Error type that occurred to be put into the 'x-amzn-errortype' header
+        error_type :
+
 
         Returns
         -------
-        dict
-            Dict representing the Lambda Error Response Headers
+
+
         """
         return {"x-amzn-errortype": error_type, "Content-Type": "application/json"}

--- a/samcli/local/lambda_service/local_lambda_invoke_service.py
+++ b/samcli/local/lambda_service/local_lambda_invoke_service.py
@@ -16,28 +16,13 @@ LOG = logging.getLogger(__name__)
 
 class LocalLambdaInvokeService(BaseLocalService):
     def __init__(self, lambda_runner, port, host, stderr=None):
-        """
-        Creates a Local Lambda Service that will only response to invoking a function
-
-        Parameters
-        ----------
-        lambda_runner samcli.commands.local.lib.local_lambda.LocalLambdaRunner
-            The Lambda runner class capable of invoking the function
-        port int
-            Optional. port for the service to start listening on
-        host str
-            Optional. host to start the service on
-        stderr io.BaseIO
-            Optional stream where the stderr from Docker container should be written to
-        """
+        """Creates a Local Lambda Service that will only response to invoking a function"""
         super(LocalLambdaInvokeService, self).__init__(lambda_runner.is_debugging(), port=port, host=host)
         self.lambda_runner = lambda_runner
         self.stderr = stderr
 
     def create(self):
-        """
-        Creates a Flask Application that can be started.
-        """
+        """Creates a Flask Application that can be started."""
         self._app = Flask(__name__)
 
         path = "/2015-03-31/functions/<function_name>/invocations"
@@ -56,8 +41,7 @@ class LocalLambdaInvokeService(BaseLocalService):
 
     @staticmethod
     def validate_request():
-        """
-        Validates the incoming request
+        """Validates the incoming request
 
         The following are invalid
             1. The Request data is not json serializable
@@ -66,13 +50,13 @@ class LocalLambdaInvokeService(BaseLocalService):
             4. 'X-Amz-Log-Type' header is not 'None'
             5. 'X-Amz-Invocation-Type' header is not 'RequestResponse'
 
+        Parameters
+        ----------
+
         Returns
         -------
-        flask.Response
-            If the request is not valid a flask Response is returned
 
-        None:
-            If the request passes all validation
+
         """
         flask_request = request
         request_data = flask_request.get_data()
@@ -113,27 +97,26 @@ class LocalLambdaInvokeService(BaseLocalService):
         return None
 
     def _construct_error_handling(self):
-        """
-        Updates the Flask app with Error Handlers for different Error Codes
-
-        """
+        """Updates the Flask app with Error Handlers for different Error Codes"""
         self._app.register_error_handler(500, LambdaErrorResponses.generic_service_exception)
         self._app.register_error_handler(404, LambdaErrorResponses.generic_path_not_found)
         self._app.register_error_handler(405, LambdaErrorResponses.generic_method_not_allowed)
 
     def _invoke_request_handler(self, function_name):
-        """
-        Request Handler for the Local Lambda Invoke path. This method is responsible for understanding the incoming
+        """Request Handler for the Local Lambda Invoke path. This method is responsible for understanding the incoming
         request and invoking the Local Lambda Function
 
         Parameters
         ----------
-        function_name str
+        function_name str :
             Name of the function to invoke
+        function_name :
+
 
         Returns
         -------
-        A Flask Response response object as if it was returned from Lambda
+
+
         """
         flask_request = request
 

--- a/samcli/local/lambdafn/config.py
+++ b/samcli/local/lambdafn/config.py
@@ -6,9 +6,15 @@ from .env_vars import EnvironmentVariables
 
 
 class FunctionConfig:
-    """
-    Data class to store function configuration. This class is a flavor of function configuration passed to
+    """Data class to store function configuration. This class is a flavor of function configuration passed to
     AWS Lambda APIs on the cloud. It is limited to properties that make sense in a local testing environment.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     _DEFAULT_TIMEOUT_SECONDS = 3

--- a/samcli/local/lambdafn/env_vars.py
+++ b/samcli/local/lambdafn/env_vars.py
@@ -6,8 +6,7 @@ import sys
 
 
 class EnvironmentVariables:
-    """
-    Use this class to get the environment variables necessary to run the Lambda function. It returns the AWS specific
+    """Use this class to get the environment variables necessary to run the Lambda function. It returns the AWS specific
     variables (credentials, regions, etc) along with any environment variables configured on the function.
 
     Customers define the name of the environment variables along with default values, if any, when creating the
@@ -28,6 +27,13 @@ class EnvironmentVariables:
         region = "us-east-1"
         key = "defaultkey"
         secret = "defaultsecret"
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     _BLANK_VALUE = ""
@@ -69,12 +75,18 @@ class EnvironmentVariables:
         self.aws_creds = aws_creds or {}
 
     def resolve(self):
-        """
-        Resolves the values from different sources and returns a dict of environment variables to use when running
+        """Resolves the values from different sources and returns a dict of environment variables to use when running
         the function locally.
 
         :return dict: Dict where key is the variable name and value is the value of the variable. Both key and values
             are strings
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         # AWS_* variables must always be passed to the function, but user has the choice to override them
@@ -98,8 +110,16 @@ class EnvironmentVariables:
         return result
 
     def add_lambda_event_body(self, value):
-        """
-        Adds the value of AWS_LAMBDA_EVENT_BODY environment variable.
+        """Adds the value of AWS_LAMBDA_EVENT_BODY environment variable.
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
         """
         self.variables["AWS_LAMBDA_EVENT_BODY"] = value
 
@@ -128,11 +148,17 @@ class EnvironmentVariables:
         self._function["handler"] = value
 
     def _get_aws_variables(self):
-        """
-        Returns the AWS specific environment variables that should be available in the Lambda runtime.
+        """Returns the AWS specific environment variables that should be available in the Lambda runtime.
         They are prefixed it "AWS_*".
 
         :return dict: Name and value of AWS environment variable
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         result = {
@@ -161,13 +187,19 @@ class EnvironmentVariables:
         return result
 
     def _stringify_value(self, value):
-        """
-        This method stringifies values of environment variables. If the value of the method is a list or dictionary,
+        """This method stringifies values of environment variables. If the value of the method is a list or dictionary,
         then this method will replace it with empty string. Values of environment variables in Lambda must be a string.
         List or dictionary usually means they are intrinsic functions which have not been resolved.
 
-        :param value: Value to stringify
-        :return string: Stringified value
+        Parameters
+        ----------
+        value :
+            Value to stringify
+            :return string: Stringified value
+
+        Returns
+        -------
+
         """
 
         # List/dict/None values are replaced with a blank

--- a/samcli/local/lambdafn/exceptions.py
+++ b/samcli/local/lambdafn/exceptions.py
@@ -4,6 +4,4 @@ Custom exception used by Local Lambda execution
 
 
 class FunctionNotFound(Exception):
-    """
-    Raised when the requested Lambda function is not found
-    """
+    """ """

--- a/samcli/local/lambdafn/runtime.py
+++ b/samcli/local/lambdafn/runtime.py
@@ -17,10 +17,16 @@ LOG = logging.getLogger(__name__)
 
 
 class LambdaRuntime:
-    """
-    This class represents a Local Lambda runtime. It can run the Lambda function code locally in a Docker container
+    """This class represents a Local Lambda runtime. It can run the Lambda function code locally in a Docker container
     and return results. Public methods exposed by this class are similar to the AWS Lambda APIs, for convenience only.
     This class is **not** intended to be an local replica of the Lambda APIs.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
     """
 
     SUPPORTED_ARCHIVE_EXTENSIONS = (".zip", ".jar", ".ZIP", ".JAR")
@@ -40,8 +46,7 @@ class LambdaRuntime:
         self._image_builder = image_builder
 
     def invoke(self, function_config, event, debug_context=None, stdout=None, stderr=None):
-        """
-        Invoke the given Lambda function locally.
+        """Invoke the given Lambda function locally.
 
         ##### NOTE: THIS IS A LONG BLOCKING CALL #####
         This method will block until either the Lambda function completes or timed out, which could be seconds.
@@ -50,12 +55,35 @@ class LambdaRuntime:
         take care to invoke the function in a separate thread. Co-Routines or micro-threads might not perform well
         because the underlying implementation essentially blocks on a socket, which is synchronous.
 
-        :param FunctionConfig function_config: Configuration of the function to invoke
-        :param event: String input event passed to Lambda function
-        :param DebugContext debug_context: Debugging context for the function (includes port, args, and path)
-        :param io.IOBase stdout: Optional. IO Stream to that receives stdout text from container.
-        :param io.IOBase stderr: Optional. IO Stream that receives stderr text from container
-        :raises Keyboard
+        Parameters
+        ----------
+        FunctionConfig :
+            function_config: Configuration of the function to invoke
+        event :
+            String input event passed to Lambda function
+        DebugContext :
+            debug_context: Debugging context for the function (includes port, args, and path)
+        io :
+            IOBase stdout: Optional. IO Stream to that receives stdout text from container.
+        io :
+            IOBase stderr: Optional. IO Stream that receives stderr text from container
+        function_config :
+
+        debug_context :
+             (Default value = None)
+        stdout :
+             (Default value = None)
+        stderr :
+             (Default value = None)
+
+        Returns
+        -------
+
+        Raises
+        ------
+        Keyboard
+
+
         """
         timer = None
 
@@ -112,16 +140,33 @@ class LambdaRuntime:
                 self._container_manager.stop(container)
 
     def _configure_interrupt(self, function_name, timeout, container, is_debugging):
-        """
-        When a Lambda function is executing, we setup certain interrupt handlers to stop the execution.
+        """When a Lambda function is executing, we setup certain interrupt handlers to stop the execution.
         Usually, we setup a function timeout interrupt to kill the container after timeout expires. If debugging though,
         we don't enforce a timeout. But we setup a SIGINT interrupt to catch Ctrl+C and terminate the container.
 
-        :param string function_name: Name of the function we are running
-        :param integer timeout: Timeout in seconds
-        :param samcli.local.docker.container.Container container: Instance of a container to terminate
-        :param bool is_debugging: Are we debugging?
-        :return threading.Timer: Timer object, if we setup a timer. None otherwise
+        Parameters
+        ----------
+        string :
+            function_name: Name of the function we are running
+        integer :
+            timeout: Timeout in seconds
+        samcli :
+            local.docker.container.Container container: Instance of a container to terminate
+        bool :
+            is_debugging: Are we debugging?
+            :return threading.Timer: Timer object, if we setup a timer. None otherwise
+        function_name :
+
+        timeout :
+
+        container :
+
+        is_debugging :
+
+
+        Returns
+        -------
+
         """
 
         def timer_handler():
@@ -147,8 +192,7 @@ class LambdaRuntime:
 
     @contextmanager
     def _get_code_dir(self, code_path):
-        """
-        Method to get a path to a directory where the Lambda function code is available. This directory will
+        """Method to get a path to a directory where the Lambda function code is available. This directory will
         be mounted directly inside the Docker container.
 
         This method handles a few different cases for ``code_path``:
@@ -157,9 +201,18 @@ class LambdaRuntime:
             - ``code_path`` is a file/dir that does not exist: Return it as is. May be this method is not clever to
                 detect the existence of the path
 
-        :param string code_path: Path to the code. This could be pointing at a file or folder either on a local
+        Parameters
+        ----------
+        string :
+            code_path: Path to the code. This could be pointing at a file or folder either on a local
             disk or in some network file system
-        :return string: Directory containing Lambda function code. It can be mounted directly in container
+            :return string: Directory containing Lambda function code. It can be mounted directly in container
+        code_path :
+
+
+        Returns
+        -------
+
         """
 
         decompressed_dir = None
@@ -179,11 +232,19 @@ class LambdaRuntime:
 
 
 def _unzip_file(filepath):
-    """
-    Helper method to unzip a file to a temporary directory
+    """Helper method to unzip a file to a temporary directory
 
-    :param string filepath: Absolute path to this file
-    :return string: Path to the temporary directory where it was unzipped
+    Parameters
+    ----------
+    string :
+        filepath: Absolute path to this file
+        :return string: Path to the temporary directory where it was unzipped
+    filepath :
+
+
+    Returns
+    -------
+
     """
 
     temp_dir = tempfile.mkdtemp()

--- a/samcli/local/lambdafn/zip.py
+++ b/samcli/local/lambdafn/zip.py
@@ -17,19 +17,21 @@ LOG = logging.getLogger(__name__)
 
 
 def unzip(zip_file_path, output_dir, permission=None):
-    """
-    Unzip the given file into the given directory while preserving file permissions in the process.
+    """Unzip the given file into the given directory while preserving file permissions in the process.
 
     Parameters
     ----------
-    zip_file_path : str
-        Path to the zip file
+    zip_file_path :
 
-    output_dir : str
-        Path to the directory where the it should be unzipped to
+    output_dir :
 
-    permission : octal int
-        Permission to set
+    permission :
+         (Default value = None)
+
+    Returns
+    -------
+
+
     """
 
     with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
@@ -48,15 +50,18 @@ def unzip(zip_file_path, output_dir, permission=None):
 
 
 def _override_permissions(path, permission):
-    """
-    Forcefully override the permissions on the path
+    """Forcefully override the permissions on the path
 
     Parameters
     ----------
-    path str
-        Path where the file or directory
-    permission octal int
-        Permission to set
+    path :
+
+    permission :
+
+
+    Returns
+    -------
+
 
     """
     if permission:
@@ -64,16 +69,19 @@ def _override_permissions(path, permission):
 
 
 def _set_permissions(zip_file_info, extracted_path):
-    """
-    Sets permissions on the extracted file by reading the ``external_attr`` property of given file info.
+    """Sets permissions on the extracted file by reading the ``external_attr`` property of given file info.
 
     Parameters
     ----------
-    zip_file_info : zipfile.ZipInfo
-        Object containing information about a file within a zip archive
+    zip_file_info :
 
-    extracted_path : str
-        Path where the file has been extracted to
+    extracted_path :
+
+
+    Returns
+    -------
+
+
     """
 
     # Permission information is stored in first two bytes.
@@ -88,19 +96,23 @@ def _set_permissions(zip_file_info, extracted_path):
 
 
 def unzip_from_uri(uri, layer_zip_path, unzip_output_dir, progressbar_label):
-    """
-    Download the LayerVersion Zip to the Layer Pkg Cache
+    """Download the LayerVersion Zip to the Layer Pkg Cache
 
     Parameters
     ----------
-    uri str
-        Uri to download from
-    layer_zip_path str
-        Path to where the content from the uri should be downloaded to
-    unzip_output_dir str
-        Path to unzip the zip to
-    progressbar_label str
-        Label to use in the Progressbar
+    uri :
+
+    layer_zip_path :
+
+    unzip_output_dir :
+
+    progressbar_label :
+
+
+    Returns
+    -------
+
+
     """
     try:
         get_request = requests.get(uri, stream=True, verify=os.environ.get("AWS_CA_BUNDLE", True))

--- a/samcli/local/layers/layer_downloader.py
+++ b/samcli/local/layers/layer_downloader.py
@@ -40,32 +40,28 @@ class LayerDownloader:
 
     @property
     def layer_cache(self):
-        """
-        Layer Cache property. This will always return a cache that exists on the system.
-
-        Returns
-        -------
-        str
-            Path to the Layer Cache
-        """
+        """Layer Cache property. This will always return a cache that exists on the system."""
         self._create_cache(self._layer_cache)
         return self._layer_cache
 
     def download_all(self, layers, force=False):
-        """
-        Download a list of layers to the cache
+        """Download a list of layers to the cache
 
         Parameters
         ----------
-        layers list(samcli.commands.local.lib.provider.Layer)
+        layers list(samcli.commands.local.lib.provider.Layer) :
             List of Layers representing the layer to be downloaded
-        force bool
+        force bool :
             True to download the layer even if it exists already on the system
+        layers :
+
+        force :
+             (Default value = False)
 
         Returns
         -------
-        List(Path)
-            List of Paths to where the layer was cached
+
+
         """
         layer_dirs = []
         for layer in layers:
@@ -74,20 +70,23 @@ class LayerDownloader:
         return layer_dirs
 
     def download(self, layer, force=False):
-        """
-        Download a given layer to the local cache.
+        """Download a given layer to the local cache.
 
         Parameters
         ----------
-        layer samcli.commands.local.lib.provider.Layer
+        layer samcli.commands.local.lib.provider.Layer :
             Layer representing the layer to be downloaded.
-        force bool
+        force bool :
             True to download the layer even if it exists already on the system
+        layer :
+
+        force :
+             (Default value = False)
 
         Returns
         -------
-        Path
-            Path object that represents where the layer is download to
+
+
         """
         if layer.is_defined_within_template:
             LOG.info("%s is a local Layer in the template", layer.name)
@@ -114,23 +113,21 @@ class LayerDownloader:
         return layer
 
     def _fetch_layer_uri(self, layer):
-        """
-        Fetch the Layer Uri based on the LayerVersion Arn
+        """Fetch the Layer Uri based on the LayerVersion Arn
 
         Parameters
         ----------
-        layer samcli.commands.local.lib.provider.LayerVersion
+        layer samcli.commands.local.lib.provider.LayerVersion :
             LayerVersion to fetch
+        layer :
+
 
         Returns
         -------
         str
             The Uri to download the LayerVersion Content from
 
-        Raises
-        ------
-        samcli.commands.local.cli_common.user_exceptions.NoCredentialsError
-            When the Credentials given are not sufficient to call AWS Lambda
+
         """
         try:
             layer_version_response = self.lambda_client.get_layer_version(
@@ -157,35 +154,34 @@ class LayerDownloader:
         return layer_version_response.get("Content").get("Location")
 
     def _is_layer_cached(self, layer_path):
-        """
-        Checks if the layer is already cached on the system
+        """Checks if the layer is already cached on the system
 
         Parameters
         ----------
-        layer_path Path
+        layer_path Path :
             Path to where the layer should exist if cached on the system
+        layer_path :
+
 
         Returns
         -------
-        bool
-            True if the layer_path already exists otherwise False
+
 
         """
         return layer_path.exists()
 
     @staticmethod
     def _create_cache(layer_cache):
-        """
-        Create the Cache directory if it does not exist.
+        """Create the Cache directory if it does not exist.
 
         Parameters
         ----------
-        layer_cache
+        layer_cache :
             Directory to where the layers should be cached
 
         Returns
         -------
-        None
+
 
         """
         Path(layer_cache).mkdir(mode=0o700, parents=True, exist_ok=True)

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -11,38 +11,27 @@ LOG = logging.getLogger(__name__)
 
 class BaseLocalService:
     def __init__(self, is_debugging, port, host):
-        """
-        Creates a BaseLocalService class
-
-        Parameters
-        ----------
-        is_debugging bool
-            Flag to run in debug mode or not
-        port int
-            Optional. port for the service to start listening on Defaults to 3000
-        host str
-            Optional. host to start the service on Defaults to '127.0.0.1
-        """
+        """Creates a BaseLocalService class"""
         self.is_debugging = is_debugging
         self.port = port
         self.host = host
         self._app = None
 
     def create(self):
-        """
-        Creates a Flask Application that can be started.
-        """
+        """Creates a Flask Application that can be started."""
         raise NotImplementedError("Required method to implement")
 
     def run(self):
-        """
-        This starts up the (threaded) Local Server.
+        """This starts up the (threaded) Local Server.
         Note: This is a **blocking call**
 
-        Raises
-        ------
-        RuntimeError
-            if the service was not created
+        Parameters
+        ----------
+
+        Returns
+        -------
+
+
         """
         if not self._app:
             raise RuntimeError("The application must be created before running")
@@ -64,13 +53,28 @@ class BaseLocalService:
 
     @staticmethod
     def service_response(body, headers, status_code):
-        """
-        Constructs a Flask Response from the body, headers, and status_code.
+        """Constructs a Flask Response from the body, headers, and status_code.
 
-        :param str body: Response body as a string
-        :param werkzeug.datastructures.Headers headers: headers for the response
-        :param int status_code: status_code for response
-        :return: Flask Response
+        Parameters
+        ----------
+        str :
+            body: Response body as a string
+        werkzeug :
+            datastructures.Headers headers: headers for the response
+        int :
+            status_code: status_code for response
+        body :
+
+        headers :
+
+        status_code :
+
+
+        Returns
+        -------
+        type
+            Flask Response
+
         """
         response = Response(body)
         response.headers = headers
@@ -81,8 +85,7 @@ class BaseLocalService:
 class LambdaOutputParser:
     @staticmethod
     def get_lambda_output(stdout_stream):
-        """
-        This method will extract read the given stream and return the response from Lambda function separated out
+        """This method will extract read the given stream and return the response from Lambda function separated out
         from any log statements it might have outputted. Logs end up in the stdout stream if the Lambda function
         wrote directly to stdout using System.out.println or equivalents.
 
@@ -93,12 +96,8 @@ class LambdaOutputParser:
 
         Returns
         -------
-        str
-            String data containing response from Lambda function
-        str
-            String data containng logs statements, if any.
-        bool
-            If the response is an error/exception from the container
+
+
         """
         # We only want the last line of stdout, because it's possible that
         # the function may have written directly to stdout using
@@ -131,18 +130,19 @@ class LambdaOutputParser:
 
     @staticmethod
     def is_lambda_error_response(lambda_response):
-        """
-        Check to see if the output from the container is in the form of an Error/Exception from the Lambda invoke
+        """Check to see if the output from the container is in the form of an Error/Exception from the Lambda invoke
 
         Parameters
         ----------
-        lambda_response str
+        lambda_response str :
             The response the container returned
+        lambda_response :
+
 
         Returns
         -------
-        bool
-            True if the output matches the Error/Exception Dictionary otherwise False
+
+
         """
         is_lambda_user_error_response = False
         try:

--- a/samcli/yamlhelper.py
+++ b/samcli/yamlhelper.py
@@ -25,9 +25,21 @@ from yaml.resolver import ScalarNode, SequenceNode
 
 
 def intrinsics_multi_constructor(loader, tag_prefix, node):
-    """
-    YAML constructor to parse CloudFormation intrinsics.
+    """YAML constructor to parse CloudFormation intrinsics.
     This will return a dictionary with key being the instrinsic name
+
+    Parameters
+    ----------
+    loader :
+
+    tag_prefix :
+
+    node :
+
+
+    Returns
+    -------
+
     """
 
     # Get the actual tag name excluding the first exclamation
@@ -66,10 +78,16 @@ def _dict_representer(dumper, data):
 
 
 def yaml_dump(dict_to_dump):
-    """
-    Dumps the dictionary as a YAML document
-    :param dict_to_dump:
-    :return:
+    """Dumps the dictionary as a YAML document
+
+    Parameters
+    ----------
+    dict_to_dump :
+        return:
+
+    Returns
+    -------
+
     """
     FlattenAliasDumper.add_representer(OrderedDict, _dict_representer)
     return yaml.dump(dict_to_dump, default_flow_style=False, Dumper=FlattenAliasDumper)
@@ -82,7 +100,17 @@ def _dict_constructor(loader, node):
 
 
 def yaml_parse(yamlstr):
-    """Parse a yaml string"""
+    """Parse a yaml string
+
+    Parameters
+    ----------
+    yamlstr :
+
+
+    Returns
+    -------
+
+    """
     try:
         # PyYAML doesn't support json as well as it should, so if the input
         # is actually just json it is better to parse it with the standard

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -9,9 +9,7 @@ from .start_api_integ_base import StartApiIntegBaseClass
 
 
 class TestParallelRequests(StartApiIntegBaseClass):
-    """
-    Test Class centered around sending parallel requests to the service `sam local start-api`
-    """
+    """Test Class centered around sending parallel requests to the service `sam local start-api`"""
 
     # This is here so the setUpClass doesn't fail. Set to this something else once the class is implemented
     template_path = "/testdata/start_api/template.yaml"
@@ -22,9 +20,15 @@ class TestParallelRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_same_endpoint(self):
-        """
-        Send two requests to the same path at the same time. This is to ensure we can handle
+        """Send two requests to the same path at the same time. This is to ensure we can handle
         multiple requests at once and do not block/queue up requests
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         number_of_requests = 10
         start_time = time()
@@ -48,9 +52,15 @@ class TestParallelRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_different_endpoints(self):
-        """
-        Send two requests to different paths at the same time. This is to ensure we can handle
+        """Send two requests to different paths at the same time. This is to ensure we can handle
         multiple requests for different paths and do not block/queue up the requests
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         number_of_requests = 10
         start_time = time()
@@ -75,9 +85,7 @@ class TestParallelRequests(StartApiIntegBaseClass):
 
 
 class TestServiceErrorResponses(StartApiIntegBaseClass):
-    """
-    Test Class centered around the Error Responses the Service can return for a given api
-    """
+    """Test Class centered around the Error Responses the Service can return for a given api"""
 
     # This is here so the setUpClass doesn't fail. Set to this something else once the class is implemented.
     template_path = "/testdata/start_api/template.yaml"
@@ -116,9 +124,7 @@ class TestServiceErrorResponses(StartApiIntegBaseClass):
 
 
 class TestService(StartApiIntegBaseClass):
-    """
-    Testing general requirements around the Service that powers `sam local start-api`
-    """
+    """Testing general requirements around the Service that powers `sam local start-api`"""
 
     template_path = "/testdata/start_api/template.yaml"
 
@@ -139,9 +145,7 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_implicit_api(self):
-        """
-        Get Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
-        """
+        """Get Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events"""
         response = requests.get(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -150,9 +154,7 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_implicit_api(self):
-        """
-        Post Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
-        """
+        """Post Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events"""
         response = requests.post(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -161,9 +163,7 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_implicit_api(self):
-        """
-        Put Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
-        """
+        """Put Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events"""
         response = requests.put(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -172,9 +172,7 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_implicit_api(self):
-        """
-        Head Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
-        """
+        """Head Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events"""
         response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -182,9 +180,7 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_implicit_api(self):
-        """
-        Delete Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
-        """
+        """Delete Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events"""
         response = requests.delete(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -193,9 +189,7 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_implicit_api(self):
-        """
-        Options Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
-        """
+        """Options Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events"""
         response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -203,9 +197,7 @@ class TestService(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_implicit_api(self):
-        """
-        Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events
-        """
+        """Patch Request to a path that was defined as ANY in SAM through AWS::Serverless::Function Events"""
         response = requests.patch(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -222,9 +214,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
-        """
-        Get Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Get Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.get(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -233,9 +223,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
-        """
-        Post Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Post Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.post(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -244,9 +232,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
-        """
-        Put Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Put Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.put(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -255,9 +241,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
-        """
-        Head Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Head Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -265,9 +249,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
-        """
-        Delete Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Delete Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.delete(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -276,9 +258,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
-        """
-        Options Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Options Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -286,9 +266,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
-        """
-        Patch Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Patch Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.patch(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -321,9 +299,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
-        """
-        This tests that the service can accept and invoke a lambda when given binary data in a request
-        """
+        """This tests that the service can accept and invoke a lambda when given binary data in a request"""
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
             self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
@@ -336,9 +312,7 @@ class TestStartApiWithSwaggerApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
-        """
-        Binary data is returned correctly
-        """
+        """Binary data is returned correctly"""
         expected = self.get_binary_data(self.binary_data_file)
 
         response = requests.get(self.url + "/base64response", timeout=300)
@@ -358,9 +332,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
-        """
-        Get Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Get Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.get(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -369,9 +341,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
-        """
-        Post Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Post Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.post(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -380,9 +350,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
-        """
-        Put Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Put Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.put(self.url + "/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -391,9 +359,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
-        """
-        Head Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Head Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.head(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -401,9 +367,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
-        """
-        Delete Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Delete Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.delete(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -412,9 +376,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
-        """
-        Options Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Options Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.options(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -422,9 +384,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
-        """
-        Patch Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Patch Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.patch(self.url + "/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -449,9 +409,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
-        """
-        This tests that the service can accept and invoke a lambda when given binary data in a request
-        """
+        """This tests that the service can accept and invoke a lambda when given binary data in a request"""
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
             self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
@@ -464,9 +422,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
-        """
-        Binary data is returned correctly
-        """
+        """Binary data is returned correctly"""
         expected = self.get_binary_data(self.binary_data_file)
 
         response = requests.get(self.url + "/base64response", timeout=300)
@@ -477,9 +433,7 @@ class TestStartApiWithSwaggerRestApis(StartApiIntegBaseClass):
 
 
 class TestServiceResponses(StartApiIntegBaseClass):
-    """
-    Test Class centered around the different responses that can happen in Lambda and pass through start-api
-    """
+    """Test Class centered around the different responses that can happen in Lambda and pass through start-api"""
 
     template_path = "/testdata/start_api/template.yaml"
     binary_data_file = "testdata/start_api/binarydata.gif"
@@ -508,9 +462,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
-        """
-        Binary data is returned correctly
-        """
+        """Binary data is returned correctly"""
         expected = self.get_binary_data(self.binary_data_file)
 
         response = requests.get(self.url + "/base64response", timeout=300)
@@ -522,9 +474,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_header_content_type(self):
-        """
-        Test that if no ContentType is given the default is "application/json"
-        """
+        """Test that if no ContentType is given the default is "application/json"""
         response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -534,9 +484,15 @@ class TestServiceResponses(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_status_code(self):
-        """
-        Test that if no status_code is given, the status code is 200
+        """Test that if no status_code is given, the status code is 200
         :return:
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         response = requests.get(self.url + "/onlysetbody", timeout=300)
 
@@ -546,9 +502,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_string_status_code(self):
-        """
-        Test that an integer-string can be returned as the status code
-        """
+        """Test that an integer-string can be returned as the status code"""
         response = requests.get(self.url + "/stringstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -556,9 +510,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_body(self):
-        """
-        Test that if no body is given, the response is 'no data'
-        """
+        """Test that if no body is given, the response is 'no data'"""
         response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -590,9 +542,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
 
 
 class TestServiceRequests(StartApiIntegBaseClass):
-    """
-    Test Class centered around the different requests that can happen
-    """
+    """Test Class centered around the different requests that can happen"""
 
     template_path = "/testdata/start_api/template.yaml"
     binary_data_file = "testdata/start_api/binarydata.gif"
@@ -603,9 +553,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
-        """
-        This tests that the service can accept and invoke a lambda when given binary data in a request
-        """
+        """This tests that the service can accept and invoke a lambda when given binary data in a request"""
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
             self.url + "/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
@@ -618,9 +566,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_form_data(self):
-        """
-        Form-encoded data should be put into the Event to Lambda
-        """
+        """Form-encoded data should be put into the Event to Lambda"""
         response = requests.post(
             self.url + "/echoeventbody",
             headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -667,9 +613,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_query_params(self):
-        """
-        Query params given should be put into the Event to Lambda
-        """
+        """Query params given should be put into the Event to Lambda"""
         response = requests.get(self.url + "/id/4", params={"key": "value"}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -682,9 +626,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_list_of_query_params(self):
-        """
-        Query params given should be put into the Event to Lambda
-        """
+        """Query params given should be put into the Event to Lambda"""
         response = requests.get(self.url + "/id/4", params={"key": ["value", "value2"]}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -697,9 +639,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_path_params(self):
-        """
-        Path Parameters given should be put into the Event to Lambda
-        """
+        """Path Parameters given should be put into the Event to Lambda"""
         response = requests.get(self.url + "/id/4", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -711,9 +651,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_request_with_many_path_params(self):
-        """
-        Path Parameters given should be put into the Event to Lambda
-        """
+        """Path Parameters given should be put into the Event to Lambda"""
         response = requests.get(self.url + "/id/4/user/jacob", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -725,9 +663,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_forward_headers_are_added_to_event(self):
-        """
-        Test the Forwarding Headers exist in the Api Event to Lambda
-        """
+        """Test the Forwarding Headers exist in the Api Event to Lambda"""
         response = requests.get(self.url + "/id/4", timeout=300)
 
         response_data = response.json()
@@ -739,9 +675,7 @@ class TestServiceRequests(StartApiIntegBaseClass):
 
 
 class TestStartApiWithStage(StartApiIntegBaseClass):
-    """
-    Test Class centered around the different responses that can happen in Lambda and pass through start-api
-    """
+    """Test Class centered around the different responses that can happen in Lambda and pass through start-api"""
 
     template_path = "/testdata/start_api/template.yaml"
 
@@ -772,9 +706,7 @@ class TestStartApiWithStage(StartApiIntegBaseClass):
 
 
 class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
-    """
-    Test Class centered around the different responses that can happen in Lambda and pass through start-api
-    """
+    """Test Class centered around the different responses that can happen in Lambda and pass through start-api"""
 
     template_path = "/testdata/start_api/swagger-template.yaml"
 
@@ -803,9 +735,7 @@ class TestStartApiWithStageAndSwagger(StartApiIntegBaseClass):
 
 
 class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
-    """
-    Test to check that the correct headers are being added with Cors with swagger code
-    """
+    """Test to check that the correct headers are being added with Cors with swagger code"""
 
     template_path = "/testdata/start_api/swagger-template.yaml"
     binary_data_file = "testdata/start_api/binarydata.gif"
@@ -816,9 +746,7 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_cors_swagger_options(self):
-        """
-        This tests that the Cors are added to option requests in the swagger template
-        """
+        """This tests that the Cors are added to option requests in the swagger template"""
         response = requests.options(self.url + "/echobase64eventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -830,9 +758,7 @@ class TestServiceCorsSwaggerRequests(StartApiIntegBaseClass):
 
 
 class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
-    """
-    Test to check that the correct headers are being added with Cors with the global property
-    """
+    """Test to check that the correct headers are being added with Cors with the global property"""
 
     template_path = "/testdata/start_api/template.yaml"
 
@@ -842,9 +768,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_cors_global(self):
-        """
-        This tests that the Cors are added to options requests when the global property is set
-        """
+        """This tests that the Cors are added to options requests when the global property is set"""
         response = requests.options(self.url + "/echobase64eventbody", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -856,9 +780,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_cors_global_get(self):
-        """
-        This tests that the Cors are added to post requests when the global property is set
-        """
+        """This tests that the Cors are added to post requests when the global property is set"""
         response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -871,9 +793,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
 
 
 class TestStartApiWithCloudFormationStage(StartApiIntegBaseClass):
-    """
-    Test Class centered around the different responses that can happen in Lambda and pass through start-api
-    """
+    """Test Class centered around the different responses that can happen in Lambda and pass through start-api"""
 
     template_path = "/testdata/start_api/swagger-rest-api-template.yaml"
 
@@ -912,9 +832,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_call_with_path_setup_with_any_swagger(self):
-        """
-        Get Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Get Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.get(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -923,9 +841,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_post_call_with_path_setup_with_any_swagger(self):
-        """
-        Post Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Post Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.post(self.url + "/root/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -934,9 +850,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_put_call_with_path_setup_with_any_swagger(self):
-        """
-        Put Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Put Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.put(self.url + "/root/anyandall", json={}, timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -945,9 +859,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_head_call_with_path_setup_with_any_swagger(self):
-        """
-        Head Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Head Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.head(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -955,9 +867,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_delete_call_with_path_setup_with_any_swagger(self):
-        """
-        Delete Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Delete Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.delete(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -966,9 +876,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_options_call_with_path_setup_with_any_swagger(self):
-        """
-        Options Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Options Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.options(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -976,9 +884,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_patch_call_with_path_setup_with_any_swagger(self):
-        """
-        Patch Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Patch Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.patch(self.url + "/root/anyandall", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -1003,9 +909,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_request(self):
-        """
-        This tests that the service can accept and invoke a lambda when given binary data in a request
-        """
+        """This tests that the service can accept and invoke a lambda when given binary data in a request"""
         input_data = self.get_binary_data(self.binary_data_file)
         response = requests.post(
             self.url + "/root/echobase64eventbody", headers={"Content-Type": "image/gif"}, data=input_data, timeout=300
@@ -1018,9 +922,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_binary_response(self):
-        """
-        Binary data is returned correctly
-        """
+        """Binary data is returned correctly"""
         expected = self.get_binary_data(self.binary_data_file)
 
         response = requests.get(self.url + "/root/base64response", timeout=300)
@@ -1032,9 +934,7 @@ class TestStartApiWithMethodsAndResources(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_proxy_response(self):
-        """
-        Binary data is returned correctly
-        """
+        """Binary data is returned correctly"""
         response = requests.get(self.url + "/root/v1/test", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -1050,9 +950,7 @@ class TestCDKApiGateway(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_with_cdk(self):
-        """
-        Get Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Get Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.get(self.url + "/hello-world", timeout=300)
 
         self.assertEqual(response.status_code, 200)
@@ -1068,9 +966,7 @@ class TestServerlessApiGateway(StartApiIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_get_with_serverless(self):
-        """
-        Get Request to a path that was defined as ANY in SAM through Swagger
-        """
+        """Get Request to a path that was defined as ANY in SAM through Swagger"""
         response = requests.get(self.url + "/hello-world", timeout=300)
 
         self.assertEqual(response.status_code, 200)

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -29,9 +29,15 @@ class TestParallelRequests(StartLambdaIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=300, method="thread")
     def test_same_endpoint(self):
-        """
-        Send two requests to the same path at the same time. This is to ensure we can handle
+        """Send two requests to the same path at the same time. This is to ensure we can handle
         multiple requests at once and do not block/queue up requests
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         number_of_requests = 10
         start_time = time()
@@ -180,8 +186,7 @@ class TestLambdaService(StartLambdaIntegBaseClass):
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=300, method="thread")
     def test_invoke_with_function_timeout(self):
-        """
-        This behavior does not match the actually Lambda Service. For functions that timeout, data returned like the
+        """This behavior does not match the actually Lambda Service. For functions that timeout, data returned like the
         following:
         {"errorMessage":"<timestamp> <request_id> Task timed out after 5.00 seconds"}
 
@@ -189,6 +194,13 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         invoke is on a different thread, we do not (currently) have a way to communicate this back to the caller. So
         when a timeout happens locally, we do not add the FunctionError: Unhandled to the response and have an empty
         string as the data returned (because no data was found in stdout from the container).
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         response = self.lambda_client.invoke(FunctionName="TimeoutFunction")
 

--- a/tests/integration/telemetry/integ_base.py
+++ b/tests/integration/telemetry/integ_base.py
@@ -82,12 +82,19 @@ class IntegBase(TestCase):
 
     @staticmethod
     def wait_for_process_terminate(process, timeout_seconds=5):
-        """
-        This is needed because Python2's wait() method does *not* have a timeout
+        """This is needed because Python2's wait() method does *not* have a timeout
+
+        Parameters
+        ----------
+        process :
+
+        timeout_seconds :
+             (Default value = 5)
 
         Returns
         -------
-            Return code if the process exited within the timout. None, if process is still executing
+
+
         """
 
         start = timeit.default_timer()
@@ -106,9 +113,14 @@ class IntegBase(TestCase):
 
 
 class TelemetryServer(Thread):
-    """
-    HTTP Server that can receive and store Telemetry requests. Caller can later retrieve the responses for
+    """HTTP Server that can receive and store Telemetry requests. Caller can later retrieve the responses for
     assertion
+
+    Parameters
+    ----------
+
+    Returns
+    -------
 
     Examples
     --------
@@ -146,9 +158,7 @@ class TelemetryServer(Thread):
         self._requests = deque()
 
     def run(self):
-        """
-        Method that runs when thread starts. This starts up Flask server as well
-        """
+        """Method that runs when thread starts. This starts up Flask server as well"""
         # os.environ['WERKZEUG_RUN_MAIN'] = 'true'
         self.flask_app.run(port=TELEMETRY_ENDPOINT_PORT, host=TELEMETRY_ENDPOINT_HOST, threaded=True)
 
@@ -173,8 +183,16 @@ class TelemetryServer(Thread):
         return list(self._requests)
 
     def _request_handler(self, **kwargs):
-        """
-        Handles Flask requests
+        """Handles Flask requests
+
+        Parameters
+        ----------
+        **kwargs :
+
+
+        Returns
+        -------
+
         """
 
         # `request` is a variable populated by Flask automatically when handler method is called

--- a/tests/integration/telemetry/test_installed_metric.py
+++ b/tests/integration/telemetry/test_installed_metric.py
@@ -7,9 +7,7 @@ from samcli import __version__ as SAM_CLI_VERSION
 
 class TestSendInstalledMetric(IntegBase):
     def test_send_installed_metric_on_first_run(self):
-        """
-        On the first run, send the installed metric
-        """
+        """On the first run, send the installed metric"""
         self.unset_config()
 
         with TelemetryServer() as server:
@@ -53,9 +51,15 @@ class TestSendInstalledMetric(IntegBase):
             self.assertEqual(request["data"], expected_data)
 
     def test_must_not_send_installed_metric_when_prompt_is_disabled(self):
-        """
-        If the Telemetry Prompt is not displayed, we must *not* send installed metric, even if Telemetry is enabled.
+        """If the Telemetry Prompt is not displayed, we must *not* send installed metric, even if Telemetry is enabled.
         This happens on all subsequent runs.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         # Enable Telemetry. This will skip the Telemetry Prompt.
@@ -75,9 +79,7 @@ class TestSendInstalledMetric(IntegBase):
             self.assertEqual(0, len(requests), "'installed' metric should NOT be sent")
 
     def test_must_not_send_installed_metric_on_second_run(self):
-        """
-        On first run, send installed metric. On second run, must *not* send installed metric
-        """
+        """On first run, send installed metric. On second run, must *not* send installed metric"""
 
         # Unset config to show the prompt
         self.unset_config()

--- a/tests/integration/telemetry/test_prompt.py
+++ b/tests/integration/telemetry/test_prompt.py
@@ -4,9 +4,7 @@ from .integ_base import IntegBase, EXPECTED_TELEMETRY_PROMPT
 
 class TestTelemetryPrompt(IntegBase):
     def test_must_prompt_if_config_is_not_set(self):
-        """
-        Must print prompt if Telemetry config is not set.
-        """
+        """Must print prompt if Telemetry config is not set."""
         self.unset_config()
 
         process = self.run_cmd()
@@ -17,8 +15,18 @@ class TestTelemetryPrompt(IntegBase):
 
     @parameterized.expand([(True, "Enable Telemetry"), (False, "Disalbe Telemetry")])
     def test_must_not_prompt_if_config_is_set(self, telemetry_enabled, msg):
-        """
-        If telemetry config is already set, prompt must not be displayed
+        """If telemetry config is already set, prompt must not be displayed
+
+        Parameters
+        ----------
+        telemetry_enabled :
+
+        msg :
+
+
+        Returns
+        -------
+
         """
 
         # Set the telemetry config
@@ -31,9 +39,7 @@ class TestTelemetryPrompt(IntegBase):
         self.assertNotIn(EXPECTED_TELEMETRY_PROMPT, stderrdata.decode())
 
     def test_prompt_must_not_display_on_second_run(self):
-        """
-        On first run, display the prompt. Do *not* display prompt on subsequent runs.
-        """
+        """On first run, display the prompt. Do *not* display prompt on subsequent runs."""
         self.unset_config()
 
         # First Run

--- a/tests/integration/telemetry/test_telemetry_contract.py
+++ b/tests/integration/telemetry/test_telemetry_contract.py
@@ -2,14 +2,10 @@ from .integ_base import IntegBase, TelemetryServer
 
 
 class TestTelemetryContract(IntegBase):
-    """
-    Validates the basic tenets/contract Telemetry module needs to adhere to
-    """
+    """Validates the basic tenets/contract Telemetry module needs to adhere to"""
 
     def test_must_not_send_metrics_if_disabled_using_envvar(self):
-        """
-        No metrics should be sent if "Enabled via Config file but Disabled via Envvar"
-        """
+        """No metrics should be sent if "Enabled via Config file but Disabled via Envvar"""
         # Enable it via configuration file
         self.set_config(telemetry_enabled=True)
 
@@ -31,9 +27,7 @@ class TestTelemetryContract(IntegBase):
             self.assertEqual(1, len(all_requests), "Command run metric should be sent")
 
     def test_must_send_metrics_if_enabled_via_envvar(self):
-        """
-        Metrics should be sent if "Disabled via config file but Enabled via Envvar"
-        """
+        """Metrics should be sent if "Disabled via config file but Enabled via Envvar"""
         # Disable it via configuration file
         self.set_config(telemetry_enabled=False)
 
@@ -55,9 +49,7 @@ class TestTelemetryContract(IntegBase):
             self.assertEqual(1, len(all_requests), "Command run metric must be sent")
 
     def test_must_not_crash_when_offline(self):
-        """
-        Must not crash the process if internet is not available
-        """
+        """Must not crash the process if internet is not available"""
         self.set_config(telemetry_enabled=True)
 
         # DO NOT START Telemetry Server here.

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -28,6 +28,21 @@ class FileCreator(object):
         ``mode`` is the mode the file should be opened either as ``w`` or
         `wb``.
         Returns the full path to the file.
+
+        Parameters
+        ----------
+        filename :
+
+        contents :
+
+        mtime :
+             (Default value = None)
+        mode :
+             (Default value = "w")
+
+        Returns
+        -------
+
         """
         full_path = os.path.join(self.rootdir, filename)
         if not os.path.isdir(os.path.dirname(full_path)):
@@ -46,6 +61,17 @@ class FileCreator(object):
         ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
         It will be translated into a full path in a tmp dir.
         Returns the full path to the file.
+
+        Parameters
+        ----------
+        filename :
+
+        contents :
+
+
+        Returns
+        -------
+
         """
         full_path = os.path.join(self.rootdir, filename)
         if not os.path.isdir(os.path.dirname(full_path)):
@@ -57,5 +83,14 @@ class FileCreator(object):
     def full_path(self, filename):
         """Translate relative path to full path in temp dir.
         f.full_path('foo/bar.txt') -> /tmp/asdfasd/foo/bar.txt
+
+        Parameters
+        ----------
+        filename :
+
+
+        Returns
+        -------
+
         """
         return os.path.join(self.rootdir, filename)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -7,9 +7,15 @@ from samcli.cli.main import cli
 
 class TestCliBase(TestCase):
     def test_cli_base(self):
-        """
-        Just invoke the CLI without any commands and assert that help text was printed
+        """Just invoke the CLI without any commands and assert that help text was printed
         :return:
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         mock_cfg = Mock()
         with patch("samcli.cli.main.global_cfg", mock_cfg):

--- a/tests/unit/commands/local/cli_common/test_invoke_context.py
+++ b/tests/unit/commands/local/cli_common/test_invoke_context.py
@@ -152,9 +152,7 @@ class TestInvokeContext__exit__(TestCase):
 
 
 class TestInvokeContextAsContextManager(TestCase):
-    """
-    Must be able to use the class as a context manager
-    """
+    """Must be able to use the class as a context manager"""
 
     @patch.object(InvokeContext, "__enter__")
     @patch.object(InvokeContext, "__exit__")

--- a/tests/unit/commands/local/lib/test_sam_api_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_api_provider.py
@@ -1243,18 +1243,18 @@ class TestSamCors(TestCase):
 
 
 def make_swagger(routes, binary_media_types=None):
-    """
-    Given a list of API configurations named tuples, returns a Swagger document
+    """Given a list of API configurations named tuples, returns a Swagger document
 
     Parameters
     ----------
     routes : list of samcli.commands.local.agiw.local_agiw_service.Route
+
     binary_media_types : list of str
+         (Default value = None)
 
     Returns
     -------
-    dict
-        Swagger document
+
 
     """
     swagger = {"paths": {}}

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -9,9 +9,7 @@ from samcli.lib.providers.exceptions import InvalidLayerReference
 
 
 class TestSamFunctionProviderEndToEnd(TestCase):
-    """
-    Test all public methods with an input template
-    """
+    """Test all public methods with an input template"""
 
     TEMPLATE = {
         "Resources": {

--- a/tests/unit/commands/samconfig/test_samconfig.py
+++ b/tests/unit/commands/samconfig/test_samconfig.py
@@ -651,26 +651,25 @@ class TestSamConfigWithOverrides(TestCase):
 
 @contextmanager
 def samconfig_parameters(cmd_names, config_dir=None, env=None, **kwargs):
-    """
-    ContextManager to write a new SAM Config and remove the file after the contextmanager exists
+    """ContextManager to write a new SAM Config and remove the file after the contextmanager exists
 
     Parameters
     ----------
     cmd_names : list(str)
         Name of the full commnad split as a list: ["generate-event", "s3", "put"]
-
     config_dir : str
         Path where the SAM config file should be written to. Defaults to os.getcwd()
-
     env : str
-        Optional name of the config environment. This is currently unused
-
+        Optional name of the config environment. This is currently unused (Default value = None)
     kwargs : dict
         Parameter names and values to be written to the file.
+    **kwargs :
+
 
     Returns
     -------
-    Path to the config file
+
+
     """
 
     env = env or DEFAULT_ENV

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -568,9 +568,17 @@ class TestArtifactExporter(unittest.TestCase):
 
     @patch("samcli.lib.package.artifact_exporter.upload_local_artifacts")
     def test_resource_with_s3_url_dict(self, upload_local_artifacts_mock):
-        """
-        Checks if we properly export from the Resource classc
+        """Checks if we properly export from the Resource classc
         :return:
+
+        Parameters
+        ----------
+        upload_local_artifacts_mock :
+
+
+        Returns
+        -------
+
         """
 
         self.assertTrue(issubclass(ResourceWithS3UrlDict, Resource))
@@ -1093,19 +1101,27 @@ class TestArtifactExporter(unittest.TestCase):
                 os.rmdir(filename)
 
     def example_yaml_template(self):
-        return """
-        AWSTemplateFormatVersion: '2010-09-09'
-        Description: Simple CRUD webservice. State is stored in a SimpleTable (DynamoDB) resource.
-        Resources:
-        MyFunction:
-          Type: AWS::Lambda::Function
-          Properties:
+        """
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        type
+            AWSTemplateFormatVersion: '2010-09-09'
+            Description: Simple CRUD webservice. State is stored in a SimpleTable (DynamoDB) resource.
+            Resources:
+            MyFunction:
+            Type: AWS::Lambda::Function
+            Properties:
             Code: ./handler
             Handler: index.get
             Role:
-              Fn::GetAtt:
-              - MyFunctionRole
-              - Arn
+            Fn::GetAtt:
+            - MyFunctionRole
+            - Arn
             Timeout: 20
             Runtime: nodejs4.3
+
         """

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -239,9 +239,15 @@ class TestApiGatewayService(TestCase):
         self.assertEqual(self.service._get_current_route(request_mock), "function")
 
     def test_get_current_route_keyerror(self):
-        """
-        When the a HTTP request for given method+path combination is allowed by Flask but not in the list of routes,
+        """When the a HTTP request for given method+path combination is allowed by Flask but not in the list of routes,
         something is messed up. Flask should be configured only from the list of routes.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         request_mock = Mock()

--- a/tests/unit/local/docker/test_container.py
+++ b/tests/unit/local/docker/test_container.py
@@ -68,9 +68,15 @@ class TestContainer_create(TestCase):
         self.mock_docker_client.networks.get = Mock()
 
     def test_must_create_container_with_required_values(self):
-        """
-        Create a container with only required values. Optional values are not provided
+        """Create a container with only required values. Optional values are not provided
         :return:
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
@@ -97,9 +103,15 @@ class TestContainer_create(TestCase):
         self.mock_docker_client.networks.get.assert_not_called()
 
     def test_must_create_container_including_all_optional_values(self):
-        """
-        Create a container with required and optional values.
+        """Create a container with required and optional values.
         :return:
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
 
         expected_volumes = {
@@ -147,9 +159,17 @@ class TestContainer_create(TestCase):
 
     @patch("samcli.local.docker.utils.os")
     def test_must_create_container_translate_volume_path(self, os_mock):
-        """
-        Create a container with required and optional values, with windows style volume mount.
+        """Create a container with required and optional values, with windows style volume mount.
         :return:
+
+        Parameters
+        ----------
+        os_mock :
+
+
+        Returns
+        -------
+
         """
 
         os_mock.name = "nt"
@@ -203,9 +223,15 @@ class TestContainer_create(TestCase):
         self.mock_docker_client.networks.get.assert_not_called()
 
     def test_must_connect_to_network_on_create(self):
-        """
-        Create a container with only required values. Optional values are not provided
+        """Create a container with only required values. Optional values are not provided
         :return:
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
 
@@ -240,9 +266,15 @@ class TestContainer_create(TestCase):
         network_mock.connect.assert_called_with(container_id)
 
     def test_must_connect_to_host_network_on_create(self):
-        """
-        Create a container with only required values. Optional values are not provided
+        """Create a container with only required values. Optional values are not provided
         :return:
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         expected_volumes = {self.host_dir: {"bind": self.working_dir, "mode": "ro,delegated"}}
 

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -197,8 +197,16 @@ class TestLambdaContainer_get_debug_settings(TestCase):
 
     @parameterized.expand([param(r) for r in set(RUNTIMES_WITH_ENTRYPOINT)])
     def test_debug_arg_must_be_split_by_spaces_and_appended_to_entrypoint(self, runtime):
-        """
-        Debug args list is appended starting at second position in the array
+        """Debug args list is appended starting at second position in the array
+
+        Parameters
+        ----------
+        runtime :
+
+
+        Returns
+        -------
+
         """
         expected_debug_args = ["a=b", "c=d", "e=f"]
         result, _ = LambdaContainer._get_debug_settings(runtime, self.debug_options)
@@ -208,8 +216,16 @@ class TestLambdaContainer_get_debug_settings(TestCase):
 
     @parameterized.expand([param(r) for r in set(RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT)])
     def test_debug_arg_must_be_split_by_spaces_and_appended_to_bootstrap_based_entrypoint(self, runtime):
-        """
-        Debug args list is appended as arguments to bootstrap-args, which is past the fourth position in the array
+        """Debug args list is appended as arguments to bootstrap-args, which is past the fourth position in the array
+
+        Parameters
+        ----------
+        runtime :
+
+
+        Returns
+        -------
+
         """
         expected_debug_args = ["a=b", "c=d", "e=f"]
         result, _ = LambdaContainer._get_debug_settings(runtime, self.debug_options)

--- a/tests/unit/local/lambdafn/test_env_vars.py
+++ b/tests/unit/local/lambdafn/test_env_vars.py
@@ -101,9 +101,7 @@ class TestEnvironmentVariables_resolve(TestCase):
         }
 
     def test_with_no_additional_variables(self):
-        """
-        Test assuming user has *not* passed any environment variables. Only AWS variables should be setup
-        """
+        """Test assuming user has *not* passed any environment variables. Only AWS variables should be setup"""
 
         expected = {
             "AWS_SAM_LOCAL": "true",
@@ -125,9 +123,7 @@ class TestEnvironmentVariables_resolve(TestCase):
         self.assertEqual(result, expected)
 
     def test_with_only_default_values_for_variables(self):
-        """
-        Given only environment variable values, without any shell env values or overridden values
-        """
+        """Given only environment variable values, without any shell env values or overridden values"""
 
         expected = {
             "AWS_SAM_LOCAL": "true",
@@ -153,9 +149,7 @@ class TestEnvironmentVariables_resolve(TestCase):
         self.assertEqual(environ.resolve(), expected)
 
     def test_with_shell_env_value(self):
-        """
-        Given values for the variables from shell environment
-        """
+        """Given values for the variables from shell environment"""
 
         expected = {
             "AWS_SAM_LOCAL": "true",
@@ -184,9 +178,7 @@ class TestEnvironmentVariables_resolve(TestCase):
         self.assertEqual(environ.resolve(), expected)
 
     def test_with_overrides_value(self):
-        """
-        Given values for the variables from user specified overrides
-        """
+        """Given values for the variables from user specified overrides"""
 
         expected = {
             "AWS_SAM_LOCAL": "true",

--- a/tests/unit/local/lambdafn/test_runtime.py
+++ b/tests/unit/local/lambdafn/test_runtime.py
@@ -232,8 +232,18 @@ class TestLambdaRuntime_configure_interrupt(TestCase):
     @patch("samcli.local.lambdafn.runtime.threading")
     @patch("samcli.local.lambdafn.runtime.signal")
     def test_verify_signal_handler(self, SignalMock, ThreadingMock):
-        """
-        Verify the internal implementation of the Signal Handler
+        """Verify the internal implementation of the Signal Handler
+
+        Parameters
+        ----------
+        SignalMock :
+
+        ThreadingMock :
+
+
+        Returns
+        -------
+
         """
         is_debugging = True  # We are debugging. So setup signal
         SignalMock.SIGTERM = "sigterm"
@@ -249,8 +259,18 @@ class TestLambdaRuntime_configure_interrupt(TestCase):
     @patch("samcli.local.lambdafn.runtime.threading")
     @patch("samcli.local.lambdafn.runtime.signal")
     def test_verify_timer_handler(self, SignalMock, ThreadingMock):
-        """
-        Verify the internal implementation of the Signal Handler
+        """Verify the internal implementation of the Signal Handler
+
+        Parameters
+        ----------
+        SignalMock :
+
+        ThreadingMock :
+
+
+        Returns
+        -------
+
         """
         is_debugging = False
 
@@ -297,8 +317,20 @@ class TestLambdaRuntime_get_code_dir(TestCase):
     @patch("samcli.local.lambdafn.runtime.shutil")
     @patch("samcli.local.lambdafn.runtime._unzip_file")
     def test_must_return_a_valid_file(self, unzip_file_mock, shutil_mock, os_mock):
-        """
-        Input is a file that exists, but is not a zip/jar file
+        """Input is a file that exists, but is not a zip/jar file
+
+        Parameters
+        ----------
+        unzip_file_mock :
+
+        shutil_mock :
+
+        os_mock :
+
+
+        Returns
+        -------
+
         """
         code_path = "foo.exe"
 


### PR DESCRIPTION
Why is this change necessary?

* To follow coding conventions, changing all docstrings that are of reST
format to numpy.

How does it address the issue?

* Changes only existing docstrings that were present and does not add
new docstrings, with this change coding conventions that are presented
in the development guide are followed.

What side effects does this change have?

* None
* `pyment` cli was used to make the changes from reST to numpydoc. 
* `pyment -i reST -o numpydoc -t -w $AWS_SAM_CLI_WORKING_DIR`

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
