### PR TITLE
refactor: deploy integration tests to use same level of logging.

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import uuid
 import time
+from collections import namedtuple
 from subprocess import Popen, PIPE, TimeoutExpired
 from unittest import skipIf
 
@@ -20,6 +21,8 @@ from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RU
 SKIP_DEPLOY_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 CFN_SLEEP = 3
 TIMEOUT = 300
+
+CommandResult = namedtuple("CommandResult", "process stdout stderr")
 
 
 @skipIf(SKIP_DEPLOY_TESTS, "Skip deploy tests in CI/CD only")
@@ -45,15 +48,9 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             package_command_list = self.get_command_list(
                 s3_bucket=self.s3_bucket.name, template=template_path, output_template_file=output_template_file.name
             )
+            package_process = self._run_command(command_list=package_command_list)
 
-            package_process = Popen(package_command_list, stdout=PIPE)
-            try:
-                package_process.communicate(timeout=TIMEOUT)
-            except TimeoutExpired:
-                package_process.kill()
-                raise
-
-            self.assertEqual(package_process.returncode, 0)
+            self.assertEqual(package_process.process.returncode, 0)
 
             stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
             self.stack_names.append(stack_name)
@@ -73,13 +70,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 tags="integ=true clarity=yes foo_bar=baz",
             )
 
-            deploy_process_no_execute = Popen(deploy_command_list_no_execute, stdout=PIPE)
-            try:
-                deploy_process_no_execute.communicate(timeout=TIMEOUT)
-            except TimeoutExpired:
-                deploy_process_no_execute.kill()
-                raise
-            self.assertEqual(deploy_process_no_execute.returncode, 0)
+            deploy_process_no_execute = self._run_command(deploy_command_list_no_execute)
+            self.assertEqual(deploy_process_no_execute.process.returncode, 0)
 
             # Deploy the given stack with the changeset.
             deploy_command_list_execute = self.get_deploy_command_list(
@@ -94,13 +86,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 tags="integ=true clarity=yes foo_bar=baz",
             )
 
-            deploy_process = Popen(deploy_command_list_execute, stdout=PIPE)
-            try:
-                deploy_process.communicate(timeout=TIMEOUT)
-            except TimeoutExpired:
-                deploy_process.kill()
-                raise
-            self.assertEqual(deploy_process.returncode, 0)
+            deploy_process = self._run_command(deploy_command_list_execute, tag="pnd_no_s3_bucket")
+            self.assertEqual(deploy_process.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_no_package_and_deploy_with_s3_bucket_all_args(self, template_file):
@@ -125,13 +112,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        deploy_process_execute = self._run_command(deploy_command_list, "no_pnd_with_s3_all_args")
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_no_redeploy_on_same_built_artifacts(self, template_file):
@@ -139,13 +121,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Build project
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
-        build_process = Popen(build_command_list, stdout=PIPE)
-        try:
-            build_process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            build_process.kill()
-            raise
-
+        self._run_command(build_command_list, "deploy_no_redeploy_on_same_built_artifacts")
         stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
         self.stack_names.append(stack_name)
 
@@ -165,33 +141,18 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        deploy_process_execute = self._run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
         # ReBuild project, absolutely nothing has changed, will result in same build artifacts.
 
-        build_process = Popen(build_command_list, stdout=PIPE)
-        try:
-            build_process.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            build_process.kill()
-            raise
+        self._run_command(build_command_list)
 
         # Re-deploy, this should cause an empty changeset error and not re-deploy.
         # This will cause a non zero exit code.
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Does not cause a re-deploy
-        self.assertEqual(deploy_process_execute.returncode, 1)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_no_package_and_deploy_with_s3_bucket_all_args_confirm_changeset(self, template_file):
@@ -216,9 +177,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=True,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        deploy_process_execute.communicate("Y".encode(), timeout=TIMEOUT)
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        deploy_process_execute = self._run_command_with_input(deploy_command_list, "Y".encode())
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_s3_bucket(self, template_file):
@@ -241,21 +201,15 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            _, stderr = deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Error asking for s3 bucket
-        self.assertEqual(deploy_process_execute.returncode, 1)
-        stderr = stderr.strip()
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
         self.assertIn(
             bytes(
                 f"S3 Bucket not specified, use --s3-bucket to specify a bucket name or run sam deploy --guided",
                 encoding="utf-8",
             ),
-            stderr,
+            deploy_process_execute.stderr,
         )
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -276,14 +230,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
-        # Error no stack name present
-        self.assertEqual(deploy_process_execute.returncode, 2)
+        deploy_process_execute = self._run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 2)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_capabilities(self, template_file):
@@ -305,14 +253,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
-        # Error capabilities not specified
-        self.assertEqual(deploy_process_execute.returncode, 1)
+        deploy_process_execute = self._run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_template_file(self, template_file):
@@ -331,14 +273,9 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Error template file not specified
-        self.assertEqual(deploy_process_execute.returncode, 1)
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_with_s3_bucket_switch_region(self, template_file):
@@ -363,14 +300,9 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Deploy should succeed
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
 
         # Try to deploy to another region.
         deploy_command_list = self.get_deploy_command_list(
@@ -389,15 +321,10 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             region="eu-west-2",
         )
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            _, stderr = deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Deploy should fail, asking for s3 bucket
-        self.assertEqual(deploy_process_execute.returncode, 1)
-        stderr = stderr.strip()
+        self.assertEqual(deploy_process_execute.process.returncode, 1)
+        stderr = deploy_process_execute.stderr.strip()
         self.assertIn(
             bytes(
                 f"Error: Failed to create/update stack {stack_name} : "
@@ -431,27 +358,17 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(**kwargs)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Deploy should succeed
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
 
         # Deploy with `--no-fail-on-empty-changeset` after deploying the same template first
         deploy_command_list = self.get_deploy_command_list(fail_on_empty_changeset=False, **kwargs)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            stdout, _ = deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Deploy should not fail
-        self.assertEqual(deploy_process_execute.returncode, 0)
-        stdout = stdout.strip()
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+        stdout = deploy_process_execute.stdout.strip()
         self.assertIn(bytes(f"No changes to deploy. Stack {stack_name} is up to date", encoding="utf-8"), stdout)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -478,27 +395,17 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         }
         deploy_command_list = self.get_deploy_command_list(**kwargs)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE)
