### PR TITLE
chore: version bump on aws-lambda-builders to 0.7.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,5 +11,5 @@ dateparser~=0.7
 python-dateutil~=2.6, <2.8.1
 requests==2.22.0
 serverlessrepo==0.1.9
-aws_lambda_builders==0.6.0
+aws_lambda_builders==0.7.0
 tomlkit==0.5.8

--- a/requirements/isolated.txt
+++ b/requirements/isolated.txt
@@ -1,6 +1,6 @@
 arrow==0.15.2
 attrs==19.1.0
-aws-lambda-builders==0.5.0
+aws-lambda-builders==0.7.0
 aws-sam-translator==1.15.1
 binaryornot==0.4.4
 boto3==1.9.228


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
