### PR TITLE
Support 4 property errors for Java lambdas

### DIFF
--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -152,11 +152,14 @@ class LambdaOutputParser:
             # Error/Exception that was raised/returned/thrown from the container. To ensure minimal false positives in
             # this checking, we check for all the keys that can occur in Lambda raised/thrown/returned an
             # Error/Exception. This still risks false positives when the data returned matches exactly a dictionary with
-            # the keys 'errorMessage', 'errorType' and 'cause'
+            # the keys 'errorMessage', 'errorType', 'stackTrace' and 'cause'.
+            # This also accounts for a situation where there are three keys returned, two of which are
+            # 'errorMessage' and 'errorType', for languages with different error signatures
             if (
                 isinstance(lambda_response_dict, dict)
-                and len(lambda_response_dict.keys() & {"errorMessage", "errorType", "stackTrace", "cause"})
-                  == len(lambda_response_dict)
+                and ((len(lambda_response_dict.keys() & {"errorMessage", "errorType", "stackTrace", "cause"})
+                  == len(lambda_response_dict))
+                  or (len(lambda_response_dict) - len(lambda_response_dict.keys() & {"errorMessage", "errorType"}) <= 1))
             ):
                 is_lambda_user_error_response = True
         except ValueError:

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -159,8 +159,7 @@ class LambdaOutputParser:
                 isinstance(lambda_response_dict, dict)
                 and len(lambda_response_dict.keys() & {"errorMessage", "errorType"}) == 2
                 and ((len(lambda_response_dict.keys() & {"errorMessage", "errorType", "stackTrace", "cause"})
-                  == len(lambda_response_dict))
-                  or (len(lambda_response_dict) == 3))
+                    == len(lambda_response_dict)) or (len(lambda_response_dict) == 3))
             ):
                 is_lambda_user_error_response = True
         except ValueError:

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -158,8 +158,13 @@ class LambdaOutputParser:
             if (
                 isinstance(lambda_response_dict, dict)
                 and len(lambda_response_dict.keys() & {"errorMessage", "errorType"}) == 2
-                and ((len(lambda_response_dict.keys() & {"errorMessage", "errorType", "stackTrace", "cause"})
-                    == len(lambda_response_dict)) or (len(lambda_response_dict) == 3))
+                and (
+                    (
+                        len(lambda_response_dict.keys() & {"errorMessage", "errorType", "stackTrace", "cause"})
+                        == len(lambda_response_dict)
+                    )
+                    or (len(lambda_response_dict) == 3)
+                )
             ):
                 is_lambda_user_error_response = True
         except ValueError:

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -157,9 +157,10 @@ class LambdaOutputParser:
             # 'errorMessage' and 'errorType', for languages with different error signatures
             if (
                 isinstance(lambda_response_dict, dict)
+                and len(lambda_response_dict.keys() & {"errorMessage", "errorType"}) == 2
                 and ((len(lambda_response_dict.keys() & {"errorMessage", "errorType", "stackTrace", "cause"})
                   == len(lambda_response_dict))
-                  or (len(lambda_response_dict) - len(lambda_response_dict.keys() & {"errorMessage", "errorType"}) <= 1))
+                  or (len(lambda_response_dict) == 3))
             ):
                 is_lambda_user_error_response = True
         except ValueError:

--- a/samcli/local/services/base_local_service.py
+++ b/samcli/local/services/base_local_service.py
@@ -152,12 +152,11 @@ class LambdaOutputParser:
             # Error/Exception that was raised/returned/thrown from the container. To ensure minimal false positives in
             # this checking, we check for all the keys that can occur in Lambda raised/thrown/returned an
             # Error/Exception. This still risks false positives when the data returned matches exactly a dictionary with
-            # the keys 'errorMessage' and 'errorType'.
+            # the keys 'errorMessage', 'errorType' and 'cause'
             if (
                 isinstance(lambda_response_dict, dict)
-                and len(lambda_response_dict) in [2, 3]
-                and "errorMessage" in lambda_response_dict
-                and "errorType" in lambda_response_dict
+                and len(lambda_response_dict.keys() & {"errorMessage", "errorType", "stackTrace", "cause"})
+                  == len(lambda_response_dict)
             ):
                 is_lambda_user_error_response = True
         except ValueError:

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -100,7 +100,8 @@ class TestLambdaOutputParser(TestCase):
             ),
             param(
                 '{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type",'
-                '"cause": "has a cause"}', True
+                '"cause": "has a cause"}', 
+                True,
             ),
             param('{"errorMessage": "has a message", "errorType": "has a type"}', True),
             param(

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -100,7 +100,7 @@ class TestLambdaOutputParser(TestCase):
             ),
             param(
                 '{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type",'
-                '"cause": "has a cause"}', 
+                '"cause": "has a cause"}',
                 True,
             ),
             param('{"errorMessage": "has a message", "errorType": "has a type"}', True),

--- a/tests/unit/local/services/test_base_local_service.py
+++ b/tests/unit/local/services/test_base_local_service.py
@@ -98,6 +98,10 @@ class TestLambdaOutputParser(TestCase):
             param(
                 '{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type"}', True
             ),
+            param(
+                '{"errorMessage": "has a message", "stackTrace": "has a stacktrace", "errorType": "has a type",'
+                '"cause": "has a cause"}', True
+            ),
             param('{"errorMessage": "has a message", "errorType": "has a type"}', True),
             param(
                 '{"error message": "has a message", "stack Trace": "has a stacktrace", "error Type": "has a type"}',


### PR DESCRIPTION
*Issue #1404 *

When a Java thrown exception has a cause, the `start-lambda` runtime does not mark it as a failure. When it does not have a cause, it does.

*How does it address the issue?*
Supports 4 property dicts as sent by Java.

*What side effects does this change have?*
Unknown?

*Checklist:*

- [X] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [X] Write unit tests
- [X] Write/update functional tests
- [X] Write/update integration tests
- [X] `make pr` passes
- [X] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
