### PR TITLE
fix: deploy help text for `--template-file` option.

### DIFF
--- a/samcli/commands/_utils/options.py
+++ b/samcli/commands/_utils/options.py
@@ -113,7 +113,9 @@ def template_click_option(include_build=True):
         callback=partial(get_or_default_template_file_name, include_build=include_build),
         show_default=True,
         is_eager=True,
-        help="AWS SAM template file",
+        help="AWS SAM template which references built artifacts for resources in the template. (if applicable)"
+        if include_build
+        else "AWS SAM template file.",
     )
 
 


### PR DESCRIPTION
Why is this change necessary?

* deploy command has a `--template-file` option but does not say that
the template specified to it needs to contain built artifacts.

How does it address the issue?

* The help text makes it explicit that the template specified to the
`--template-file` option in `sam deploy` needs to contain built
artifacts for the resources specified in the template, if applicable.

What side effects does this change have?

* None

*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
