### PR TITLE
deploy command help improvements

### DIFF
--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -78,7 +78,7 @@ LOG = logging.getLogger(__name__)
     "--s3-prefix",
     required=False,
     help="A prefix name that the command adds to the "
-    "artifacts' name when it uploads them to the S3 bucket."
+    "artifacts' name when it uploads them to the S3 bucket. "
     "The prefix name is a path name (folder name) for the S3 bucket.",
 )
 @click.option(
@@ -90,8 +90,8 @@ LOG = logging.getLogger(__name__)
     "--no-execute-changeset",
     required=False,
     is_flag=True,
-    help="Indicates  whether  to  execute  the"
-    "change  set.  Specify  this flag if you want to view your stack changes "
+    help="Indicates whether to execute the change set. "
+    "Specify this flag if you want to view your stack changes "
     "before executing the change set. The command creates an AWS CloudFormation "
     "change set and then exits without executing the change set. if "
     "the changeset looks satisfactory, the stack changes can be made by "


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
Ugly break points when reading the --help

*How does it address the issue?*
Added some missing trailing spaces

*What side effects does this change have?*
None

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [X] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
