### PR TITLE
fix: adding better logging to build_integ_test base's run of Popen command

### DIFF
--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -13,7 +13,7 @@ import jmespath
 from pathlib import Path
 
 from samcli.yamlhelper import yaml_parse
-from tests.testing_utils import IS_WINDOWS
+from tests.testing_utils import IS_WINDOWS, _run_command
 
 LOG = logging.getLogger(__name__)
 
@@ -126,8 +126,8 @@ class BuildIntegBase(TestCase):
             overrides,
         ]
 
-        process = subprocess.Popen(cmdlist, stdout=subprocess.PIPE)
-        process.wait()
+        process_execute = _run_command(cmdlist)
+        process_execute.process.wait()
 
-        process_stdout = b"".join(process.stdout.readlines()).strip().decode("utf-8")
+        process_stdout = process_execute.stdout.decode("utf-8")
         self.assertEqual(json.loads(process_stdout), expected_result)

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -13,7 +13,7 @@ import jmespath
 from pathlib import Path
 
 from samcli.yamlhelper import yaml_parse
-from tests.testing_utils import IS_WINDOWS, _run_command
+from tests.testing_utils import IS_WINDOWS, run_command
 
 LOG = logging.getLogger(__name__)
 
@@ -126,7 +126,7 @@ class BuildIntegBase(TestCase):
             overrides,
         ]
 
-        process_execute = _run_command(cmdlist)
+        process_execute = run_command(cmdlist)
         process_execute.process.wait()
 
         process_stdout = process_execute.stdout.decode("utf-8")

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -8,7 +8,7 @@ from parameterized import parameterized
 import pytest
 
 from .build_integ_base import BuildIntegBase
-from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, CI_OVERRIDE, _run_command
+from tests.testing_utils import IS_WINDOWS, RUNNING_ON_CI, CI_OVERRIDE, run_command
 
 LOG = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
         LOG.info("Running Command: {}", cmdlist)
