### PR TITLE
fix: config env cannot be other than default

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -103,11 +103,12 @@ def configuration_callback(cmd_name, option_name, config_env_name, saved_callbac
     ctx.default_map = ctx.default_map or {}
     cmd_name = cmd_name or ctx.info_name
     param.default = None
-    config_env_name = value or config_env_name
+    # explicitly ignore values passed to --config-env, can be opened up in the future.
+    config_env_name = DEFAULT_ENV
     config = get_ctx_defaults(cmd_name, provider, ctx, config_env_name=config_env_name)
     ctx.default_map.update(config)
 
-    return saved_callback(ctx, param, value) if saved_callback else value
+    return saved_callback(ctx, param, config_env_name) if saved_callback else config_env_name
 
 
 def get_ctx_defaults(cmd_name, provider, ctx, config_env_name):

--- a/tests/unit/cli/test_cli_config_file.py
+++ b/tests/unit/cli/test_cli_config_file.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 from samcli.commands.exceptions import ConfigException
 from samcli.cli.cli_config_file import TomlProvider, configuration_option, configuration_callback, get_ctx_defaults
-from samcli.lib.config.samconfig import SamConfig
+from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV
 
 
 class MockContext:
@@ -58,6 +58,7 @@ class TestCliConfiguration(TestCase):
     def setUp(self):
         self.cmd_name = "test_cmd"
         self.option_name = "test_option"
+        # No matter what config-env is passed in, default is chosen.
         self.config_env = "test_config_env"
         self.saved_callback = MagicMock()
         self.provider = MagicMock()
@@ -85,8 +86,9 @@ class TestCliConfiguration(TestCase):
             value=self.value,
         )
         self.assertEqual(self.saved_callback.call_count, 1)
-        for arg in [self.ctx, self.param, self.value]:
+        for arg in [self.ctx, self.param, DEFAULT_ENV]:
             self.assertIn(arg, self.saved_callback.call_args[0])
+        self.assertNotIn(self.value, self.saved_callback.call_args[0])
 
     def test_configuration_option(self):
         toml_provider = TomlProvider()


### PR DESCRIPTION
Why is this change necessary?

* This change is necessary because there was code that allowed for using
non default config prefixes, even though an attempt was made to hide
them.

How does it address the issue?

* Irrespective of the configuration prefix passed in to the hidden
option, a default config prefix is always chosen.

What side effects does this change have?

* Users who had subscribed and started using an unsupported option will
be affected.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
