### PR TITLE
ux: improve deploy outputs text

### DIFF
--- a/samcli/commands/_utils/table_print.py
+++ b/samcli/commands/_utils/table_print.py
@@ -7,6 +7,8 @@ from functools import wraps
 
 import click
 
+MIN_OFFSET = 20
+
 
 def pprint_column_names(format_string, format_kwargs, margin=None, table_header=None, color="yellow"):
     """
@@ -75,7 +77,7 @@ def pprint_column_names(format_string, format_kwargs, margin=None, table_header=
     return pprint_wrap
 
 
-def wrapped_text_generator(texts, width, margin):
+def wrapped_text_generator(texts, width, margin, **textwrap_kwargs):
     """
 
     Return a generator where the contents are wrapped text to a specified width.
@@ -83,13 +85,14 @@ def wrapped_text_generator(texts, width, margin):
     :param texts: list of text that needs to be wrapped at specified width
     :param width: width of the text to be wrapped
     :param margin: margin to be reduced from width for cleaner UX
+    :param textwrap_kwargs: keyword arguments that are passed to textwrap.wrap
     :return: generator of wrapped text
     """
     for text in texts:
-        yield textwrap.wrap(text, width=width - margin)
+        yield textwrap.wrap(text, width=width - margin, **textwrap_kwargs)
 
 
-def pprint_columns(columns, width, margin, format_string, format_args, columns_dict, color="yellow"):
+def pprint_columns(columns, width, margin, format_string, format_args, columns_dict, color="yellow", **textwrap_kwargs):
     """
 
     Print columns based on list of columnar text, associated formatting string and associated format arguments.
@@ -101,12 +104,29 @@ def pprint_columns(columns, width, margin, format_string, format_args, columns_d
     :param format_args: list of offset specifiers
     :param columns_dict: arguments dictionary that have dummy values per column
     :param color: color supplied for rows within the table.
+    :param textwrap_kwargs: keyword arguments that are passed to textwrap.wrap
     :return:
     """
-    for columns_text in zip_longest(*wrapped_text_generator(columns, width, margin), fillvalue=""):
+    for columns_text in zip_longest(*wrapped_text_generator(columns, width, margin, **textwrap_kwargs), fillvalue=""):
         counter = count()
         # Generate columnar data that correspond to the column names and update them.
         for k, _ in columns_dict.items():
             columns_dict[k] = columns_text[next(counter)]
 
         click.secho(format_string.format(*format_args, **columns_dict), fg=color)
+
+
+def newline_per_item(iterable, counter):
+    """
+    Adds a new line based on the index of a given iterable
+    Parameters
+    ----------
+    iterable: Any iterable that implements __len__
+    counter: Current index within the iterable
+
+    Returns
+    -------
+
+    """
+    if counter < len(iterable) - 1:
+        click.echo(message="", nl=True)

--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -31,7 +31,7 @@ from samcli.commands.deploy.exceptions import (
     DeployStackOutPutFailedError,
     DeployBucketInDifferentRegionError,
 )
-from samcli.commands._utils.table_print import pprint_column_names, pprint_columns
+from samcli.commands._utils.table_print import pprint_column_names, pprint_columns, newline_per_item, MIN_OFFSET
 from samcli.commands.deploy import exceptions as deploy_exceptions
 from samcli.lib.package.artifact_exporter import mktempfile, parse_s3_url
 from samcli.lib.utils.time import utc_to_timestamp
@@ -59,8 +59,10 @@ DESCRIBE_CHANGESET_DEFAULT_ARGS = OrderedDict(
 
 DESCRIBE_CHANGESET_TABLE_HEADER_NAME = "CloudFormation stack changeset"
 
-OUTPUTS_FORMAT_STRING = "{OutputKey-Description:<{0}} {OutputValue:<{1}}"
-OUTPUTS_DEFAULTS_ARGS = OrderedDict({"OutputKey-Description": "OutputKey-Description", "OutputValue": "OutputValue"})
+OUTPUTS_FORMAT_STRING = "{Outputs:<{0}}"
+OUTPUTS_DEFAULTS_ARGS = OrderedDict({"Outputs": "Outputs"})
+
+OUTPUTS_TABLE_HEADER_NAME = "CloudFormation outputs from deployed stack"
 
 
 class Deployer:
@@ -398,7 +400,8 @@ class Deployer:
 
             raise deploy_exceptions.DeployFailedError(stack_name=stack_name, msg=str(ex))
 
-        self.get_stack_outputs(stack_name=stack_name)
+        outputs = self.get_stack_outputs(stack_name=stack_name, echo=False)
+        self._stack_outputs(outputs)
 
     def create_and_wait_for_changeset(
         self, stack_name, cfn_template, parameter_values, capabilities, role_arn, notification_arns, s3_uploader, tags
@@ -413,17 +416,29 @@ class Deployer:
         except botocore.exceptions.ClientError as ex:
             raise DeployFailedError(stack_name=stack_name, msg=str(ex))
 
-    @pprint_column_names(format_string=OUTPUTS_FORMAT_STRING, format_kwargs=OUTPUTS_DEFAULTS_ARGS)
+    @pprint_column_names(
+        format_string=OUTPUTS_FORMAT_STRING, format_kwargs=OUTPUTS_DEFAULTS_ARGS, table_header=OUTPUTS_TABLE_HEADER_NAME
+    )
     def _stack_outputs(self, stack_outputs, **kwargs):
-        for output in stack_outputs:
-            pprint_columns(
-                columns=[" - ".join([output["OutputKey"], output.get("Description", "")]), output["OutputValue"]],
-                width=kwargs["width"],
-                margin=kwargs["margin"],
-                format_string=OUTPUTS_FORMAT_STRING,
-                format_args=kwargs["format_args"],
-                columns_dict=OUTPUTS_DEFAULTS_ARGS.copy(),
-            )
+        for counter, output in enumerate(stack_outputs):
+            for k, v in [
+                ("Key", output.get("OutputKey")),
+                ("Description", output.get("Description", "-")),
+                ("Value", output.get("OutputValue")),
+            ]:
+                pprint_columns(
+                    columns=["{k:<{0}}{v:<{0}}".format(MIN_OFFSET, k=k, v=v)],
+                    width=kwargs["width"],
+                    margin=kwargs["margin"],
+                    format_string=OUTPUTS_FORMAT_STRING,
+                    format_args=kwargs["format_args"],
+                    columns_dict=OUTPUTS_DEFAULTS_ARGS.copy(),
+                    color="green",
+                    replace_whitespace=False,
+                    break_long_words=False,
+                    drop_whitespace=False,
+                )
+            newline_per_item(stack_outputs, counter)
 
     def get_stack_outputs(self, stack_name, echo=True):
         try:


### PR DESCRIPTION
* easier to grok the outputs from the deployed stack
* (Key, Description, Value) are new line separated to provide a clean
interface.
* Change stack outputs colors to green as they indicate a successfully
deployed stack.

*Preview*

![SAM CLI Output](https://i.imgur.com/qlu4EHe.png "SAM CLI Output")

*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/1659

*Why is this change necessary?*

* Hard to copy/paste outputs

*How does it address the issue?*

* All output value start from a minimal offset so that they have enough width to showcase without breaks.

*What side effects does this change have?*

* A potentially super long output value could still flow over to the next line.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
