### PR TITLE
fix: `aws-serverless-function` template to have python3.7 runtime

### DIFF
--- a/tests/integration/testdata/package/aws-serverless-function.yaml
+++ b/tests/integration/testdata/package/aws-serverless-function.yaml
@@ -13,6 +13,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.handler
-      Runtime: python3.6
+      Runtime: python3.7
       CodeUri: .
       Timeout: 600


### PR DESCRIPTION
Why is this change necessary?

* python3.6 runtime was not present in the default test environment.

How does it address the issue?

* change runtime to be `python3.7`

What side effects does this change have?

* None

*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
