### PR TITLE
feat: ruby2.7 support in AWS SAM CLI

### DIFF
--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -109,6 +109,7 @@ def get_workflow_config(runtime, code_dir, project_dir):
         "nodejs10.x": BasicWorkflowSelector(NODEJS_NPM_CONFIG),
         "nodejs12.x": BasicWorkflowSelector(NODEJS_NPM_CONFIG),
         "ruby2.5": BasicWorkflowSelector(RUBY_BUNDLER_CONFIG),
+        "ruby2.7": BasicWorkflowSelector(RUBY_BUNDLER_CONFIG),
         "dotnetcore2.0": BasicWorkflowSelector(DOTNET_CLIPACKAGE_CONFIG),
         "dotnetcore2.1": BasicWorkflowSelector(DOTNET_CLIPACKAGE_CONFIG),
         "go1.x": BasicWorkflowSelector(GO_MOD_CONFIG),

--- a/samcli/lib/init/templates/cookiecutter-aws-sam-hello-ruby/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/lib/init/templates/cookiecutter-aws-sam-hello-ruby/{{cookiecutter.project_name}}/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: hello_world/
       Handler: app.lambda_handler
-      Runtime: ruby2.5
+      Runtime: {{ cookiecutter.runtime }}
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -22,7 +22,7 @@ RUNTIME_DEP_TEMPLATE_MAPPING = {
     ],
     "ruby": [
         {
-            "runtimes": ["ruby2.5"],
+            "runtimes": ["ruby2.5", "ruby2.7"],
             "dependency_manager": "bundler",
             "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-ruby"),
             "build": True,
@@ -74,6 +74,7 @@ RUNTIME_TO_DEPENDENCY_MANAGERS = {
     "python3.6": ["pip"],
     "python2.7": ["pip"],
     "ruby2.5": ["bundler"],
+    "ruby2.7": ["bundler"],
     "nodejs12.x": ["npm"],
     "nodejs10.x": ["npm"],
     "dotnetcore2.1": ["cli-package"],
@@ -100,7 +101,7 @@ INIT_RUNTIMES = [
     # latest of each runtime version
     "nodejs12.x",
     "python3.8",
-    "ruby2.5",
+    "ruby2.7",
     "go1.x",
     "java11",
     "dotnetcore2.1",
@@ -111,6 +112,7 @@ INIT_RUNTIMES = [
     "python3.6",
     "python2.7",
     # older ruby runtimes
+    "ruby2.5",
     # older java runtimes
     "java8",
     # older dotnetcore runtimes

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -28,6 +28,7 @@ class Runtime(Enum):
     python37 = "python3.7"
     python38 = "python3.8"
     ruby25 = "ruby2.5"
+    ruby27 = "ruby2.7"
     java8 = "java8"
     java11 = "java11"
     go1x = "go1.x"

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -237,12 +237,12 @@ class TestBuildCommand_RubyFunctions(BuildIntegBase):
     FUNCTION_LOGICAL_ID = "Function"
 
     @pytest.mark.flaky(reruns=3)
-    @parameterized.expand([("ruby2.5")])
+    @parameterized.expand([("ruby2.5"), ("ruby2.7")])
     def test_building_ruby_in_container(self, runtime):
         self._test_with_default_gemfile(runtime, "use_container")
 
     @pytest.mark.flaky(reruns=3)
-    @parameterized.expand([("ruby2.5")])
+    @parameterized.expand([("ruby2.5"), ("ruby2.7")])
     def test_building_ruby_in_process(self, runtime):
         self._test_with_default_gemfile(runtime, False)
 


### PR DESCRIPTION
Why is this change necessary?

* To support ruby2.7 runtime in AWS SAM CLI.

How does it address the issue?

* `sam init`, `sam build` , `sam local` are all supported for ruby2.7

What side effects does this change have?

* None

*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