-        _run_command(cmdlist, cwd=self.working_dir)
+        run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(
             self.default_build_dir, self.FUNCTION_LOGICAL_ID, self.EXPECTED_FILES_PROJECT_MANIFEST
@@ -115,7 +115,7 @@ class TestBuildCommand_ErrorCases(BuildIntegBase):
         cmdlist = self.get_command_list(parameter_overrides=overrides)
 
         LOG.info("Running Command: {}", cmdlist)
-        process_execute = _run_command(cmdlist, cwd=self.working_dir)
+        process_execute = run_command(cmdlist, cwd=self.working_dir)
         self.assertEqual(1, process_execute.process.returncode)
 
         self.assertIn("Build Failed", str(process_execute.stdout))
@@ -151,7 +151,7 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
         LOG.info("Running Command: {}", cmdlist)
-        _run_command(cmdlist, cwd=self.working_dir)
+        run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(
             self.default_build_dir,
@@ -232,7 +232,7 @@ class TestBuildCommand_RubyFunctions(BuildIntegBase):
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
         LOG.info("Running Command: {}".format(cmdlist))
-        _run_command(cmdlist, cwd=self.working_dir)
+        run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(
             self.default_build_dir,
@@ -364,7 +364,7 @@ class TestBuildCommand_Java(BuildIntegBase):
             self._change_to_unix_line_ending(os.path.join(self.test_data_path, self.USING_GRADLEW_PATH, "gradlew"))
 
         LOG.info("Running Command: {}".format(cmdlist))
-        _run_command(cmdlist, cwd=self.working_dir)
+        run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(
             self.default_build_dir, self.FUNCTION_LOGICAL_ID, expected_files, self.EXPECTED_DEPENDENCIES
@@ -472,7 +472,7 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
         if mode:
             newenv["SAM_BUILD_MODE"] = mode
 
-        _run_command(cmdlist, cwd=self.working_dir, env=newenv)
+        run_command(cmdlist, cwd=self.working_dir, env=newenv)
 
         self._verify_built_artifact(
             self.default_build_dir, self.FUNCTION_LOGICAL_ID, self.EXPECTED_FILES_PROJECT_MANIFEST
@@ -517,7 +517,7 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
         LOG.info("Running Command: {}".format(cmdlist))
-        process_execute = _run_command(cmdlist, cwd=self.working_dir)
+        process_execute = run_command(cmdlist, cwd=self.working_dir)
 
         # Must error out, because container builds are not supported
         self.assertEqual(process_execute.process.returncode, 1)
@@ -568,7 +568,7 @@ class TestBuildCommand_Go_Modules(BuildIntegBase):
         newenv["GOPROXY"] = "direct"
         newenv["GOPATH"] = str(self.working_dir)
 
-        _run_command(cmdlist, cwd=self.working_dir, env=newenv)
+        run_command(cmdlist, cwd=self.working_dir, env=newenv)
 
         self._verify_built_artifact(
             self.default_build_dir, self.FUNCTION_LOGICAL_ID, self.EXPECTED_FILES_PROJECT_MANIFEST
@@ -599,7 +599,7 @@ class TestBuildCommand_Go_Modules(BuildIntegBase):
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
         LOG.info("Running Command: {}".format(cmdlist))
-        process_execute = _run_command(cmdlist, cwd=self.working_dir)
+        process_execute = run_command(cmdlist, cwd=self.working_dir)
 
         # Must error out, because container builds are not supported
         self.assertEqual(process_execute.process.returncode, 1)
@@ -643,7 +643,7 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
         overrides = {"Runtime": "python3.7", "CodeUri": "Python", "Handler": "main.handler"}
         cmdlist = self.get_command_list(parameter_overrides=overrides, function_identifier="FunctionNotInTemplate")
 
-        process_execute = _run_command(cmdlist, cwd=self.working_dir)
+        process_execute = run_command(cmdlist, cwd=self.working_dir)
 
         self.assertEqual(process_execute.process.returncode, 1)
         self.assertIn("FunctionNotInTemplate not found", str(process_execute.stderr))
@@ -664,7 +664,7 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
         )
 
         LOG.info("Running Command: {}", cmdlist)
-        _run_command(cmdlist, cwd=self.working_dir)
+        run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(self.default_build_dir, function_identifier, self.EXPECTED_FILES_PROJECT_MANIFEST)
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -13,7 +13,7 @@ from samcli.lib.bootstrap.bootstrap import SAM_CLI_STACK_NAME
 from tests.integration.deploy.deploy_integ_base import DeployIntegBase
 from tests.integration.package.package_integ_base import PackageIntegBase
 from tests.testing_utils import RUNNING_ON_CI, RUNNING_TEST_FOR_MASTER_ON_CI, RUN_BY_CANARY
-from tests.testing_utils import CommandResult, _run_command, _run_command_with_input
+from tests.testing_utils import CommandResult, run_command, run_command_with_input
 
 # Deploy tests require credentials and CI/CD will only add credentials to the env if the PR is from the same repo.
 # This is to restrict package tests to run outside of CI/CD, when the branch is not master or tests are not run by Canary.
@@ -46,7 +46,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             package_command_list = self.get_command_list(
                 s3_bucket=self.s3_bucket.name, template=template_path, output_template_file=output_template_file.name
             )
-            package_process = _run_command(command_list=package_command_list)
+            package_process = run_command(command_list=package_command_list)
 
             self.assertEqual(package_process.process.returncode, 0)
 
@@ -68,7 +68,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 tags="integ=true clarity=yes foo_bar=baz",
             )
 
-            deploy_process_no_execute = _run_command(deploy_command_list_no_execute)
+            deploy_process_no_execute = run_command(deploy_command_list_no_execute)
             self.assertEqual(deploy_process_no_execute.process.returncode, 0)
 
             # Deploy the given stack with the changeset.
@@ -84,7 +84,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
                 tags="integ=true clarity=yes foo_bar=baz",
             )
 
-            deploy_process = _run_command(deploy_command_list_execute)
+            deploy_process = run_command(deploy_command_list_execute)
             self.assertEqual(deploy_process.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -110,7 +110,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -119,7 +119,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Build project
         build_command_list = self.get_minimal_build_command_list(template_file=template_path)
 
-        _run_command(build_command_list)
+        run_command(build_command_list)
         stack_name = self._method_to_stack_name(self.id())
         self.stack_names.append(stack_name)
         # Should result in a zero exit code.
@@ -137,16 +137,16 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         # ReBuild project, absolutely nothing has changed, will result in same build artifacts.
 
-        _run_command(build_command_list)
+        run_command(build_command_list)
 
         # Re-deploy, this should cause an empty changeset error and not re-deploy.
         # This will cause a non zero exit code.
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Does not cause a re-deploy
         self.assertEqual(deploy_process_execute.process.returncode, 1)
 
@@ -173,7 +173,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=True,
         )
 
-        deploy_process_execute = _run_command_with_input(deploy_command_list, "Y".encode())
+        deploy_process_execute = run_command_with_input(deploy_command_list, "Y".encode())
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -197,7 +197,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Error asking for s3 bucket
         self.assertEqual(deploy_process_execute.process.returncode, 1)
         self.assertIn(
@@ -226,7 +226,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 2)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -249,7 +249,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 1)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -269,7 +269,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Error template file not specified
         self.assertEqual(deploy_process_execute.process.returncode, 1)
 
@@ -296,7 +296,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             confirm_changeset=False,
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Deploy should succeed
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
@@ -317,7 +317,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
             region="eu-west-2",
         )
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Deploy should fail, asking for s3 bucket
         self.assertEqual(deploy_process_execute.process.returncode, 1)
         stderr = deploy_process_execute.stderr.strip()
@@ -354,14 +354,14 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(**kwargs)
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Deploy should succeed
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
         # Deploy with `--no-fail-on-empty-changeset` after deploying the same template first
         deploy_command_list = self.get_deploy_command_list(fail_on_empty_changeset=False, **kwargs)
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Deploy should not fail
         self.assertEqual(deploy_process_execute.process.returncode, 0)
         stdout = deploy_process_execute.stdout.strip()
@@ -391,14 +391,14 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         }
         deploy_command_list = self.get_deploy_command_list(**kwargs)
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Deploy should succeed
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
         # Deploy with `--fail-on-empty-changeset` after deploying the same template first
         deploy_command_list = self.get_deploy_command_list(fail_on_empty_changeset=True, **kwargs)
 
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         # Deploy should not fail
         self.assertNotEqual(deploy_process_execute.process.returncode, 0)
         stderr = deploy_process_execute.stderr.strip()
