### PR TITLE
fix(start-api): raise concrete exceptions during parsing of lambda output

### DIFF
--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -9,7 +9,7 @@ from werkzeug.datastructures import Headers
 
 from samcli.lib.providers.provider import Api
 from samcli.lib.providers.provider import Cors
-from samcli.local.apigw.local_apigw_service import LocalApigwService, Route
+from samcli.local.apigw.local_apigw_service import LocalApigwService, Route, LambdaResponseParseException
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 
 
@@ -208,7 +208,7 @@ class TestApiGatewayService(TestCase):
         self, service_error_responses_patch, request_mock
     ):
         parse_output_mock = Mock()
-        parse_output_mock.side_effect = KeyError()
+        parse_output_mock.side_effect = LambdaResponseParseException()
         self.service._parse_lambda_output = parse_output_mock
 
         failure_response_mock = Mock()
@@ -396,7 +396,7 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false, "another_key": "some value"}'
         )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(LambdaResponseParseException):
             LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
     def test_parse_returns_correct_tuple(self):
@@ -412,6 +412,15 @@ class TestServiceParsingLambdaOutput(TestCase):
         self.assertEqual(status_code, 200)
         self.assertEqual(headers, Headers({"Content-Type": "application/json"}))
         self.assertEqual(body, '{"message":"Hello from Lambda"}')
+
+    def test_parse_raises_when_invalid_mimetype(self):
+        lambda_output = (
+            '{"statusCode": 200, "headers": {\\"Content-Type\\": \\"text\\"}, "body": "{\\"message\\":\\"Hello from Lambda\\"}", '
+            '"isBase64Encoded": false}'
+        )
+
+        with self.assertRaises(LambdaResponseParseException):
+            LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
     @patch("samcli.local.apigw.local_apigw_service.LocalApigwService._should_base64_decode_body")
     def test_parse_returns_decodes_base64_to_binary(self, should_decode_body_patch):
@@ -440,7 +449,7 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false}'
         )
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(LambdaResponseParseException):
             LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
     def test_status_code_int_str(self):
@@ -460,7 +469,7 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false}'
         )
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(LambdaResponseParseException):
             LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
     def test_status_code_negative_int_str(self):
@@ -469,19 +478,19 @@ class TestServiceParsingLambdaOutput(TestCase):
             '"isBase64Encoded": false}'
         )
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(LambdaResponseParseException):
             LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
     def test_lambda_output_list_not_dict(self):
         lambda_output = "[]"
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(LambdaResponseParseException):
             LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
     def test_lambda_output_not_json_serializable(self):
         lambda_output = "some str"
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(LambdaResponseParseException):
             LocalApigwService._parse_lambda_output(lambda_output, binary_types=[], flask_request=Mock())
 
     def test_properties_are_null(self):


### PR DESCRIPTION
Putting this in draft and will update with more details on Monday but wanted to send this out today to have appveyor run all the tests.

TLDR: In start-api, we would output 
```
LOG.error(
    "Function returned an invalid response (must include one of: body, headers, multiValueHeaders or "
    "statusCode in the response object). Response received: %s",
    lambda_response,)
```

in cases that made it very difficult to debug my Api Gateway and function locally. For example, we would log the above when the mime type was incorrect. It took me putting SAM CLI into debug to figure out that was the cause of the "internal service error" on the Api.

*Issue #, if available:*
#1770 and #1530 Seem to have the same symptom I saw. I think they are related but it is hard to tell given the issues. 

*Why is this change necessary?*
This updates our error handling when parsing output from the local lambda. Previously, we were raising `KeyError, TypeError, ValueError`, instead of actual more concrete Exceptions. `KeyError, TypeError, ValueError` are thrown in a variety of cases by Python itself and when that happens it leads to a error message reported to the customer that is unclear and wrong.  

*How does it address the issue?*
I removed the explicit need to throw `KeyError, TypeError, ValueError` when parsing output from the Lambda Function. This will make the error cases clear to customers and not obscure the output.

*What side effects does this change have?*
None that I know of.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
