### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/tests/integration/init/schemas/schemas_test_data_setup.py
+++ b/tests/integration/init/schemas/schemas_test_data_setup.py
@@ -169,7 +169,7 @@ def _create_3p_schemas(registry_name, schemas_client, no_of_schemas):
         '{"openapi":"3.0.0","info":{"version":"1.0.0","title":"TicketCreated"},"paths":{},"components":{"schemas":{"AWSEvent":{"type":"object",'
         '"required":["detail-type","resources","id","source","time","detail","region","version","account"],"x-amazon-events-detail-type":"MongoDB Trigger for '
         'my_store.reviews","x-amazon-events-source":"aws.partner-mongodb.com","properties":{"detail":{'
-        '"$ref":"#\/components\/schemas\/aws.partner\/mongodb.com\/Ticket.Created"},"detail-type":{"type":"string"},"resources":{"type":"array",'
+        r'"$ref":"#\/components\/schemas\/aws.partner\/mongodb.com\/Ticket.Created"},"detail-type":{"type":"string"},"resources":{"type":"array",'
         '"items":{"type":"string"}},"id":{"type":"string"},"source":{"type":"string"},"time":{"type":"string","format":"date-time"},'
         '"region":{"type":"string","enum":["ap-south-1","eu-west-3","eu-north-1","eu-west-2","eu-west-1","ap-northeast-2","ap-northeast-1","me-south-1",'
         '"sa-east-1","ca-central-1","ap-east-1","cn-north-1","us-gov-west-1","ap-southeast-1","ap-southeast-2","eu-central-1","us-east-1","us-west-1",'

--- a/tests/unit/lib/schemas/test_schemas_api_caller.py
+++ b/tests/unit/lib/schemas/test_schemas_api_caller.py
@@ -230,8 +230,8 @@ class TestSchemasCommand(TestCase):
             "openapi": "3.0.0",
             "info": {"version": "1.0.0", "title": "SomeAwesomeSchema"},
             "paths": {},
-            "Content": '{"components":{"schemas":{"Some\/Awesome\/Schema.Object.1":{"type":"object","required":["foo","bar","baz"],"properties":{"foo":{"type":"string"},'
-            '"bar":{"type":"string"},"baz":{"type":"string"}}},"Some\/Awesome\/Schema.Object$2":{"type":"object","required":["foo","bar","baz"],'
+            "Content": r'{"components":{"schemas":{"Some\/Awesome\/Schema.Object.1":{"type":"object","required":["foo","bar","baz"],"properties":{"foo":{"type":"string"},'
+            r'"bar":{"type":"string"},"baz":{"type":"string"}}},"Some\/Awesome\/Schema.Object$2":{"type":"object","required":["foo","bar","baz"],'
             '"properties":{"foo":{"type":"string"},"bar":{"type":"string"},"baz":{"type":"string"}}}}}}',
         }
         registry_name = "registry1"


### PR DESCRIPTION
*Issue* : Fixes #1777 

*Why is this change necessary?*

Fixes deprecation warnings in Python 3.7+

*How does it address the issue?*

Uses raw strings for the fix.

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
