### PR TITLE
add missing --no-confirm-changeset option

### DIFF
--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -115,6 +115,7 @@ LOG = logging.getLogger(__name__)
 )
 @click.option(
     "--confirm-changeset/--no-confirm-changeset",
+    default=False,
     required=False,
     is_flag=True,
     help="Prompt to confirm if the computed changeset is to be deployed by SAM CLI.",

--- a/samcli/commands/deploy/command.py
+++ b/samcli/commands/deploy/command.py
@@ -114,7 +114,7 @@ LOG = logging.getLogger(__name__)
     "non-zero exit code.",
 )
 @click.option(
-    "--confirm-changeset",
+    "--confirm-changeset/--no-confirm-changeset",
     required=False,
     is_flag=True,
     help="Prompt to confirm if the computed changeset is to be deployed by SAM CLI.",

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -116,6 +116,34 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
+    def test_no_package_and_deploy_with_s3_bucket_and_no_confirm_changeset(self, template_file):
+        template_path = self.test_data_path.joinpath(template_file)
+
+        stack_name = "a" + str(uuid.uuid4()).replace("-", "")[:10]
+        self.stack_names.append(stack_name)
+
+        # Package and Deploy in one go without confirming change set.
+        deploy_command_list = self.get_deploy_command_list(
+            template_file=template_path,
+            stack_name=stack_name,
+            capabilities="CAPABILITY_IAM",
+            s3_prefix="integ_deploy",
+            s3_bucket=self.s3_bucket.name,
+            force_upload=True,
+            notification_arns=self.sns_arn,
+            parameter_overrides="Parameter=Clarity",
+            kms_key_id=self.kms_key,
+            no_execute_changeset=False,
+            tags="integ=true clarity=yes foo_bar=baz",
+            confirm_changeset=False,
+        )
+
+        deploy_command_list.append("--no-confirm-changeset")
+
+        deploy_process_execute = self._run_command(deploy_command_list)
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+
+    @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_no_redeploy_on_same_built_artifacts(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
         # Build project

--- a/tests/integration/package/package_integ_base.py
+++ b/tests/integration/package/package_integ_base.py
@@ -29,7 +29,11 @@ class PackageIntegBase(TestCase):
 
         For backwards compatibility we are falling back to reading AWS_S3 so that current tests keep working.
         """
-        cls.pre_created_bucket = os.environ.get(os.environ.get("AWS_S3"), False)
+        s3_bucket_from_env_var = os.environ.get("AWS_S3")
+        if s3_bucket_from_env_var:
+            cls.pre_created_bucket = os.environ.get(s3_bucket_from_env_var, False)
+        else:
+            cls.pre_created_bucket = False
         cls.bucket_name = cls.pre_created_bucket if cls.pre_created_bucket else str(uuid.uuid4())
         cls.test_data_path = Path(__file__).resolve().parents[1].joinpath("testdata", "package")
 


### PR DESCRIPTION
*Why is this change necessary?*

It is impossible to switch changeset confirmation off


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
