### PR TITLE
fix: Handle global value for Function CodeUri in Package

### DIFF
--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -616,7 +616,7 @@ class Template:
             resource_type = resource.get("Type", None)
             resource_dict = resource.get("Properties", None)
 
-            if "CodeUri" not in resource and resource_type == AWS_SERVERLESS_FUNCTION:
+            if "CodeUri" not in resource_dict and resource_type == AWS_SERVERLESS_FUNCTION:
                 code_uri_global = self.template_dict.get("Globals", {}).get("Function", {}).get("CodeUri", None)
                 if code_uri_global is not None and resource_dict is not None:
                     resource_dict["CodeUri"] = code_uri_global
@@ -636,8 +636,8 @@ class Template:
         if "Resources" not in self.template_dict:
             return self.template_dict
 
-        self.template_dict = self.export_global_artifacts(self.template_dict)
         self.template_dict = self.apply_global_values(self.template_dict)
+        self.template_dict = self.export_global_artifacts(self.template_dict)
 
         for resource_id, resource in self.template_dict["Resources"].items():
 

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -602,6 +602,22 @@ class Template:
 
         return template_dict
 
+    def apply_global_values(self, template_dict):
+        """
+        Takes values from the "Global" parameters and applies them to resources where needed for packaging.
+        """
+        for resource_id, resource in self.template_dict["Resources"].items():
+
+            resource_type = resource.get("Type", None)
+            resource_dict = resource.get("Properties", None)
+
+            if 'CodeUri' not in resource and resource_type == AWS_SERVERLESS_FUNCTION:
+                code_uri_global = self.template_dict.get('Globals', {}).get('Function', {}).get('CodeUri', None)
+                if code_uri_global is not None and resource_dict is not None:
+                    resource_dict['CodeUri'] = code_uri_global
+
+        return template_dict
+
     def export(self):
         """
         Exports the local artifacts referenced by the given template to an
@@ -616,6 +632,7 @@ class Template:
             return self.template_dict
 
         self.template_dict = self.export_global_artifacts(self.template_dict)
+        self.template_dict = self.apply_global_values(self.template_dict)
 
         for resource_id, resource in self.template_dict["Resources"].items():
 

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -605,6 +605,11 @@ class Template:
     def apply_global_values(self, template_dict):
         """
         Takes values from the "Global" parameters and applies them to resources where needed for packaging.
+
+        This transform method addresses issue 1706, where CodeUri is expected to be allowed as a global param for
+        packaging, even when there may not be a build step (such as the source being an S3 file). This is the only
+        known use case for using any global values in the package step, so any other such global value applications
+        should be scoped to this method if possible.
         """
         for resource_id, resource in self.template_dict["Resources"].items():
 

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -616,10 +616,10 @@ class Template:
             resource_type = resource.get("Type", None)
             resource_dict = resource.get("Properties", None)
 
-            if 'CodeUri' not in resource and resource_type == AWS_SERVERLESS_FUNCTION:
-                code_uri_global = self.template_dict.get('Globals', {}).get('Function', {}).get('CodeUri', None)
+            if "CodeUri" not in resource and resource_type == AWS_SERVERLESS_FUNCTION:
+                code_uri_global = self.template_dict.get("Globals", {}).get("Function", {}).get("CodeUri", None)
                 if code_uri_global is not None and resource_dict is not None:
-                    resource_dict['CodeUri'] = code_uri_global
+                    resource_dict["CodeUri"] = code_uri_global
 
         return template_dict
 

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -611,7 +611,7 @@ class Template:
         known use case for using any global values in the package step, so any other such global value applications
         should be scoped to this method if possible.
         """
-        for resource_id, resource in self.template_dict["Resources"].items():
+        for _, resource in self.template_dict["Resources"].items():
 
             resource_type = resource.get("Type", None)
             resource_dict = resource.get("Properties", None)

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -610,6 +610,8 @@ class Template:
         packaging, even when there may not be a build step (such as the source being an S3 file). This is the only
         known use case for using any global values in the package step, so any other such global value applications
         should be scoped to this method if possible.
