### PR TITLE
feat: adding separate bucket based on python version for integration tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
       NOSE_PARAMETERIZED_NO_WARN: 1
       INSTALL_PY_37_PIP: 1
       INSTALL_PY_38_PIP: 1
+      AWS_S3: 'AWS_S3_36'
 
     - PYTHON_HOME: "C:\\Python37-x64"
       PYTHON_VERSION: '3.7.4'
@@ -23,6 +24,7 @@ environment:
       NOSE_PARAMETERIZED_NO_WARN: 1
       INSTALL_PY_36_PIP: 1
       INSTALL_PY_38_PIP: 1
+      AWS_S3: 'AWS_S3_37'
 
     - PYTHON_HOME: "C:\\Python38-x64"
       PYTHON_VERSION: '3.8.0'
@@ -31,6 +33,7 @@ environment:
       NOSE_PARAMETERIZED_NO_WARN: 1
       INSTALL_PY_36_PIP: 1
       INSTALL_PY_37_PIP: 1
+      AWS_S3: 'AWS_S3_38'
 
 for:
   - 

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -29,7 +29,10 @@ class PackageIntegBase(TestCase):
 
         For backwards compatibility we are falling back to reading AWS_S3 so that current tests keep working.
         """
-        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3", False), os.environ.get("AWS_S3"))
+        cls.pre_created_bucket = os.environ.get(
+            os.environ.get("AWS_S3", False),  # Reading env var key for specific bucket.
+            os.environ.get("AWS_S3"),  # Fallback to old logic if separate env key not present.
+        )
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "package")
 

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -29,10 +29,7 @@ class PackageIntegBase(TestCase):
 
         For backwards compatibility we are falling back to reading AWS_S3 so that current tests keep working.
         """
-        cls.pre_created_bucket = os.environ.get(
-            os.environ.get("AWS_S3", False),  # Reading env var key for specific bucket.
-            os.environ.get("AWS_S3"),  # Fallback to old logic if separate env key not present.
-        )
+        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3"), False)
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "package")
 

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -14,7 +14,22 @@ class PackageIntegBase(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")
-        cls.pre_created_bucket = os.environ.get("AWS_S3", False)
+        """
+        Our integration tests use S3 bucket to run several tests. Given that S3 objects are eventually consistent
+        and we are using same bucket for lot of integration tests, we want to have multiple buckets to reduce
+        transient failures. In order to achieve this we created 3 buckets one for each python version we support (3.6,
+        3.7 and 3.8). Tests running for respective python version will use respective bucket.
+
+        AWS_S3 will point to a new environment variable AWS_S3_36 or AWS_S3_37 or AWS_S3_38. This is controlled by
+        Appveyor. These environment variables will hold bucket name to run integration tests. Eg:
+
+        For Python36:
+        AWS_S3=AWS_S3_36
+        AWS_S3_36=aws-sam-cli-canary-region-awssamclitestbucket-forpython36
+
+        For backwards compatibility we are falling back to reading AWS_S3 so that current tests keep working.
+        """
+        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3", False), os.environ.get("AWS_S3"))
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "package")
 

--- a/tests/integration/publish/publish_app_integ_base.py
+++ b/tests/integration/publish/publish_app_integ_base.py
@@ -17,7 +17,10 @@ class PublishAppIntegBase(TestCase):
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")
         """Please read comments in package_integ_base.py for more details around this."""
-        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3", False), os.environ.get("AWS_S3"))
+        cls.pre_created_bucket = os.environ.get(
+            os.environ.get("AWS_S3", False),  # Reading env var key for specific bucket.
+            os.environ.get("AWS_S3"),  # Fallback to old logic if separate env key not present.
+        )
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.bucket_name_placeholder = "<bucket-name>"
         cls.application_name_placeholder = "<application-name>"

--- a/tests/integration/publish/publish_app_integ_base.py
+++ b/tests/integration/publish/publish_app_integ_base.py
@@ -17,10 +17,7 @@ class PublishAppIntegBase(TestCase):
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")
         """Please read comments in package_integ_base.py for more details around this."""
-        cls.pre_created_bucket = os.environ.get(
-            os.environ.get("AWS_S3", False),  # Reading env var key for specific bucket.
-            os.environ.get("AWS_S3"),  # Fallback to old logic if separate env key not present.
-        )
+        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3"), False)
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.bucket_name_placeholder = "<bucket-name>"
         cls.application_name_placeholder = "<application-name>"

--- a/tests/integration/publish/publish_app_integ_base.py
+++ b/tests/integration/publish/publish_app_integ_base.py
@@ -16,7 +16,8 @@ class PublishAppIntegBase(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")
-        cls.pre_created_bucket = os.environ.get("AWS_S3", False)
+        """Please read comments in package_integ_base.py for more details around this."""
+        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3", False), os.environ.get("AWS_S3"))
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.bucket_name_placeholder = "<bucket-name>"
         cls.application_name_placeholder = "<application-name>"

--- a/tests/regression/package/regression_package_base.py
+++ b/tests/regression/package/regression_package_base.py
@@ -18,10 +18,7 @@ class PackageRegressionBase(TestCase):
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")
         """Please read comments in package_integ_base.py for more details around this."""
-        cls.pre_created_bucket = os.environ.get(
-            os.environ.get("AWS_S3", False),  # Reading env var key for specific bucket.
-            os.environ.get("AWS_S3"),  # Fallback to old logic if separate env key not present.
-        )
+        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3"), False)
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[2].joinpath("integration", "testdata", "package")
 

--- a/tests/regression/package/regression_package_base.py
+++ b/tests/regression/package/regression_package_base.py
@@ -18,7 +18,10 @@ class PackageRegressionBase(TestCase):
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")
         """Please read comments in package_integ_base.py for more details around this."""
-        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3", False), os.environ.get("AWS_S3"))
+        cls.pre_created_bucket = os.environ.get(
+            os.environ.get("AWS_S3", False),  # Reading env var key for specific bucket.
+            os.environ.get("AWS_S3"),  # Fallback to old logic if separate env key not present.
+        )
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[2].joinpath("integration", "testdata", "package")
 

--- a/tests/regression/package/regression_package_base.py
+++ b/tests/regression/package/regression_package_base.py
@@ -17,7 +17,8 @@ class PackageRegressionBase(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.region_name = os.environ.get("AWS_DEFAULT_REGION")
-        cls.pre_created_bucket = os.environ.get("AWS_S3", False)
+        """Please read comments in package_integ_base.py for more details around this."""
+        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3", False), os.environ.get("AWS_S3"))
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[2].joinpath("integration", "testdata", "package")
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -3,7 +3,6 @@ import platform
 import tempfile
 import shutil
 
-
 IS_WINDOWS = platform.system().lower() == "windows"
 RUNNING_ON_CI = os.environ.get("APPVEYOR", False)
 RUNNING_TEST_FOR_MASTER_ON_CI = os.environ.get("APPVEYOR_REPO_BRANCH", "master") != "master"


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
        Our integration tests use S3 bucket to run several tests. Given that S3 objects are eventually consistent and we are using same bucket for lot of integration tests, we want to have multiple buckets to reduce transient failures. This change will allow referring correct bucket based on the python version for which test is running.

*How does it address the issue?*
This spreads total number of objects across several buckets and improving sync time to reduce time it takes by S3 to be consistent.

*What side effects does this change have?*
NA

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
