### PR TITLE
fix(test): Remove package regression tests

### DIFF
--- a/tests/regression/package/test_package_regression.py
+++ b/tests/regression/package/test_package_regression.py
@@ -22,19 +22,13 @@ class TestPackageRegression(PackageRegressionBase):
 
     @parameterized.expand(
         [
-            "aws-serverless-function.yaml",
             "aws-serverless-api.yaml",
             "aws-appsync-graphqlschema.yaml",
             "aws-appsync-resolver.yaml",
             "aws-appsync-functionconfiguration.yaml",
-            "aws-lambda-function.yaml",
             "aws-apigateway-restapi.yaml",
             "aws-elasticbeanstalk-applicationversion.yaml",
             "aws-cloudformation-stack.yaml",
-            "aws-serverless-application.yaml",
-            "aws-lambda-layerversion.yaml",
-            "aws-serverless-layerversion.yaml",
-            "aws-glue-job.yaml",
             "aws-serverlessrepo-application.yaml",
         ]
     )
@@ -46,19 +40,13 @@ class TestPackageRegression(PackageRegressionBase):
 
     @parameterized.expand(
         [
-            "aws-serverless-function.yaml",
             "aws-serverless-api.yaml",
             "aws-appsync-graphqlschema.yaml",
             "aws-appsync-resolver.yaml",
             "aws-appsync-functionconfiguration.yaml",
-            "aws-lambda-function.yaml",
             "aws-apigateway-restapi.yaml",
             "aws-elasticbeanstalk-applicationversion.yaml",
             "aws-cloudformation-stack.yaml",
-            "aws-serverless-application.yaml",
-            "aws-lambda-layerversion.yaml",
-            "aws-serverless-layerversion.yaml",
-            "aws-glue-job.yaml",
             "aws-serverlessrepo-application.yaml",
         ]
     )
@@ -74,19 +62,13 @@ class TestPackageRegression(PackageRegressionBase):
 
     @parameterized.expand(
         [
-            "aws-serverless-function.yaml",
             "aws-serverless-api.yaml",
             "aws-appsync-graphqlschema.yaml",
             "aws-appsync-resolver.yaml",
             "aws-appsync-functionconfiguration.yaml",
-            "aws-lambda-function.yaml",
             "aws-apigateway-restapi.yaml",
             "aws-elasticbeanstalk-applicationversion.yaml",
             "aws-cloudformation-stack.yaml",
-            "aws-serverless-application.yaml",
-            "aws-lambda-layerversion.yaml",
-            "aws-serverless-layerversion.yaml",
-            "aws-glue-job.yaml",
             "aws-serverlessrepo-application.yaml",
         ]
     )


### PR DESCRIPTION
In a recent change #1789, we updated how we hash local code for package to allow only packaging resources that have changed. We have regression tests that validate package and deploy are the same as AWS CLI. With the change, we are purposefully deviating from AWS CLI's implementation to provide a better experience and therefore need to update our regression tests. We are removing only the package regression tests that are failing due to our known difference in hashing.

*Issue #, if available:*
N/A

*Why is this change necessary?*
Regressions tests are failing on master for a change that will cause a 'regression' between us and AWS CLI.

*How does it address the issue?*
Removes the test that are known to be caused by the change.

*What side effects does this change have?*
None

The follow files were removed due to a CodeUri or other property that has a value of current working directory (local path which is a not a file).
* aws-serverless_function.yaml
* aws-lambda-function.yaml
* aws-lambda-layerversion.yaml
* aws-serverless-layerversion.yaml
* aws-glue-job.yaml

The aws-serverless-application.yaml points to a template (aws-serverless-function.yaml), which has a CodeUri value of current working directory, and also causes the aws-serverless-application.yaml hashing to change. Therefore we needed to remove this file for the package tests as well.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
