### PR TITLE
feat: boto user agent string for package and deploy

### DIFF
--- a/samcli/commands/deploy/deploy_context.py
+++ b/samcli/commands/deploy/deploy_context.py
@@ -24,6 +24,7 @@ import click
 from samcli.commands.deploy import exceptions as deploy_exceptions
 from samcli.lib.deploy.deployer import Deployer
 from samcli.lib.package.s3_uploader import S3Uploader
+from samcli.lib.utils.botoconfig import get_boto_config_with_user_agent
 from samcli.yamlhelper import yaml_parse
 
 LOG = logging.getLogger(__name__)
@@ -100,11 +101,14 @@ class DeployContext:
         template_size = os.path.getsize(self.template_file)
         if template_size > 51200 and not self.s3_bucket:
             raise deploy_exceptions.DeployBucketRequiredError()
-        cloudformation_client = boto3.client("cloudformation", region_name=self.region if self.region else None)
+        boto_config = get_boto_config_with_user_agent()
+        cloudformation_client = boto3.client(
+            "cloudformation", region_name=self.region if self.region else None, config=boto_config
+        )
 
         s3_client = None
         if self.s3_bucket:
-            s3_client = boto3.client("s3", region_name=self.region if self.region else None)
+            s3_client = boto3.client("s3", region_name=self.region if self.region else None, config=boto_config)
 
             self.s3_uploader = S3Uploader(s3_client, self.s3_bucket, self.s3_prefix, self.kms_key_id, self.force_upload)
 

--- a/samcli/commands/package/package_context.py
+++ b/samcli/commands/package/package_context.py
@@ -26,6 +26,7 @@ from botocore.config import Config
 from samcli.commands.package.exceptions import PackageFailedError
 from samcli.lib.package.artifact_exporter import Template
 from samcli.lib.package.s3_uploader import S3Uploader
+from samcli.lib.utils.botoconfig import get_boto_config_with_user_agent
 from samcli.yamlhelper import yaml_dump
 
 LOG = logging.getLogger(__name__)
@@ -80,7 +81,10 @@ class PackageContext:
     def run(self):
 
         s3_client = boto3.client(
-            "s3", config=Config(signature_version="s3v4", region_name=self.region if self.region else None)
+            "s3",
+            config=get_boto_config_with_user_agent(
+                signature_version="s3v4", region_name=self.region if self.region else None
+            ),
         )
 
         self.s3_uploader = S3Uploader(s3_client, self.s3_bucket, self.s3_prefix, self.kms_key_id, self.force_upload)

--- a/samcli/lib/utils/botoconfig.py
+++ b/samcli/lib/utils/botoconfig.py
@@ -1,0 +1,17 @@
+"""
+Automatically add user agent string to boto configs.
+"""
+from botocore.config import Config
+
+from samcli import __version__
+from samcli.cli.global_config import GlobalConfig
+
+
+def get_boto_config_with_user_agent(**kwargs):
+    gc = GlobalConfig()
+    return Config(
+        user_agent_extra=f"aws-sam-cli/{__version__}/{gc.installation_id}"
+        if gc.telemetry_enabled
+        else f"aws-sam-cli/{__version__}",
+        **kwargs,
+    )


### PR DESCRIPTION
Why is this change necessary?

* The change allows for adding sam cli version and installation id if
telemetry is on during aws services calls.

What side effects does this change have?

* None

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