@@ -413,7 +413,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(
             template_file=template_path, stack_name=stack_name, capabilities="CAPABILITY_IAM"
         )
-        deploy_process_execute = _run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])
@@ -426,7 +426,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = _run_command_with_input(
+        deploy_process_execute = run_command_with_input(
             deploy_command_list, "{}\n\n\n\n\n\n".format(stack_name).encode()
         )
 
@@ -446,7 +446,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = _run_command_with_input(
+        deploy_process_execute = run_command_with_input(
             deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n".format(stack_name).encode()
         )
 
@@ -466,7 +466,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = _run_command_with_input(
+        deploy_process_execute = run_command_with_input(
             deploy_command_list,
             "{}\n\nSuppliedParameter\n\nn\nCAPABILITY_IAM CAPABILITY_NAMED_IAM\n\n".format(stack_name).encode(),
         )
@@ -486,7 +486,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         # Package and Deploy in one go without confirming change set.
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
-        deploy_process_execute = _run_command_with_input(
+        deploy_process_execute = run_command_with_input(
             deploy_command_list, "{}\n\nSuppliedParameter\nY\n\n\nY\n".format(stack_name).encode()
         )
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -18,7 +18,7 @@ CommandResult = namedtuple("CommandResult", "process stdout stderr")
 TIMEOUT = 300
 
 
-def _run_command(command_list, cwd=None, env=None, timeout=TIMEOUT) -> CommandResult:
+def run_command(command_list, cwd=None, env=None, timeout=TIMEOUT) -> CommandResult:
     process_execute = Popen(command_list, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE)
     try:
         stdout_data, stderr_data = process_execute.communicate(timeout=timeout)
@@ -32,7 +32,7 @@ def _run_command(command_list, cwd=None, env=None, timeout=TIMEOUT) -> CommandRe
         raise
 
 
-def _run_command_with_input(command_list, stdin_input, timeout=TIMEOUT) -> CommandResult:
+def run_command_with_input(command_list, stdin_input, timeout=TIMEOUT) -> CommandResult:
     process_execute = Popen(command_list, stdout=PIPE, stderr=PIPE, stdin=PIPE)
     try:
         stdout_data, stderr_data = process_execute.communicate(stdin_input, timeout=timeout)


### PR DESCRIPTION
*Issue #, if available:*
This change will print better logs, stderr and stdout around the command that fails when running `test_with_go` integration tests.

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
