### PR TITLE
Add support for importing existing resources

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+awscli==1.17.7
 chevron~=0.12
 click~=7.0
 Flask~=1.0.2

--- a/requirements/isolated.txt
+++ b/requirements/isolated.txt
@@ -2,6 +2,7 @@ arrow==0.15.2
 attrs==19.1.0
 aws-lambda-builders==0.5.0
 aws-sam-translator==1.15.1
+awscli==1.17.7
 binaryornot==0.4.4
 boto3==1.9.228
 botocore==1.12.228

--- a/samcli/cli/types.py
+++ b/samcli/cli/types.py
@@ -19,6 +19,22 @@ VALUE_REGEX_SPACE_DELIM = _value_regex(" ")
 # Use this regex when you have comma as delimiter Ex: "KeyName1=string,KeyName2=string"
 VALUE_REGEX_COMMA_DELIM = _value_regex(",")
 
+class CfnResourcesToImportType(click.ParamType):
+    """
+    TODO. Cleanup. Document. Add error handling.
+    """
+
+    def convert(self, value, param, ctx):
+        # pylint: disable=protected-access
+        import awscli.clidriver
+        d = awscli.clidriver.create_clidriver()
+        name = 'process-cli-arg.cloudformation.create-change-set'
+        rti_arg = d._get_command_table()['cloudformation'] \
+                ._create_command_table()['create-change-set'] \
+                .arg_table['resources-to-import']
+        resources_to_import = d.session.emit(name, cli_argument=rti_arg, value=list(value))[0][1]
+        return resources_to_import
+
 
 class CfnParameterOverridesType(click.ParamType):
     """

--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -8,7 +8,7 @@ from functools import partial
 
 import click
 from click.types import FuncParamType
-from samcli.cli.types import CfnParameterOverridesType, CfnMetadataType, CfnTags
+from samcli.cli.types import CfnParameterOverridesType, CfnResourcesToImportType, CfnMetadataType, CfnTags
 from samcli.commands._utils.custom_options.option_nargs import OptionNargs
 
 
@@ -159,6 +159,16 @@ def parameter_override_click_option():
 def parameter_override_option(f):
     return parameter_override_click_option()(f)
 
+def resources_to_import_click_option():
+    return click.option(
+        "--resources-to-import",
+        cls=OptionNargs,
+        type=CfnResourcesToImportType(),
+        default=[],
+        help="Optional. A string that contains AWS CloudFormation resources to import."
+    )
+def resources_to_import_option(f):
+    return resources_to_import_click_option()(f)
 
 def metadata_click_option():
     return click.option(

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -13,6 +13,7 @@ from samcli.commands._utils.options import (
     metadata_override_option,
     notification_arns_override_option,
     parameter_override_option,
+    resources_to_import_option,
     tags_override_option,
     template_click_option,
 )
@@ -126,10 +127,12 @@ LOG = logging.getLogger(__name__)
     help="Indicates whether to use JSON as the format for "
     "the output AWS CloudFormation template. YAML is used by default.",
 )
+
 @metadata_override_option
 @notification_arns_override_option
 @tags_override_option
 @parameter_override_option
+@resources_to_import_option
 @capabilities_override_option
 @aws_creds_options
 @common_options
@@ -154,6 +157,7 @@ def cli(
     metadata,
     guided,
     confirm_changeset,
+    resources_to_import,
 ):
 
     # All logic must be implemented in the ``do_cli`` method. This helps with easy unit testing
@@ -175,6 +179,7 @@ def cli(
         metadata,
         guided,
         confirm_changeset,
+        resources_to_import,
         ctx.region,
         ctx.profile,
     )  # pragma: no cover
@@ -198,6 +203,7 @@ def do_cli(
     metadata,
     guided,
     confirm_changeset,
+    resources_to_import,
     region,
     profile,
 ):
@@ -215,6 +221,7 @@ def do_cli(
             region=region,
             profile=profile,
             confirm_changeset=confirm_changeset,
+            # TODO: Add resources_to_import?
             capabilities=capabilities,
             parameter_overrides=parameter_overrides,
             config_section=CONFIG_SECTION,
@@ -228,6 +235,7 @@ def do_cli(
         capabilities=guided_context.guided_capabilities if guided else capabilities,
         parameter_overrides=guided_context.guided_parameter_overrides if guided else parameter_overrides,
         confirm_changeset=guided_context.confirm_changeset if guided else confirm_changeset,
+        # TODO: Add resources_to_import?
     )
 
     with osutils.tempfile_platform_independent() as output_template_file:
@@ -266,5 +274,6 @@ def do_cli(
             region=guided_context.guided_region if guided else region,
             profile=profile,
             confirm_changeset=guided_context.confirm_changeset if guided else confirm_changeset,
+            resources_to_import=resources_to_import,
         ) as deploy_context:
             deploy_context.run()

--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -56,6 +56,7 @@ class DeployContext:
         region,
         profile,
         confirm_changeset,
+        resources_to_import,
     ):
         self.template_file = template_file
         self.stack_name = stack_name
@@ -75,6 +76,7 @@ class DeployContext:
         self.s3_uploader = None
         self.deployer = None
         self.confirm_changeset = confirm_changeset
+        self.resources_to_import = resources_to_import
 
     def __enter__(self):
         return self
@@ -125,6 +127,7 @@ class DeployContext:
             self.s3_uploader,
             [{"Key": key, "Value": value} for key, value in self.tags.items()] if self.tags else [],
             region,
+            self.resources_to_import,
             self.fail_on_empty_changeset,
             self.confirm_changeset,
         )
@@ -141,6 +144,7 @@ class DeployContext:
         s3_uploader,
         tags,
         region,
+        resources_to_import,
         fail_on_empty_changeset=True,
         confirm_changeset=False,
     ):
@@ -154,6 +158,7 @@ class DeployContext:
                 notification_arns=notification_arns,
                 s3_uploader=s3_uploader,
                 tags=tags,
+                resources_to_import=resources_to_import,
             )
             click.echo(self.MSG_SHOWCASE_CHANGESET.format(changeset_id=result["Id"]))
 


### PR DESCRIPTION
AWS recently announced support for importing existing resources
into a cloudformation stack:

https://aws.amazon.com/blogs/aws/new-import-existing-resources-into-a-cloudformation-stack/

This commit adds a '--resources-to-import' cli option for doing
the same.

*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/1699

*Why is this change necessary?*

Only necessary if you want to import existing resources. :)


*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
