### PR TITLE
fix: buildcmd to use same level of logging as deploy integration tests.

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -3,8 +3,6 @@ import shutil
 import tempfile
 import uuid
 import time
-from collections import namedtuple
-from subprocess import Popen, PIPE, TimeoutExpired
 from unittest import skipIf
 
 import boto3
@@ -15,6 +13,7 @@ from samcli.lib.bootstrap.bootstrap import SAM_CLI_STACK_NAME
 from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
+from tests.testing_utils import CommandResult, _run_command, _run_command_with_input
 
 # Deploy tests require credentials and CI/CD will only add credentials to the env if the PR is from the same repo.
 # This is to restrict package tests to run outside of CI/CD, when the branch is not master or tests are not run by Canary.
@@ -22,8 +21,6 @@ SKIP_DEPLOY_TESTS = RUNNING_ON_CI and RUNNING_TEST_FOR_MASTER_ON_CI and not RUN_
 CFN_SLEEP = 3
 TIMEOUT = 300
 CFN_PYTHON_VERSION_SUFFIX = os.environ.get("PYTHON_VERSION", "0.0.0").replace(".", "-")
-
-CommandResult = namedtuple("CommandResult", "process stdout stderr")
 
 
 @skipIf(SKIP_DEPLOY_TESTS, "Skip deploy tests in CI/CD only")
@@ -49,7 +46,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             package_command_list = self.get_command_list(
                 s3_bucket=self.s3_bucket.name, template=template_path, output_template_file=output_template_file.name
             )
-            package_process = self._run_command(command_list=package_command_list)
+            package_process = _run_command(command_list=package_command_list)
 
             self.assertEqual(package_process.process.returncode, 0)
 
@@ -71,7 +68,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 tags="integ=true clarity=yes foo_bar=baz",
             )
 
-            deploy_process_no_execute = self._run_command(deploy_command_list_no_execute)
+            deploy_process_no_execute = _run_command(deploy_command_list_no_execute)
             self.assertEqual(deploy_process_no_execute.process.returncode, 0)
 
             # Deploy the given stack with the changeset.
@@ -87,7 +84,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 tags="integ=true clarity=yes foo_bar=baz",
             )
 
-            deploy_process = self._run_command(deploy_command_list_execute)
+            deploy_process = _run_command(deploy_command_list_execute)
             self.assertEqual(deploy_process.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -113,7 +110,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -122,7 +119,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Build project
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
-        self._run_command(build_command_list)
+        _run_command(build_command_list)
         stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
         # Should result in a zero exit code.
@@ -140,16 +137,16 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         # ReBuild project, absolutely nothing has changed, will result in same build artifacts.
 
-        self._run_command(build_command_list)
+        _run_command(build_command_list)
 
         # Re-deploy, this should cause an empty changeset error and not re-deploy.
         # This will cause a non zero exit code.
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Does not cause a re-deploy
         self.assertEqual(deploy_process_execute.process.returncode, 1)
 
@@ -176,7 +173,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=True,
         )
 
-        deploy_process_execute = self._run_command_with_input(deploy_command_list, "Y".encode())
+        deploy_process_execute = _run_command_with_input(deploy_command_list, "Y".encode())
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -200,7 +197,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Error asking for s3 bucket
         self.assertEqual(deploy_process_execute.process.returncode, 1)
         self.assertIn(
@@ -229,7 +226,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 2)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -252,7 +249,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 1)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -272,7 +269,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Error template file not specified
         self.assertEqual(deploy_process_execute.process.returncode, 1)
 
@@ -299,7 +296,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Deploy should succeed
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
@@ -320,7 +317,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             region="eu-west-2",
         )
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Deploy should fail, asking for s3 bucket
         self.assertEqual(deploy_process_execute.process.returncode, 1)
         stderr = deploy_process_execute.stderr.strip()
@@ -357,14 +354,14 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(**kwargs)
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Deploy should succeed
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
         # Deploy with `--no-fail-on-empty-changeset` after deploying the same template first
         deploy_command_list = self.get_deploy_command_list(fail_on_empty_changeset=False, **kwargs)
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Deploy should not fail
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         stdout = deploy_process_execute.stdout.strip()
@@ -394,14 +391,14 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         }
         deploy_command_list = self.get_deploy_command_list(**kwargs)
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Deploy should succeed
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
         # Deploy with `--fail-on-empty-changeset` after deploying the same template first
         deploy_command_list = self.get_deploy_command_list(fail_on_empty_changeset=True, **kwargs)
 
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         # Deploy should not fail
         self.assertNotEqual(deploy_process_execute.process.returncode, 0)
         stderr = deploy_process_execute.stderr.strip()
@@ -416,7 +413,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(
             template_file=template_path, stack_name=stack_name, capabilities="CAPABILITY_IAM"
         )
