### PR TITLE
fix: default capabilities on guided mode to be a list

### DIFF
--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -94,7 +94,7 @@ class GuidedContext:
         if not capabilities_confirm:
             input_capabilities = prompt(
                 f"\t{self.start_bold}Capabilities{self.end_bold}",
-                default=default_capabilities[0],
+                default=list(default_capabilities),
                 type=FuncParamType(func=_space_separated_list_func_type),
             )
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -477,6 +477,26 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
 
     @parameterized.expand(["aws-serverless-function.yaml"])
+    def test_deploy_guided_capabilities_default(self, template_file):
+        template_path = self.test_data_path.joinpath(template_file)
+
+        stack_name = self._method_to_stack_name(self.id())
+        self.stack_names.append(stack_name)
+
+        # Package and Deploy in one go without confirming change set.
+        deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
+
+        # Set no for Allow SAM CLI IAM role creation, but allow default of ["CAPABILITY_IAM"] by just hitting the return key.
+        deploy_process_execute = _run_command_with_input(
+            deploy_command_list, "{}\n\nSuppliedParameter\n\nn\n\n\n\n".format(stack_name).encode(),
+        )
+        # Deploy should succeed with a managed stack
+        self.assertEqual(deploy_process_execute.process.returncode, 0)
+        self.stack_names.append(SAM_CLI_STACK_NAME)
+        # Remove samconfig.toml
+        os.remove(self.test_data_path.joinpath(DEFAULT_CONFIG_FILE_NAME))
+
+    @parameterized.expand(["aws-serverless-function.yaml"])
     def test_deploy_guided_set_confirm_changeset(self, template_file):
         template_path = self.test_data_path.joinpath(template_file)
 

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -8,7 +8,7 @@ from samcli.commands.deploy.deploy_context import DeployContext
 from samcli.commands.deploy.exceptions import DeployBucketRequiredError, DeployFailedError, ChangeEmptyError
 
 
-class TestPackageCommand(TestCase):
+class TestSamDeployCommand(TestCase):
     def setUp(self):
         self.deploy_command_context = DeployContext(
             template_file="template-file",

--- a/tests/unit/commands/deploy/test_guided_config.py
+++ b/tests/unit/commands/deploy/test_guided_config.py
@@ -1,0 +1,54 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+import click
+from click.globals import _local
+from click import Context
+
+from samcli.commands.deploy.exceptions import GuidedDeployFailedError
+from samcli.lib.config.samconfig import SamConfig, DEFAULT_CONFIG_FILE_NAME
+from samcli.lib.utils.osutils import tempfile_platform_independent, remove
+from samcli.commands.deploy.guided_config import GuidedConfig
+
+
+class TestGuidedConfig(TestCase):
+    def setUp(self):
+        setattr(
+            _local,
+            "stack",
+            [
+                Context(
+                    command="test", allow_extra_args=False, allow_interspersed_args=False, ignore_unknown_options=False
+                )
+            ],
+        )
+        with tempfile_platform_independent() as template:
+            self.template_file = os.path.abspath(template.name)
+            self.samconfig_dir = os.path.dirname(self.template_file)
+            self.samconfig_path = os.path.join(self.samconfig_dir, DEFAULT_CONFIG_FILE_NAME)
+        self.gc = GuidedConfig(template_file=self.template_file, section="dummy")
+
+    def tearDown(self):
+        delattr(_local, "stack")
+        remove(self.samconfig_path)
+
+    def test_guided_config_init(self):
+        ctx, samconfig = self.gc.get_config_ctx()
+        self.assertTrue(isinstance(ctx, click.Context))
+        self.assertTrue(isinstance(samconfig, SamConfig))
+
+    def test_read_config_showcase(self):
+        # No samconfig file present, no errors thrown.
+        self.gc.read_config_showcase()
+        with open(self.samconfig_path, "wb") as f:
+            f.write(b"default\\n")
+        # Empty samconfig, config file found but invalid
+        with self.assertRaises(GuidedDeployFailedError):
+            self.gc.read_config_showcase()
+
+    @patch("samcli.commands.deploy.guided_config.get_cmd_names")
+    def test_save_config(self, patched_cmd_names):
+        patched_cmd_names.return_value = ["local", "start-api"]
+        # Should save with no errors.
+        self.gc.save_config(parameter_overrides={"a": "b"}, port="9090")

--- a/tests/unit/commands/deploy/test_guided_context.py
+++ b/tests/unit/commands/deploy/test_guided_context.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+from unittest.mock import patch, call, ANY
+
+import click
+
+from samcli.commands.deploy.guided_context import GuidedContext
+
+
+class TestGuidedContext(TestCase):
+    def setUp(self):
+        self.gc = GuidedContext(
+            template_file="template",
+            stack_name="test",
+            s3_bucket="s3_b",
+            s3_prefix="s3_p",
+            confirm_changeset=True,
+            region="region",
+        )
+
+    @patch("samcli.commands.deploy.guided_context.prompt")
+    @patch("samcli.commands.deploy.guided_context.confirm")
+    @patch("samcli.commands.deploy.guided_context.manage_stack")
+    def test_guided_prompts_check_defaults(self, patched_manage_stack, patched_confirm, patched_prompt):
+        # Series of inputs to confirmations so that full range of questions are asked.
+        patched_confirm.side_effect = [True, False, "", True]
+        patched_manage_stack.return_value = "managed_s3_stack"
+        self.gc.guided_prompts(parameter_override_keys=None)
+        # Now to check for all the defaults on confirmations.
+        expected_confirmation_calls = [
+            call(f"\t{self.gc.start_bold}Confirm changes before deploy{self.gc.end_bold}", default=True),
+            call(f"\t{self.gc.start_bold}Allow SAM CLI IAM role creation{self.gc.end_bold}", default=True),
+            call(f"\t{self.gc.start_bold}Save arguments to samconfig.toml{self.gc.end_bold}", default=True),
+        ]
+        self.assertEqual(expected_confirmation_calls, patched_confirm.call_args_list)
+
+        # Now to check for all the defaults on prompts.
+        expected_prompt_calls = [
+            call(f"\t{self.gc.start_bold}Stack Name{self.gc.end_bold}", default="test", type=click.STRING),
+            call(f"\t{self.gc.start_bold}AWS Region{self.gc.end_bold}", default="region", type=click.STRING),
+            call(f"\t{self.gc.start_bold}Capabilities{self.gc.end_bold}", default=["CAPABILITY_IAM"], type=ANY),
+        ]
+        self.assertEqual(expected_prompt_calls, patched_prompt.call_args_list)


### PR DESCRIPTION
Why is this change necessary?

* Previously, the string was passed along which leads to a validation
failure.

How does it address the issue?

* The default is now a list.

What side effects does this change have?

* None.

*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/1848

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
