### PR TITLE
fix: Handle the case for Parameters being empty strings

### DIFF
--- a/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
+++ b/samcli/lib/intrinsic_resolver/intrinsics_symbol_table.py
@@ -208,7 +208,7 @@ class IntrinsicsSymbolTable:
 
         # Handle Default Parameters
         translated = self._parameters.get(logical_id, {}).get("Default")
-        if translated:
+        if translated is not None:
             return translated
         # Handle Default Property Type Resolution
         resource_type = self._resources.get(logical_id, {}).get(IntrinsicsSymbolTable.CFN_RESOURCE_TYPE)

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -223,6 +223,7 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(environ["URLSuffix"], "localhost")
         self.assertEqual(environ["Timeout"], "100")
         self.assertEqual(environ["MyRuntimeVersion"], "v0")
+        self.assertEqual(environ["EmptyDefaultParameter"], "")
 
     @pytest.mark.flaky(reruns=3)
     def test_invoke_with_env_using_parameters_with_custom_region(self):

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -14,6 +14,10 @@ Parameters:
       Default: "5"
       Type: Number
 
+  EmptyDefaultParameter:
+    Type: String
+    Default: ""
+
 Resources:
   HelloWorldServerlessFunction:
     Type: AWS::Serverless::Function
@@ -125,6 +129,7 @@ Resources:
           URLSuffix: !Ref "AWS::URLSuffix"
           Timeout: !Ref DefaultTimeout
           MyRuntimeVersion: !Ref MyRuntimeVersion
+          EmptyDefaultParameter: !Ref EmptyDefaultParameter
 
   TimeoutFunctionWithStringParameter:
     Type: AWS::Serverless::Function

--- a/tests/unit/lib/intrinsic_resolver/test_intrinsics_symbol_table.py
+++ b/tests/unit/lib/intrinsic_resolver/test_intrinsics_symbol_table.py
@@ -74,6 +74,12 @@ class TestSymbolResolution(TestCase):
         result = symbol_resolver.resolve_symbols("Test", IntrinsicResolver.REF)
         self.assertEqual(result, "data")
 
+    def test_parameter_symbols_for_empty_string(self):
+        template = {"Resources": {}, "Parameters": {"Test": {"Default": ""}}}
+        symbol_resolver = IntrinsicsSymbolTable(template=template)
+        result = symbol_resolver.resolve_symbols("Test", IntrinsicResolver.REF)
+        self.assertEqual(result, "")
+
     def test_default_type_resolver_function(self):
         template = {"Resources": {"MyApi": {"Type": "AWS::ApiGateway::RestApi"}}}
         default_type_resolver = {"AWS::ApiGateway::RestApi": {"RootResourceId": lambda logical_id: logical_id}}


### PR DESCRIPTION
*Issue #, if available:*
#1476

*Why is this change necessary?*
When a Parameter is an empty string, we select the name of the Parameter instead of the value during intrinsic resolving. This is unexpected to customers when they want the value to be an empty string.

*How does it address the issue?*
Fixes and allows Empty Strings for Parameters to be resolved correctly.

*What side effects does this change have?*
I don't believe so.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
