### PR TITLE
fix: Nested properties in RESOURCES_WITH_LOCAL_PATHS

### DIFF
--- a/samcli/commands/_utils/resources.py
+++ b/samcli/commands/_utils/resources.py
@@ -32,7 +32,7 @@ RESOURCES_WITH_LOCAL_PATHS = {
     AWS_SERVERLESS_APPLICATION: ["Location"],
     AWS_LAMBDA_LAYERVERSION: ["Content"],
     AWS_SERVERLESS_LAYERVERSION: ["ContentUri"],
-    AWS_GLUE_JOB: ["Command.ScriptLocation"],
+    AWS_GLUE_JOB: [["Command", "ScriptLocation"]],
 }
 
 

--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -141,14 +141,21 @@ def _update_relative_paths(template_dict, original_root, new_root):
 
         for path_prop_name in RESOURCES_WITH_LOCAL_PATHS[resource_type]:
             properties = resource.get("Properties", {})
-            path = properties.get(path_prop_name)
+
+            p_ref = properties
+            if isinstance(path_prop_name, list):
+                for nested_prop_name in path_prop_name[:-1]:
+                    p_ref = p_ref.get(nested_prop_name)
+                path_prop_name = path_prop_name[-1]
+
+            path = p_ref.get(path_prop_name)
 
             updated_path = _resolve_relative_to(path, original_root, new_root)
             if not updated_path:
                 # This path does not need to get updated
                 continue
 
-            properties[path_prop_name] = updated_path
+            p_ref[path_prop_name] = updated_path
 
     # AWS::Includes can be anywhere within the template dictionary. Hence we need to recurse through the
     # dictionary in a separate method to find and update relative paths in there


### PR DESCRIPTION
*#1537*

*Why is this change necessary?*

Nested properties in `RESOURCES_WITH_LOCAL_PATHS` are not handled and tested correctly. Also, using dot notation is not really future-proof in case a real property contains a dot in its name.

This PR is an alternative to #1550 

*How does it address the issue?*

Uses lists instead of dot notation.

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
