### PR TITLE
chore: Upgrade jmespath to remove SyntaxError logs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ chevron~=0.12
 click~=7.0
 Flask~=1.0.2
 boto3~=1.10, >=1.10.29
-jmespath~=0.9.4
+jmespath~=0.9.5
 PyYAML~=5.1
 cookiecutter~=1.6.0
 aws-sam-translator==1.21.0


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
In version 0.9.4 of jmespath in Python3.8, there was SyntaxErrors getting reported to the console. In version of jmespath 0.9.5, this was fixed. 

*How does it address the issue?*
Upgrades the jmespath dependency to one that does not have SyntaxErrors in Python3.8

*What side effects does this change have?*
None.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
