### PR TITLE
fix: linting

### DIFF
--- a/samcli/commands/package/package_context.py
+++ b/samcli/commands/package/package_context.py
@@ -80,7 +80,7 @@ class PackageContext:
     def run(self):
 
         s3_client = boto3.client(
-            "s3", config=Config(signature_version="s3v4", region_name=self.region if self.region else None),
+            "s3", config=Config(signature_version="s3v4", region_name=self.region if self.region else None)
         )
 
         self.s3_uploader = S3Uploader(s3_client, self.s3_bucket, self.s3_prefix, self.kms_key_id, self.force_upload)


### PR DESCRIPTION
*Why is this change necessary?*

Appveyor gates are failing on linting.

*How does it address the issue?*

Ran against black on ubuntu docker machine to reproduce the issue, turns out be an extra comma. This is however not caught locally running against black on mac os x.

*What side effects does this change have?*

None

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
