### PR TITLE
chore: Upgrade aws-lambda-builders to 0.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,5 +11,5 @@ dateparser~=0.7
 python-dateutil~=2.6, <2.8.1
 requests==2.22.0
 serverlessrepo==0.1.9
-aws_lambda_builders==0.7.0
+aws_lambda_builders==0.8.0
 tomlkit==0.5.8


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
