### PR TITLE
fix: removing object deletion and using same stack name for integration tests to avoid NoSuchKey errors.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+log_cli = 1
+log_cli_level = INFO
 env =
     AWS_DEFAULT_REGION = ap-southeast-1
 #filterwarnings =

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -53,7 +53,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
             self.assertEqual(package_process.process.returncode, 0)
 
-            stack_name = "test-package-and-deploy-no-s3-bucket-all-args" + CFN_PYTHON_VERSION_SUFFIX
+            stack_name = f"test-package-and-deploy-no-s3-bucket-all-args-{CFN_PYTHON_VERSION_SUFFIX}"
             self.stack_names.append(stack_name)
 
             # Deploy and only show changeset.
@@ -94,7 +94,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-no-package-and-deploy-with-s3-bucket-all-args-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -123,7 +123,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
         self._run_command(build_command_list)
-        stack_name = "test-deploy-no-redeploy-on-same-built-artifacts" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-no-redeploy-on-same-built-artifacts-{CFN_PYTHON_VERSION_SUFFIX}"
         # Should result in a zero exit code.
         deploy_command_list = self.get_deploy_command_list(
             stack_name=stack_name,
@@ -156,7 +156,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args-confirm-changeset" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-no-package-and-deploy-with-s3-bucket-all-args-confirm-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -182,7 +182,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_s3_bucket(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-without-s3-bucket" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-without-s3-bucket-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -235,7 +235,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-without-capabilities" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-without-capabilities-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -256,7 +256,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_template_file(self, template_file):
-        stack_name = "test-deploy-without-template-file" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-without-template-file-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -279,7 +279,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_with_s3_bucket_switch_region(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-with-s3-bucket-switch-region" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-with-s3-bucket-switch-region-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -336,7 +336,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_no_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-twice-with-no-fail-on-empty-changeset" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-twice-with-no-fail-on-empty-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         kwargs = {
@@ -373,7 +373,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-twice-with-fail-on-empty-changeset" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-twice-with-fail-on-empty-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -409,7 +409,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     @parameterized.expand(["aws-serverless-inline.yaml"])
     def test_deploy_inline_no_package(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        stack_name = "test-deploy-inline-no-package" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-inline-no-package-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         deploy_command_list = self.get_deploy_command_list(
@@ -422,7 +422,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-guided-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -442,7 +442,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_parameter(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided-set-parameter" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-guided-set-parameter-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -462,7 +462,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided-set-capabilities" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-guided-set-capabilities-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -482,7 +482,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided-set-confirm-changeset" + CFN_PYTHON_VERSION_SUFFIX
+        stack_name = f"test-deploy-guided-set-confirm-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -21,6 +21,7 @@ from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RU
 SKIP_DEPLOY_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 CFN_SLEEP = 3
 TIMEOUT = 300
+CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "3.6.9").replace(".", "-")
 
 CommandResult = namedtuple("CommandResult", "process stdout stderr")
 
@@ -52,7 +53,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
             self.assertEqual(package_process.process.returncode, 0)
 
-            stack_name = "test-package-and-deploy-no-s3-bucket-all-args"
+            stack_name = "test-package-and-deploy-no-s3-bucket-all-args" + CFN_PYTHON_VERSION_SUFFIX
             self.stack_names.append(stack_name)
 
             # Deploy and only show changeset.
@@ -93,7 +94,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args"
+        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -122,10 +123,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
         self._run_command(build_command_list)
-        stack_name = "test-deploy-no-redeploy-on-same-built-artifacts"
-        self.stack_names.append(stack_name)
-
-        # Package and Deploy in one go without confirming change set on a built template.
+        stack_name = "test-deploy-no-redeploy-on-same-built-artifacts" + CFN_PYTHON_VERSION_SUFFIX
         # Should result in a zero exit code.
         deploy_command_list = self.get_deploy_command_list(
             stack_name=stack_name,
@@ -158,7 +156,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args-confirm-changeset"
+        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args-confirm-changeset" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -184,7 +182,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_s3_bucket(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-without-s3-bucket"
+        stack_name = "test-deploy-without-s3-bucket" + CFN_PYTHON_VERSION_SUFFIX
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -237,7 +235,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-without-capabilities"
+        stack_name = "test-deploy-without-capabilities" + CFN_PYTHON_VERSION_SUFFIX
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -258,7 +256,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_template_file(self, template_file):
-        stack_name = "test-deploy-without-template-file"
+        stack_name = "test-deploy-without-template-file" + CFN_PYTHON_VERSION_SUFFIX
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -281,7 +279,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_with_s3_bucket_switch_region(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-with-s3-bucket-switch-region"
+        stack_name = "test-deploy-with-s3-bucket-switch-region" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -338,7 +336,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_no_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-twice-with-no-fail-on-empty-changeset"
+        stack_name = "test-deploy-twice-with-no-fail-on-empty-changeset" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         kwargs = {
@@ -375,7 +373,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-twice-with-fail-on-empty-changeset"
+        stack_name = "test-deploy-twice-with-fail-on-empty-changeset" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -411,7 +409,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     @parameterized.expand(["aws-serverless-inline.yaml"])
     def test_deploy_inline_no_package(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        stack_name = "test-deploy-inline-no-package"
+        stack_name = "test-deploy-inline-no-package" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         deploy_command_list = self.get_deploy_command_list(
@@ -424,7 +422,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided"
+        stack_name = "test-deploy-guided" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -444,7 +442,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_parameter(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided-set-parameter"
+        stack_name = "test-deploy-guided-set-parameter" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -464,7 +462,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided-set-capabilities"
+        stack_name = "test-deploy-guided-set-capabilities" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -484,7 +482,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "test-deploy-guided-set-confirm-changeset"
+        stack_name = "test-deploy-guided-set-confirm-changeset" + CFN_PYTHON_VERSION_SUFFIX
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -53,7 +53,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
             self.assertEqual(package_process.process.returncode, 0)
 
-            stack_name = f"test-package-and-deploy-no-s3-bucket-all-args-{CFN_PYTHON_VERSION_SUFFIX}"
+            method_name = self.id().split(".")[1]
+            stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
             self.stack_names.append(stack_name)
 
             # Deploy and only show changeset.
@@ -94,7 +95,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-no-package-and-deploy-with-s3-bucket-all-args-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -123,7 +125,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
         self._run_command(build_command_list)
-        stack_name = f"test-deploy-no-redeploy-on-same-built-artifacts-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         # Should result in a zero exit code.
         deploy_command_list = self.get_deploy_command_list(
             stack_name=stack_name,
@@ -156,7 +159,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-no-package-and-deploy-with-s3-bucket-all-args-confirm-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -182,7 +186,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_s3_bucket(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-without-s3-bucket-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -235,7 +240,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-without-capabilities-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -256,7 +262,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_template_file(self, template_file):
-        stack_name = f"test-deploy-without-template-file-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -279,7 +286,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_with_s3_bucket_switch_region(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-with-s3-bucket-switch-region-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -336,7 +344,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_no_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-twice-with-no-fail-on-empty-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         kwargs = {
@@ -373,7 +382,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-twice-with-fail-on-empty-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -409,7 +419,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     @parameterized.expand(["aws-serverless-inline.yaml"])
     def test_deploy_inline_no_package(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        stack_name = f"test-deploy-inline-no-package-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         deploy_command_list = self.get_deploy_command_list(
@@ -422,7 +433,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-guided-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -442,7 +454,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_parameter(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-guided-set-parameter-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -462,7 +475,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-guided-set-capabilities-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -482,7 +496,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = f"test-deploy-guided-set-confirm-changeset-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[1]
+        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -52,7 +52,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
             self.assertEqual(package_process.process.returncode, 0)
 
-            stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+            stack_name = "test-package-and-deploy-no-s3-bucket-all-args"
             self.stack_names.append(stack_name)
 
             # Deploy and only show changeset.
@@ -93,7 +93,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -122,7 +122,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
         self._run_command(build_command_list)
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-no-redeploy-on-same-built-artifacts"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set on a built template.
@@ -158,7 +158,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-no-package-and-deploy-with-s3-bucket-all-args-confirm-changeset"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -184,7 +184,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_s3_bucket(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-without-s3-bucket"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -237,7 +237,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-without-capabilities"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -258,7 +258,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_template_file(self, template_file):
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-without-template-file"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -281,7 +281,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_with_s3_bucket_switch_region(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-with-s3-bucket-switch-region"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -338,7 +338,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_no_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-twice-with-no-fail-on-empty-changeset"
         self.stack_names.append(stack_name)
 
         kwargs = {
@@ -375,7 +375,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-twice-with-fail-on-empty-changeset"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -411,7 +411,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     @parameterized.expand(["aws-serverless-inline.yaml"])
     def test_deploy_inline_no_package(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-inline-no-package"
         self.stack_names.append(stack_name)
 
         deploy_command_list = self.get_deploy_command_list(
@@ -424,7 +424,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-guided"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -444,7 +444,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_parameter(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-guided-set-parameter"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -464,7 +464,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-guided-set-capabilities"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -484,7 +484,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        stack_name = "test-deploy-guided-set-confirm-changeset"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -53,8 +53,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
             self.assertEqual(package_process.process.returncode, 0)
 
-            method_name = self.id().split(".")[1]
-            stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+            method_name = self.id().split(".")[-1]
+            stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
             self.stack_names.append(stack_name)
 
             # Deploy and only show changeset.
@@ -95,8 +95,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -125,8 +125,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
         self._run_command(build_command_list)
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         # Should result in a zero exit code.
         deploy_command_list = self.get_deploy_command_list(
             stack_name=stack_name,
@@ -159,8 +159,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -186,8 +186,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_s3_bucket(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -240,8 +240,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -262,8 +262,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_template_file(self, template_file):
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -286,8 +286,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_with_s3_bucket_switch_region(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -344,8 +344,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_no_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         kwargs = {
@@ -382,8 +382,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -419,8 +419,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     @parameterized.expand(["aws-serverless-inline.yaml"])
     def test_deploy_inline_no_package(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         deploy_command_list = self.get_deploy_command_list(
@@ -433,8 +433,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -454,8 +454,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_parameter(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -475,8 +475,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -496,8 +496,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[1]
-        stack_name = f"{method_name.replace('.', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        method_name = self.id().split(".")[-1]
+        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -127,6 +127,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         self._run_command(build_command_list)
         method_name = self.id().split(".")[-1]
         stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        self.stack_names.append(stack_name)
         # Should result in a zero exit code.
         deploy_command_list = self.get_deploy_command_list(
             stack_name=stack_name,

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -21,7 +21,7 @@ from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RU
 SKIP_DEPLOY_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_BY_CANARY
 CFN_SLEEP = 3
 TIMEOUT = 300
-CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "3.6.9").replace(".", "-")
+CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".", "-")
 
 CommandResult = namedtuple("CommandResult", "process stdout stderr")
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -53,8 +53,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
             self.assertEqual(package_process.process.returncode, 0)
 
-            method_name = self.id().split(".")[-1]
-            stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+            stack_name = self._method_to_stack_name(self.id())
             self.stack_names.append(stack_name)
 
             # Deploy and only show changeset.
@@ -95,8 +94,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -125,8 +123,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
         self._run_command(build_command_list)
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
         # Should result in a zero exit code.
         deploy_command_list = self.get_deploy_command_list(
@@ -160,8 +157,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_no_package_and_deploy_with_s3_bucket_all_args_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -187,8 +183,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_s3_bucket(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -241,8 +236,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_without_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -263,8 +257,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
     @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_without_template_file(self, template_file):
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
 
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(
@@ -287,8 +280,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_with_s3_bucket_switch_region(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -345,8 +337,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_no_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         kwargs = {
@@ -383,8 +374,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_twice_with_fail_on_empty_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -420,8 +410,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     @parameterized.expand(["aws-serverless-inline.yaml"])
     def test_deploy_inline_no_package(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         deploy_command_list = self.get_deploy_command_list(
@@ -434,8 +423,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -455,8 +443,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_parameter(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -476,8 +463,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_capabilities(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -497,8 +483,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
     def test_deploy_guided_set_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 
-        method_name = self.id().split(".")[-1]
-        stack_name = f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"
+        stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
 
         # Package and Deploy in one go without confirming change set.
@@ -543,3 +528,8 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             print(f"Return Code: {process_execute.returncode}")
             process_execute.kill()
             raise
+
+    def _method_to_stack_name(self, method_name):
+        """Method expects method name which can be a full path. Eg: test.integration.test_deploy_command.method_name"""
+        method_name = method_name.split(".")[-1]
+        return f"{method_name.replace('_', '-')}-{CFN_PYTHON_VERSION_SUFFIX}"

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -51,9 +51,10 @@ class PackageIntegBase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.s3_bucket.objects.all().delete()
-        if not cls.pre_created_bucket:
-            cls.s3_bucket.delete()
+        # cls.s3_bucket.objects.all().delete()
+        # if not cls.pre_created_bucket:
+        #     cls.s3_bucket.delete()
+        pass
 
     def base_command(self):
         command = "sam"

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -49,13 +49,6 @@ class PackageIntegBase(TestCase):
     def tearDown(self):
         super(PackageIntegBase, self).tearDown()
 
-    @classmethod
-    def tearDownClass(cls):
-        # cls.s3_bucket.objects.all().delete()
-        # if not cls.pre_created_bucket:
-        #     cls.s3_bucket.delete()
-        pass
-
     def base_command(self):
         command = "sam"
         if os.getenv("SAM_CLI_DEV"):

--- a/tests/integration/publish/publish_app_integ_base.py
+++ b/tests/integration/publish/publish_app_integ_base.py
@@ -54,13 +54,14 @@ class PublishAppIntegBase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.s3_bucket.delete_objects(
-            Delete={
-                "Objects": [{"Key": "LICENSE"}, {"Key": "README.md"}, {"Key": "README_UPDATE.md"}, {"Key": "main.py"}]
-            }
-        )
-        if not cls.pre_created_bucket:
-            cls.s3_bucket.delete()
+        # cls.s3_bucket.delete_objects(
+        #     Delete={
+        #         "Objects": [{"Key": "LICENSE"}, {"Key": "README.md"}, {"Key": "README_UPDATE.md"}, {"Key": "main.py"}]
+        #     }
+        # )
+        # if not cls.pre_created_bucket:
+        #     cls.s3_bucket.delete()
+        pass
 
     @classmethod
     def replace_template_placeholder(cls, placeholder, replace_text):

--- a/tests/integration/publish/publish_app_integ_base.py
+++ b/tests/integration/publish/publish_app_integ_base.py
@@ -53,17 +53,6 @@ class PublishAppIntegBase(TestCase):
         cls.s3_bucket.put_object(Key="main.py", Body=code_body)
 
     @classmethod
-    def tearDownClass(cls):
-        # cls.s3_bucket.delete_objects(
-        #     Delete={
-        #         "Objects": [{"Key": "LICENSE"}, {"Key": "README.md"}, {"Key": "README_UPDATE.md"}, {"Key": "main.py"}]
-        #     }
-        # )
-        # if not cls.pre_created_bucket:
-        #     cls.s3_bucket.delete()
-        pass
-
-    @classmethod
     def replace_template_placeholder(cls, placeholder, replace_text):
         for f in cls.temp_dir.iterdir():
             if f.suffix == ".yaml" or f.suffix == ".json":


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
We often see NoSuchKey error when running integration tests when trying to use object uploaded to S3. For our integration tests we rarely change our objects.

*How does it address the issue?*
 This change will stop object deletion at the end of integration test, so that we have higher chance of successful integration test.

*What side effects does this change have?*
None

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