-        deploy_process_execute = self._run_command(deploy_command_list)
+        deploy_process_execute = _run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -429,7 +426,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = self._run_command_with_input(
+        deploy_process_execute = _run_command_with_input(
             deploy_command_list, "{}\n\n\n\n\n\n".format(stack_name).encode()
         )
 
@@ -449,7 +446,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = self._run_command_with_input(
+        deploy_process_execute = _run_command_with_input(
             deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n".format(stack_name).encode()
         )
 
@@ -469,7 +466,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = self._run_command_with_input(
+        deploy_process_execute = _run_command_with_input(
             deploy_command_list,
             "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\n\n".format(stack_name).encode(),
         )
@@ -489,7 +486,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = self._run_command_with_input(
+        deploy_process_execute = _run_command_with_input(
             deploy_command_list, "{}\n\nSuppliedParameter\nY\n\n\nY\n".format(stack_name).encode()
         )
 
@@ -498,36 +495,6 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         self.stack_names.append(SAM_CLI_STACK_NAME)
         # Remove samconfig.toml
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
-
-    def _run_command(self, command_list):
-        process_execute = Popen(command_list, stdout=PIPE, stderr=PIPE)
-        try:
-            stdout_data, stderr_data = process_execute.communicate(timeout=TIMEOUT)
-            print(f"=====stdout=====")
-            print(stdout_data.decode("utf-8"))
-            print(f"=====stderr=====")
-            print(stderr_data.decode("utf-8"))
-            return CommandResult(process_execute, stdout_data, stderr_data)
-        except TimeoutExpired:
-            print(f"Command: {command_list}, TIMED OUT")
-            print(f"Return Code: {process_execute.returncode}")
-            process_execute.kill()
-            raise
-
-    def _run_command_with_input(self, command_list, stdin_input):
-        process_execute = Popen(command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
-        try:
-            stdout_data, stderr_data = process_execute.communicate(stdin_input, timeout=TIMEOUT)
-            print(f"=====stdout=====")
-            print(stdout_data.decode("utf-8"))
-            print(f"=====stderr=====")
-            print(stderr_data.decode("utf-8"))
-            return CommandResult(process_execute, stdout_data, stderr_data)
-        except TimeoutExpired:
-            print(f"Command: {command_list}, TIMED OUT")
-            print(f"Return Code: {process_execute.returncode}")
-            process_execute.kill()
-            raise
 
     def _method_to_stack_name(self, method_name):
         """Method expects method name which can be a full path. Eg: test.integration.test_deploy_command.method_name"""

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,13 +1,49 @@
+import logging
 import os
 import platform
 import tempfile
 import shutil
+from collections import namedtuple
+from subprocess import Popen, PIPE, TimeoutExpired
 
 IS_WINDOWS = platform.system().lower() == "windows"
 RUNNING_ON_CI = os.environ.get("APPVEYOR", False)
 RUNNING_TEST_FOR_MASTER_ON_CI = os.environ.get("APPVEYOR_REPO_BRANCH", "master") != "master"
 CI_OVERRIDE = os.environ.get("APPVEYOR_CI_OVERRIDE", False)
 RUN_BY_CANARY = os.environ.get("BY_CANARY", False)
+
+LOG = logging.getLogger(__name__)
+
+CommandResult = namedtuple("CommandResult", "process stdout stderr")
+TIMEOUT = 300
+
+
+def _run_command(command_list, cwd=None, env=None, timeout=TIMEOUT) -> CommandResult:
+    process_execute = Popen(command_list, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE)
+    try:
+        stdout_data, stderr_data = process_execute.communicate(timeout=timeout)
+        LOG.info(f"Stdout: {stdout_data.decode('utf-8')}")
+        LOG.info(f"Stderr: {stderr_data.decode('utf-8')}")
+        return CommandResult(process_execute, stdout_data, stderr_data)
+    except TimeoutExpired:
+        LOG.error(f"Command: {command_list}, TIMED OUT")
+        LOG.error(f"Return Code: {process_execute.returncode}")
+        process_execute.kill()
+        raise
+
+
+def _run_command_with_input(command_list, stdin_input, timeout=TIMEOUT) -> CommandResult:
+    process_execute = Popen(command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+    try:
+        stdout_data, stderr_data = process_execute.communicate(stdin_input, timeout=timeout)
+        LOG.info(f"Stdout: {stdout_data.decode('utf-8')}")
+        LOG.info(f"Stderr: {stderr_data.decode('utf-8')}")
+        return CommandResult(process_execute, stdout_data, stderr_data)
+    except TimeoutExpired:
+        LOG.error(f"Command: {command_list}, TIMED OUT")
+        LOG.error(f"Return Code: {process_execute.returncode}")
+        process_execute.kill()
+        raise
 
 
 class FileCreator(object):


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*
Refactoring buildcmd integ test to use same method which deploy uses and have better logging around failure and process run.

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