-        try:
-            deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Deploy should succeed
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
 
         # Deploy with `--fail-on-empty-changeset` after deploying the same template first
         deploy_command_list = self.get_deploy_command_list(fail_on_empty_changeset=True, **kwargs)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            _, stderr = deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
+        deploy_process_execute = self._run_command(deploy_command_list)
         # Deploy should not fail
-        self.assertNotEqual(deploy_process_execute.returncode, 0)
-        stderr = stderr.strip()
+        self.assertNotEqual(deploy_process_execute.process.returncode, 0)
+        stderr = deploy_process_execute.stderr.strip()
         self.assertIn(bytes(f"Error: No changes to deploy. Stack {stack_name} is up to date", encoding="utf-8"), stderr)
 
     @parameterized.expand(["aws-serverless-inline.yaml"])
@@ -510,15 +417,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(
             template_file=template_path, stack_name=stack_name, capabilities="CAPABILITY_IAM"
         )
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        try:
-            _, stderr = deploy_process_execute.communicate(timeout=TIMEOUT)
-        except TimeoutExpired:
-            deploy_process_execute.kill()
-            raise
-        stderr = stderr.strip()
-        print(stderr)
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        deploy_process_execute = self._run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_guided(self, template_file):
@@ -530,11 +430,12 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        deploy_process_execute.communicate("{}\n\n\n\n\n\n".format(stack_name).encode())
+        deploy_process_execute = self._run_command_with_input(
+            deploy_command_list, "{}\n\n\n\n\n\n".format(stack_name).encode()
+        )
 
         # Deploy should succeed with a managed stack
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stack_names.append(SAM_CLI_STACK_NAME)
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
@@ -549,11 +450,12 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        deploy_process_execute.communicate("{}\n\nSuppliedParameter\n\n\n\n".format(stack_name).encode())
+        deploy_process_execute = self._run_command_with_input(
+            deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n".format(stack_name).encode()
+        )
 
         # Deploy should succeed with a managed stack
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stack_names.append(SAM_CLI_STACK_NAME)
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
@@ -568,13 +470,12 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        deploy_process_execute.communicate(
-            "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\n\n".format(stack_name).encode()
+        deploy_process_execute = self._run_command_with_input(
+            deploy_command_list,
+            "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\n\n".format(stack_name).encode(),
         )
-
         # Deploy should succeed with a managed stack
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stack_names.append(SAM_CLI_STACK_NAME)
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
@@ -589,11 +490,42 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = Popen(deploy_command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        deploy_process_execute.communicate("{}\n\nSuppliedParameter\nY\n\n\nY\n".format(stack_name).encode())
+        deploy_process_execute = self._run_command_with_input(
+            deploy_command_list, "{}\n\nSuppliedParameter\nY\n\n\nY\n".format(stack_name).encode()
+        )
 
         # Deploy should succeed with a managed stack
-        self.assertEqual(deploy_process_execute.returncode, 0)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
         self.stack_names.append(SAM_CLI_STACK_NAME)
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
+
+    def _run_command(self, command_list):
+        process_execute = Popen(command_list, stdout=PIPE, stderr=PIPE)
+        try:
+            stdout_data, stderr_data = process_execute.communicate(timeout=TIMEOUT)
+            print(f"=====stdout=====")
+            print(stdout_data.decode("utf-8"))
+            print(f"=====stderr=====")
+            print(stderr_data.decode("utf-8"))
+            return CommandResult(process_execute, stdout_data, stderr_data)
+        except TimeoutExpired:
+            print(f"Command: {command_list}, TIMED OUT")
+            print(f"Return Code: {process_execute.returncode}")
+            process_execute.kill()
+            raise
+
+    def _run_command_with_input(self, command_list, stdin_input):
+        process_execute = Popen(command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        try:
+            stdout_data, stderr_data = process_execute.communicate(stdin_input, timeout=TIMEOUT)
+            print(f"=====stdout=====")
+            print(stdout_data.decode("utf-8"))
+            print(f"=====stderr=====")
+            print(stderr_data.decode("utf-8"))
+            return CommandResult(process_execute, stdout_data, stderr_data)
+        except TimeoutExpired:
+            print(f"Command: {command_list}, TIMED OUT")
+            print(f"Return Code: {process_execute.returncode}")
+            process_execute.kill()
+            raise


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
Our Deploy integration tests sometimes fail without any log message or CFN stack id. This change is extracting some code out around command execution and adding some logging which will be displayed when tests fail.

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
