### PR TITLE
fix: config_dir creation permission. Hex permissions were used instead of octal.

### DIFF
--- a/samcli/commands/init/init_templates.py
+++ b/samcli/commands/init/init_templates.py
@@ -118,7 +118,7 @@ class InitTemplates:
 
     def _shared_dir_check(self, shared_dir):
         try:
-            shared_dir.mkdir(mode=0x700, parents=True, exist_ok=True)
+            shared_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
             return True
         except OSError as ex:
             LOG.warning("WARN: Unable to create shared directory.", exc_info=ex)


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
We are creating folder with permission in Hex format, however we should be using octal format.
*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
