### PR TITLE
fix: appveyor windows job - python version

### DIFF
--- a/appveyor-windows-build-dotnet.yml
+++ b/appveyor-windows-build-dotnet.yml
@@ -21,7 +21,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'

--- a/appveyor-windows-build-dotnet.yml
+++ b/appveyor-windows-build-dotnet.yml
@@ -17,10 +17,10 @@ environment:
   TEMP: D:\tmp
   TMP: D:\tmp
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'

--- a/appveyor-windows-build-go.yml
+++ b/appveyor-windows-build-go.yml
@@ -21,7 +21,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'

--- a/appveyor-windows-build-go.yml
+++ b/appveyor-windows-build-go.yml
@@ -17,10 +17,10 @@ environment:
   TEMP: D:\tmp
   TMP: D:\tmp
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'

--- a/appveyor-windows-build-java-container.yml
+++ b/appveyor-windows-build-java-container.yml
@@ -21,7 +21,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'

--- a/appveyor-windows-build-java-container.yml
+++ b/appveyor-windows-build-java-container.yml
@@ -17,10 +17,10 @@ environment:
   TEMP: D:\tmp
   TMP: D:\tmp
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'

--- a/appveyor-windows-build-java-ruby-inprocess.yml
+++ b/appveyor-windows-build-java-ruby-inprocess.yml
@@ -12,7 +12,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
 
 install:

--- a/appveyor-windows-build-java-ruby-inprocess.yml
+++ b/appveyor-windows-build-java-ruby-inprocess.yml
@@ -8,10 +8,10 @@ environment:
   APPVEYOR_CI_OVERRIDE: 1
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
 

--- a/appveyor-windows-build-nodejs.yml
+++ b/appveyor-windows-build-nodejs.yml
@@ -21,7 +21,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'

--- a/appveyor-windows-build-nodejs.yml
+++ b/appveyor-windows-build-nodejs.yml
@@ -17,10 +17,10 @@ environment:
   TEMP: D:\tmp
   TMP: D:\tmp
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -40,6 +40,8 @@ install:
     - "echo %PYTHON_HOME%"
     - "echo %PATH%"
     - "python --version"
+    # Check if python3.8 exists on the image
+    - "C:\\Python38-x64\\python.exe --version"
 
     # Upgrade setuptools, wheel and virtualenv
     - "python -m pip install --upgrade setuptools wheel virtualenv"

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -36,12 +36,12 @@ init:
 install:
 
     - ps: "mkdir -Force D:\\tmp"
-    - "SET PATH=%PYTHON_HOME%;%PATH%;C:\\Python36-x64;C:\\Python27-x64;C:\\Python38-x64"
+    - "SET PATH=%PYTHON_HOME%;%PATH%;C:\\Python36-x64;C:\\Python27-x64;C:\\Python38"
     - "echo %PYTHON_HOME%"
     - "echo %PATH%"
     - "python --version"
     # Check if python3.8 exists on the image
-    - "C:\\Python38-x64\\python.exe --version"
+    - "C:\\Python38\\python.exe --version"
 
     # Upgrade setuptools, wheel and virtualenv
     - "python -m pip install --upgrade setuptools wheel virtualenv"

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -35,13 +35,6 @@ init:
 
 install:
 
-    # Make sure the temp directory exists for Python to use.
-    # Install python3.8
-    - "choco install chocolatey-core.extension --version 1.3.3 --force -y"
-    - "choco install python3 --version 3.8.0"
-    - "C:\\Python38\\python.exe -m pip freeze"
-    - "refreshenv"
-
     - ps: "mkdir -Force D:\\tmp"
     - "SET PATH=%PYTHON_HOME%;%PATH%;C:\\Python37-x64;C:\\Python27-x64;C:\\Python38"
     - "echo %PYTHON_HOME%"

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -34,7 +34,12 @@ init:
 
 
 install:
-
+    # Make sure the temp directory exists for Python to use.
+    # Install python3.8
+    - "choco install chocolatey-core.extension --version 1.3.3 --force -y"
+    - "choco install python3 --version 3.8.0"
+    - "C:\\Python38\\python.exe -m pip freeze"
+    - "refreshenv"
     - ps: "mkdir -Force D:\\tmp"
     - "SET PATH=%PYTHON_HOME%;%PATH%;C:\\Python36-x64;C:\\Python27-x64;C:\\Python38"
     - "echo %PYTHON_HOME%"

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -21,7 +21,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -17,10 +17,10 @@ environment:
   TEMP: D:\tmp
   TMP: D:\tmp
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -36,7 +36,7 @@ init:
 install:
 
     - ps: "mkdir -Force D:\\tmp"
-    - "SET PATH=%PYTHON_HOME%;%PATH%;C:\\Python37-x64;C:\\Python27-x64;C:\\Python38"
+    - "SET PATH=%PYTHON_HOME%;%PATH%;C:\\Python36-x64;C:\\Python27-x64;C:\\Python38-x64"
     - "echo %PYTHON_HOME%"
     - "echo %PATH%"
     - "python --version"

--- a/appveyor-windows-build-ruby.yml
+++ b/appveyor-windows-build-ruby.yml
@@ -21,7 +21,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'

--- a/appveyor-windows-build-ruby.yml
+++ b/appveyor-windows-build-ruby.yml
@@ -17,10 +17,10 @@ environment:
   TEMP: D:\tmp
   TMP: D:\tmp
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_VERSION: '3.6.8'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -20,7 +20,6 @@ environment:
   PYTHON_HOME: "C:\\Python37-x64"
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
-  PYTHON_VERSION: '3.7.5'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -16,11 +16,11 @@ environment:
   TEMP: D:\tmp
   TMP: D:\tmp
 
-  # MSI Installers only use Py3.6.6. It is sufficient to test with this version here.
-  PYTHON_HOME: "C:\\Python36-x64"
-  PYTHON_SCRIPTS: "C:\\Python36-x64\\Scripts"
-  PYTHON_EXE: "C:\\Python36-x64\\python.exe"
-  PYTHON_VERSION: '3.6.8'
+  # MSI Installers only use Py3.7.6. It is sufficient to test with this version here.
+  PYTHON_HOME: "C:\\Python37-x64"
+  PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
+  PYTHON_EXE: "C:\\Python37-x64\\python.exe"
+  PYTHON_VERSION: '3.7.5'
   PYTHON_ARCH: '64'
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'


### PR DESCRIPTION
Why is this change necessary?

* With release v0.41.0 - MSIs have version 3.7.6 as their base version.
Appveyor testing needs to reflect that.

How does it address the issue?

* Appveyor test frameworks are now using python 3.7.6. The environment
variables are set according to: https://www.appveyor.com/docs/windows-images-software/

What side effects does this change have?

* None

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
