### PR TITLE
fix: adding separate bucket env var to windows appveyor file.

### DIFF
--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -25,6 +25,7 @@ environment:
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
   NOSE_PARAMETERIZED_NO_WARN: 1
+  AWS_S3: 'AWS_S3_37_WIN'
 
 init:
   # Uncomment this for RDP


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
We have recently moved to using separate bucket for individual test run. This change is needed to make windows run compatible with that change.
*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