+
+        Intentionally not dealing with Api:DefinitionUri at this point.
         """
         for _, resource in self.template_dict["Resources"].items():
 

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -618,10 +618,11 @@ class Template:
             resource_type = resource.get("Type", None)
             resource_dict = resource.get("Properties", None)
 
-            if "CodeUri" not in resource_dict and resource_type == AWS_SERVERLESS_FUNCTION:
-                code_uri_global = self.template_dict.get("Globals", {}).get("Function", {}).get("CodeUri", None)
-                if code_uri_global is not None and resource_dict is not None:
-                    resource_dict["CodeUri"] = code_uri_global
+            if resource_dict is not None:
+                if "CodeUri" not in resource_dict and resource_type == AWS_SERVERLESS_FUNCTION:
+                    code_uri_global = self.template_dict.get("Globals", {}).get("Function", {}).get("CodeUri", None)
+                    if code_uri_global is not None and resource_dict is not None:
+                        resource_dict["CodeUri"] = code_uri_global
 
         return template_dict
 

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -894,20 +894,13 @@ class TestArtifactExporter(unittest.TestCase):
 
         properties = {"foo": "bar"}
         template_dict = {
-            "Globals": {
-                "Function": {
-                    "CodeUri": "s3://test-bucket/test-key"
-                }
-            },
+            "Globals": {"Function": {"CodeUri": "s3://test-bucket/test-key"}},
             "Resources": {
                 "FunResource": {
                     "Type": "AWS::Serverless::Function",
-                    "Properties": {
-                        "Handler": "lambda.handler",
-                        "Runtime": "nodejs10.x"
-                    }
+                    "Properties": {"Handler": "lambda.handler", "Runtime": "nodejs10.x"},
                 }
-            }
+            },
         }
 
         open_mock = mock.mock_open()
@@ -920,8 +913,7 @@ class TestArtifactExporter(unittest.TestCase):
             exported_template = template_exporter.export()
             self.assertEqual(exported_template, template_dict)
             self.assertEqual(
-                exported_template["Resources"]["FunResource"]["Properties"]["CodeUri"],
-                "s3://test-bucket/test-key"
+                exported_template["Resources"]["FunResource"]["Properties"]["CodeUri"], "s3://test-bucket/test-key"
             )
 
     @patch("samcli.lib.package.artifact_exporter.yaml_parse")

--- a/tests/unit/lib/package/test_artifact_exporter.py
+++ b/tests/unit/lib/package/test_artifact_exporter.py
@@ -875,6 +875,56 @@ class TestArtifactExporter(unittest.TestCase):
             resource_type2_instance.export.assert_called_once_with("Resource2", mock.ANY, template_dir)
 
     @patch("samcli.lib.package.artifact_exporter.yaml_parse")
+    def test_template_export_with_globals(self, yaml_parse_mock):
+        parent_dir = os.path.sep
+        template_dir = os.path.join(parent_dir, "foo", "bar")
+        template_path = os.path.join(template_dir, "path")
+        template_str = self.example_yaml_template()
+
+        resource_type1_class = Mock()
+        resource_type1_class.RESOURCE_TYPE = "resource_type1"
+        resource_type1_instance = Mock()
+        resource_type1_class.return_value = resource_type1_instance
+        resource_type2_class = Mock()
+        resource_type2_class.RESOURCE_TYPE = "resource_type2"
+        resource_type2_instance = Mock()
+        resource_type2_class.return_value = resource_type2_instance
+
+        resources_to_export = [resource_type1_class, resource_type2_class]
+
+        properties = {"foo": "bar"}
+        template_dict = {
+            "Globals": {
+                "Function": {
+                    "CodeUri": "s3://test-bucket/test-key"
+                }
+            },
+            "Resources": {
+                "FunResource": {
+                    "Type": "AWS::Serverless::Function",
+                    "Properties": {
+                        "Handler": "lambda.handler",
+                        "Runtime": "nodejs10.x"
+                    }
+                }
+            }
+        }
+
+        open_mock = mock.mock_open()
+        yaml_parse_mock.return_value = template_dict
+
+        # Patch the file open method to return template string
+        with patch("samcli.lib.package.artifact_exporter.open", open_mock(read_data=template_str)) as open_mock:
+
+            template_exporter = Template(template_path, parent_dir, self.s3_uploader_mock, resources_to_export)
+            exported_template = template_exporter.export()
+            self.assertEqual(exported_template, template_dict)
+            self.assertEqual(
+                exported_template["Resources"]["FunResource"]["Properties"]["CodeUri"],
+                "s3://test-bucket/test-key"
+            )
+
+    @patch("samcli.lib.package.artifact_exporter.yaml_parse")
     def test_template_global_export(self, yaml_parse_mock):
         parent_dir = os.path.sep
         template_dir = os.path.join(parent_dir, "foo", "bar")


### PR DESCRIPTION
*Issue #, if available:* #1706

*Why is this change necessary?*

The `sam package` command does not read any global values over the course of packaging - traditionally, only build and deploy functionality would use any values. Issue #1706 points to an uncommon use case that exposes that some global values do need to be considered, at minimum so that package won't break deploy.

*How does it address the issue?*

Creates an `apply_global_values` method that fetches global values we use (currently just the one) and applies them if/when they are applicable.

*What side effects does this change have?*

None

*Checklist:*

- [N/A] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [X] Write unit tests
- [X] Write/update functional tests
- [X] Write/update integration tests
- [X] `make pr` passes
- [X] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
