### PR TITLE
fix: bug around using temporary credentials in event bridge integration test.

### DIFF
--- a/tests/integration/init/schemas/schemas_test_data_setup.py
+++ b/tests/integration/init/schemas/schemas_test_data_setup.py
@@ -134,7 +134,8 @@ Y
 aws_access_key_id = {access_key}
 aws_secret_access_key = {secret_key}
 """
-        cred_profile_content += f"aws_session_token={session_token}\n"
+        if session_token:
+            cred_profile_content += f"aws_session_token={session_token}\n"
         return cred_profile_content
 
 

--- a/tests/integration/init/schemas/schemas_test_data_setup.py
+++ b/tests/integration/init/schemas/schemas_test_data_setup.py
@@ -17,14 +17,6 @@ AWS_PROFILE = "AWS_PROFILE"
 SLEEP_TIME = 1
 
 
-def _print_relevant_environment_vars(environ):
-    session = Session()
-    print("Session current region={}".format(session.region_name))
-    print("Session available_profiles={}".format(session.available_profiles))
-    print("Session access_key={}".format(session.get_credentials().access_key))
-    print("Session secret_key={}".format(session.get_credentials().secret_key))
-
-
 class SchemaTestDataSetup(TestCase):
     original_cred_file = None
     original_config_file = None
@@ -72,21 +64,19 @@ Y
         if AWS_DEFAULT_REGION in env:
             self.original_region = env[AWS_DEFAULT_REGION]
 
-        print("Original env values from function before customization:")
-        _print_relevant_environment_vars(env)
         custom_config = self._create_config_file(profile, region)
         session = Session()
         custom_cred = self._create_cred_file(
-            profile, session.get_credentials().access_key, session.get_credentials().secret_key
+            profile,
+            session.get_credentials().access_key,
+            session.get_credentials().secret_key,
+            session.get_credentials().token,
         )
 
         env[AWS_CONFIG_FILE] = custom_config
         env[AWS_SHARED_CREDENTIALS_FILE] = custom_cred
         env[AWS_PROFILE] = profile
         env[AWS_DEFAULT_REGION] = region
-
-        print("Updated env values after customization:")
-        _print_relevant_environment_vars(env)
 
     def _tear_down_custom_config(self):
         env = os.environ
@@ -111,9 +101,6 @@ Y
         else:
             env[AWS_DEFAULT_REGION] = self.original_region
 
-        print("Restored env values after teardown:")
-        _print_relevant_environment_vars(env)
-
         shutil.rmtree(self.config_dir, ignore_errors=True)
 
     def _create_config_file(self, profile, region):
@@ -128,16 +115,27 @@ Y
             file.write(config_file_content)
         return custom_config
 
-    def _create_cred_file(self, profile, access_key, secret_key):
-        cred_file_content = "[default]\naws_access_key_id = {1}\naws_secret_access_key = {2}\n"
+    def _create_cred_file(self, profile, access_key, secret_key, session_token=None):
+        cred_file_content = self._create_cred_profile("default", access_key, secret_key, session_token)
         if profile != DEFAULT:
-            cred_file_content += "\n[{0}]\naws_access_key_id = {1}\naws_secret_access_key = {2}"
-        cred_file_content = cred_file_content.format(profile, access_key, secret_key)
+            cred_file_content += f"\n{self._create_cred_profile(profile, access_key, secret_key, session_token)}"
         custom_cred = os.path.join(self.config_dir, "customcred")
         print("Writing custom creds to {}".format(custom_cred))
         with open(custom_cred, "w") as file:
             file.write(cred_file_content)
         return custom_cred
+
+    def _create_cred_profile(self, profile_name, access_key, secret_key, session_token=None):
+        """
+        Method to create aws credentials entry similar to ~/.aws/credentials file format.
+        """
+        cred_profile_content = f"""
+[{profile_name}]
+aws_access_key_id = {access_key}
+aws_secret_access_key = {secret_key}
+"""
+        cred_profile_content += f"aws_session_token={session_token}\n"
+        return cred_profile_content
 
 
 def setup_partner_schema_data(registry_name, schemas_client):


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
Event bridge integration tests do no respect session token to run secure tests. This code change fixes that.

*How does it address the issue?*
Using session token if present.

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
