### PR TITLE
fix(deploy): Allow all Partitions for S3 Policy on managed stack

### DIFF
--- a/samcli/lib/bootstrap/bootstrap.py
+++ b/samcli/lib/bootstrap/bootstrap.py
@@ -17,6 +17,7 @@ from samcli import __version__
 from samcli.cli.global_config import GlobalConfig
 from samcli.commands.exceptions import UserException, CredentialsError, RegionError
 
+
 SAM_CLI_STACK_NAME = "aws-sam-cli-managed-default"
 LOG = logging.getLogger(__name__)
 
@@ -142,9 +143,10 @@ def _get_stack_template():
                   Fn::Join:
                     - ""
                     -
-                      - "arn:aws:s3:::"
-                      -
-                        !Ref SamCliSourceBucket
+                      - "arn:"
+                      - !Ref AWS::Partition
+                      - ":s3:::"
+                      - !Ref SamCliSourceBucket
                       - "/*"
                 Principal:
                   Service: serverlessrepo.amazonaws.com


### PR DESCRIPTION
Solves #1696, where creating the managed stack in any partition but aws
will fail.

*Issue #, if available:*
#1696

*Why is this change necessary?*
Managed stack SAM CLI creates is not deploy-able in partitions outside of 'aws'. 

*How does it address the issue?*
Parameterizes the Partition in the manage stack

*What side effects does this change have?*
None

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
