### PR TITLE
Efficient deploy log fetching

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -340,10 +340,9 @@ class Deployer:
                 is_reached_old_entry = False
                 for event_items in response_iterator:
                     for event in event_items["StackEvents"]:
-                        current_time_stamp_marker = utc_to_timestamp(event["Timestamp"])
-                        if event["EventId"] not in events and current_time_stamp_marker > time_stamp_marker:
+                        if event["EventId"] not in events and utc_to_timestamp(event["Timestamp"]) > time_stamp_marker:
                             events.add(event["EventId"])
-                            latest_time_stamp_marker = max(latest_time_stamp_marker, current_time_stamp_marker)
+                            latest_time_stamp_marker = max(latest_time_stamp_marker, utc_to_timestamp(event["Timestamp"]))
                             row_color = self.deploy_color.get_stack_events_status_color(status=event["ResourceStatus"])
                             pprint_columns(
                                 columns=[
@@ -359,6 +358,7 @@ class Deployer:
                                 columns_dict=DESCRIBE_STACK_EVENTS_DEFAULT_ARGS.copy(),
                                 color=row_color,
                             )
+                        # Skip already shown old event entries
                         elif utc_to_timestamp(event["Timestamp"]) < time_stamp_marker:
                             time_stamp_marker = latest_time_stamp_marker
                             is_reached_old_entry = True

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -337,7 +337,6 @@ class Deployer:
                 response_iterator = paginator.paginate(StackName=stack_name)
                 stack_status = describe_stacks_resp["Stacks"][0]["StackStatus"]
                 latest_time_stamp_marker = time_stamp_marker
-                is_reached_old_entry = False
                 for event_items in response_iterator:
                     for event in event_items["StackEvents"]:
                         if event["EventId"] not in events and utc_to_timestamp(event["Timestamp"]) > time_stamp_marker:
@@ -363,10 +362,10 @@ class Deployer:
                         # Skip already shown old event entries
                         elif utc_to_timestamp(event["Timestamp"]) < time_stamp_marker:
                             time_stamp_marker = latest_time_stamp_marker
-                            is_reached_old_entry = True
                             break
-                    if is_reached_old_entry:
-                        break
+                    else:  # go to next loop if not break from inside loop
+                        continue
+                    break  # reached here only if break from inner loop!
 
                 if self._check_stack_complete(stack_status):
                     stack_change_in_progress = False

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -342,7 +342,9 @@ class Deployer:
                     for event in event_items["StackEvents"]:
                         if event["EventId"] not in events and utc_to_timestamp(event["Timestamp"]) > time_stamp_marker:
                             events.add(event["EventId"])
-                            latest_time_stamp_marker = max(latest_time_stamp_marker, utc_to_timestamp(event["Timestamp"]))
+                            latest_time_stamp_marker = max(
+                                latest_time_stamp_marker, utc_to_timestamp(event["Timestamp"])
+                            )
                             row_color = self.deploy_color.get_stack_events_status_color(status=event["ResourceStatus"])
                             pprint_columns(
                                 columns=[

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -360,10 +360,11 @@ class Deployer:
                                 color=row_color,
                             )
                         # Skip already shown old event entries
-                        elif utc_to_timestamp(event["Timestamp"]) < time_stamp_marker:
+                        elif utc_to_timestamp(event["Timestamp"]) <= time_stamp_marker:
                             time_stamp_marker = latest_time_stamp_marker
                             break
                     else:  # go to next loop if not break from inside loop
+                        time_stamp_marker = latest_time_stamp_marker  # update marker if all events are new
                         continue
                     break  # reached here only if break from inner loop!
 


### PR DESCRIPTION
*Why is this change necessary?*

This PR improves `sam deploy` inefficient log fetching. Current implementation fetches events repeatidly until deploy finished. And it fetches "all" log events for every fetches. It includes already shown events and old events before the current deployment starts.

So, when we update a stack in many times, sam-cli event showing becomes quite slow. And it takes a little bit longer time after actual stack deployment finished.

*How does it address the issue?*

The PR implementation skip older events and prevent to fetch all, old events.

*What side effects does this change have?*

I guess almost nothing. Maybe the number of API calls increases because it does not fetch all old events.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
