### PR TITLE
Allow the characters _:./+- to be used in tag keys during deploy

### DIFF
--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -14,6 +14,7 @@ def _value_regex(delim):
 
 
 KEY_REGEX = '([A-Za-z0-9\\"]+)'
+TAG_KEY_REGEX = '([A-Za-z0-9\\"_:\\./\\+-]+)'
 # Use this regex when you have space as delimiter Ex: "KeyName1=string KeyName2=string"
 VALUE_REGEX_SPACE_DELIM = _value_regex(" ")
 # Use this regex when you have comma as delimiter Ex: "KeyName1=string,KeyName2=string"
@@ -168,7 +169,7 @@ class CfnTags(click.ParamType):
 
     _EXAMPLE = "KeyName1=string KeyName2=string"
 
-    _pattern = r"{key}={value}".format(key=KEY_REGEX, value=VALUE_REGEX_SPACE_DELIM)
+    _pattern = r"{key}={value}".format(key=TAG_KEY_REGEX, value=VALUE_REGEX_SPACE_DELIM)
 
     # NOTE(TheSriram): name needs to be added to click.ParamType requires it.
     name = ""

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -68,7 +68,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 parameter_overrides="Parameter=Clarity",
                 kms_key_id=self.kms_key,
                 no_execute_changeset=True,
-                tags="integ=true clarity=yes",
+                tags="integ=true clarity=yes foo_bar=baz",
             )
 
             deploy_process_no_execute = Popen(deploy_command_list_no_execute, stdout=PIPE)
@@ -89,7 +89,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 notification_arns=self.sns_arn,
                 parameter_overrides="Parameter=Clarity",
                 kms_key_id=self.kms_key,
-                tags="integ=true clarity=yes",
+                tags="integ=true clarity=yes foo_bar=baz",
             )
 
             deploy_process = Popen(deploy_command_list_execute, stdout=PIPE)
@@ -119,7 +119,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=False,
         )
 
@@ -150,7 +150,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=True,
         )
 
@@ -175,7 +175,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=False,
         )
 
@@ -210,7 +210,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=False,
         )
 
@@ -239,7 +239,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=False,
         )
 
@@ -265,7 +265,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=False,
         )
 
@@ -297,7 +297,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=False,
         )
 
@@ -322,7 +322,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             parameter_overrides="Parameter=Clarity",
             kms_key_id=self.kms_key,
             no_execute_changeset=False,
-            tags="integ=true clarity=yes",
+            tags="integ=true clarity=yes foo_bar=baz",
             confirm_changeset=False,
             region="eu-west-2",
         )
@@ -363,7 +363,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             "parameter_overrides": "Parameter=Clarity",
             "kms_key_id": self.kms_key,
             "no_execute_changeset": False,
-            "tags": "integ=true clarity=yes",
+            "tags": "integ=true clarity=yes foo_bar=baz",
             "confirm_changeset": False,
         }
         # Package and Deploy in one go without confirming change set.
@@ -411,7 +411,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             "parameter_overrides": "Parameter=Clarity",
             "kms_key_id": self.kms_key,
             "no_execute_changeset": False,
-            "tags": "integ=true clarity=yes",
+            "tags": "integ=true clarity=yes foo_bar=baz",
             "confirm_changeset": False,
         }
         deploy_command_list = self.get_deploy_command_list(**kwargs)


### PR DESCRIPTION
*Why is this change necessary?*
Using the `aws cloudformation deploy --tags` command, you are allowed to use these characters in the tag keys. Documentation also lists these characters as supported and allowed. With `sam deploy --tags`, it did not work properly due to a regex limiting supported characters to A-Za-z0-9.

*How does it address the issue?*
By adding a regex specifically for tag keys. By using this new regex, `sam deploy --tags 'owner:name=son of anton'` no longer converts the tag key to `name` instead of `owner:name`.
Before:
```
{"name": "son of anton"}
```
After:
```
{"owner:name": "son of anton"}
```

*What side effects does this change have?*
None. More characters allowed in keys and fully backwards compatible.

*Checklist:*

- [ ] ~~Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))~~
- [ ] ~~Write unit tests~~
- [ ] ~~Write/update functional tests~~
- [X] Write/update integration tests
- [X] `make pr` passes
- [ ] ~~Write documentation~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.