### PR TITLE
Feature/lambda empty return

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -266,7 +266,9 @@ class LocalApigwService(BaseLocalService):
         headers = LocalApigwService._merge_response_headers(
             json_output.get("headers") or {}, json_output.get("multiValueHeaders") or {}
         )
-        body = json_output.get("body") or "no data"
+        body = json_output.get("body")
+        if body is None:
+            LOG.warning("Lambda returned empty body!")
         is_base_64_encoded = json_output.get("isBase64Encoded") or False
 
         try:

--- a/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
+++ b/tests/integration/local/invoke/runtimes/test_with_runtime_zips.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 
 from subprocess import Popen, PIPE, TimeoutExpired
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 import pytest
 
 from tests.integration.local.invoke.invoke_integ_base import InvokeIntegBase

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -5,7 +5,7 @@ import copy
 import tempfile
 from unittest import skipIf
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 from subprocess import Popen, PIPE, TimeoutExpired
 from timeit import default_timer as timer
 import pytest

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -528,7 +528,7 @@ class TestServiceResponses(StartApiIntegBaseClass):
         response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode("utf-8"), "no data")
+        self.assertEqual(response.content.decode("utf-8"), "")
         self.assertEqual(response.headers.get("Content-Type"), "application/json")
 
     @pytest.mark.flaky(reruns=3)
@@ -557,12 +557,12 @@ class TestServiceResponses(StartApiIntegBaseClass):
     @pytest.mark.timeout(timeout=600, method="thread")
     def test_default_body(self):
         """
-        Test that if no body is given, the response is 'no data'
+        Test that if no body is given, the response is ''
         """
         response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode("utf-8"), "no data")
+        self.assertEqual(response.content.decode("utf-8"), "")
 
     @pytest.mark.flaky(reruns=3)
     @pytest.mark.timeout(timeout=600, method="thread")
@@ -883,7 +883,7 @@ class TestServiceCorsGlobalRequests(StartApiIntegBaseClass):
         response = requests.get(self.url + "/onlysetstatuscode", timeout=300)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode("utf-8"), "no data")
+        self.assertEqual(response.content.decode("utf-8"), "")
         self.assertEqual(response.headers.get("Content-Type"), "application/json")
         self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), None)
         self.assertEqual(response.headers.get("Access-Control-Allow-Headers"), None)

--- a/tests/unit/cli/test_types.py
+++ b/tests/unit/cli/test_types.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, ANY
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from samcli.cli.types import CfnParameterOverridesType, CfnTags
 from samcli.cli.types import CfnMetadataType

--- a/tests/unit/commands/local/lib/test_sam_api_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_api_provider.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from unittest import TestCase
 
 from unittest.mock import patch
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from samcli.commands.validate.lib.exceptions import InvalidSamDocumentException
 from samcli.lib.providers.api_provider import ApiProvider

--- a/tests/unit/lib/logs/test_formatter.py
+++ b/tests/unit/lib/logs/test_formatter.py
@@ -2,7 +2,7 @@ import json
 
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from samcli.lib.logs.formatter import LogsFormatter, LambdaLogMsgFormatters, KeywordHighlighter, JSONMsgFormatter
 from samcli.lib.logs.event import LogEvent

--- a/tests/unit/lib/utils/test_colors.py
+++ b/tests/unit/lib/utils/test_colors.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 from samcli.lib.utils.colors import Colored
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -493,7 +493,7 @@ class TestServiceParsingLambdaOutput(TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
-        self.assertEqual(body, "no data")
+        self.assertEqual(body, None)
 
 
 class TestService_construct_event(TestCase):

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -169,7 +169,7 @@ class TestLambdaContainer_get_debug_settings(TestCase):
         self.debug_options = DebugContext(debug_ports=[1235], debug_args="a=b c=d e=f")
 
     def test_must_skip_if_debug_port_is_not_specified(self):
-        self.assertEquals(
+        self.assertEqual(
             (None, {}),
             LambdaContainer._get_debug_settings("runtime", None),
             "Must not provide entrypoint if debug port is not given",

--- a/tests/unit/local/lambdafn/test_zip.py
+++ b/tests/unit/local/lambdafn/test_zip.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 from unittest import skipIf
 
 from unittest.mock import Mock, patch
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 from samcli.local.lambdafn.zip import unzip, unzip_from_uri, _override_permissions
 


### PR DESCRIPTION
*Issue #, if available:* #1161

*Why is this change necessary?* The API response when lambda doesn't provide a response was unintuitive.

*How does it address the issue?* The API return value was changed when lambda returns nothing.

*What side effects does this change have?* The API return value was changed to some cases and a log message was added

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
