### PR TITLE
fix: changing order of parameterized expand and flaky annotation.

### DIFF
--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -32,7 +32,6 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
 
     FUNCTION_LOGICAL_ID = "Function"
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [
             ("python2.7", False),
@@ -45,6 +44,7 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
             ("python3.8", "use_container"),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_with_default_requirements(self, runtime, use_container):
         overrides = {"Runtime": runtime, "CodeUri": "Python", "Handler": "main.handler"}
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
@@ -133,7 +133,6 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
 
     FUNCTION_LOGICAL_ID = "Function"
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [
             ("nodejs6.10", False),
@@ -146,6 +145,7 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
             ("nodejs12.x", "use_container"),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_with_default_package_json(self, runtime, use_container):
         overrides = {"Runtime": runtime, "CodeUri": "Node", "Handler": "ignored"}
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
@@ -217,13 +217,13 @@ class TestBuildCommand_RubyFunctions(BuildIntegBase):
 
     FUNCTION_LOGICAL_ID = "Function"
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand([("ruby2.5"), ("ruby2.7")])
+    @pytest.mark.flaky(reruns=3)
     def test_building_ruby_in_container(self, runtime):
         self._test_with_default_gemfile(runtime, "use_container")
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand([("ruby2.5"), ("ruby2.7")])
+    @pytest.mark.flaky(reruns=3)
     def test_building_ruby_in_process(self, runtime):
         self._test_with_default_gemfile(runtime, False)
 
@@ -312,7 +312,6 @@ class TestBuildCommand_Java(BuildIntegBase):
     WINDOWS_LINE_ENDING = b"\r\n"
     UNIX_LINE_ENDING = b"\n"
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [
             ("java8", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE),
@@ -327,10 +326,10 @@ class TestBuildCommand_Java(BuildIntegBase):
             ("java11", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_building_java_in_container(self, runtime, code_path, expected_files):
         self._test_with_building_java(runtime, code_path, expected_files, "use_container")
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [
             ("java8", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE),
@@ -340,10 +339,10 @@ class TestBuildCommand_Java(BuildIntegBase):
             ("java8", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_building_java8_in_process(self, runtime, code_path, expected_files):
         self._test_with_building_java(runtime, code_path, expected_files, False)
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [
             ("java11", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE),
@@ -353,6 +352,7 @@ class TestBuildCommand_Java(BuildIntegBase):
             ("java11", USING_GRADLE_PATH, EXPECTED_FILES_PROJECT_MANIFEST_GRADLE),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_building_java11_in_process(self, runtime, code_path, expected_files):
         self._test_with_building_java(runtime, code_path, expected_files, False)
 
@@ -448,7 +448,6 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
         "HelloWorld.dll",
     }
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [
             ("dotnetcore2.0", "Dotnetcore2.0", None),
@@ -457,6 +456,7 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
             ("dotnetcore2.1", "Dotnetcore2.1", "debug"),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_with_dotnetcore(self, runtime, code_uri, mode):
         overrides = {
             "Runtime": runtime,
@@ -505,8 +505,8 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
 
         self.verify_docker_container_cleanedup(runtime)
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand([("dotnetcore2.0", "Dotnetcore2.0"), ("dotnetcore2.1", "Dotnetcore2.1")])
+    @pytest.mark.flaky(reruns=3)
     def test_must_fail_with_container(self, runtime, code_uri):
         use_container = True
         overrides = {
@@ -550,8 +550,8 @@ class TestBuildCommand_Go_Modules(BuildIntegBase):
     FUNCTION_LOGICAL_ID = "Function"
     EXPECTED_FILES_PROJECT_MANIFEST = {"hello-world"}
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand([("go1.x", "Go", None), ("go1.x", "Go", "debug")])
+    @pytest.mark.flaky(reruns=3)
     def test_with_go(self, runtime, code_uri, mode):
         overrides = {"Runtime": runtime, "CodeUri": code_uri, "Handler": "hello-world"}
         cmdlist = self.get_command_list(use_container=False, parameter_overrides=overrides)
@@ -591,8 +591,8 @@ class TestBuildCommand_Go_Modules(BuildIntegBase):
 
         self.verify_docker_container_cleanedup(runtime)
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand([("go1.x", "Go")])
+    @pytest.mark.flaky(reruns=3)
     def test_go_must_fail_with_container(self, runtime, code_uri):
         use_container = True
         overrides = {"Runtime": runtime, "CodeUri": code_uri, "Handler": "hello-world"}
@@ -648,7 +648,6 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
         self.assertEqual(process_execute.process.returncode, 1)
         self.assertIn("FunctionNotInTemplate not found", str(process_execute.stderr))
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [
             ("python3.7", False, "FunctionOne"),
@@ -657,6 +656,7 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
             ("python3.7", "use_container", "FunctionTwo"),
         ]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_build_single_function(self, runtime, use_container, function_identifier):
         overrides = {"Runtime": runtime, "CodeUri": "Python", "Handler": "main.handler"}
         cmdlist = self.get_command_list(

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -89,10 +89,10 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = stdout.strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello world"')
 
-    @pytest.mark.flaky(reruns=3)
     @parameterized.expand(
         [("TimeoutFunction"), ("TimeoutFunctionWithParameter"), ("TimeoutFunctionWithStringParameter")]
     )
+    @pytest.mark.flaky(reruns=3)
     def test_invoke_with_timeout_set(self, function_name):
         command_list = self.get_command_list(
             function_name, template_path=self.template_path, event_path=self.event_path


### PR DESCRIPTION
*Issue #, if available:*
Our current order of flaky and parameterized_expand annotation do not working for flaky annotation. This PR is changing order so that both annotations work.

In order to test this change I added a dummy test method with force failure and 2 parameters for expansion. [Here](https://paste.ubuntu.com/p/W2258k7gPm/) is output of test with our current order (flaky before parameter). [Here](https://paste.ubuntu.com/p/Rhvm3pk7dS/) is the output of test with new order (parameter before flaky).

In first run we only see two test runs one for each parameter, in second run we see 6 test runs one for each parameter rerun 3 times.

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
