### PR TITLE
fix: Log warning if there is unresolved intrinsics in cors

### DIFF
--- a/samcli/lib/providers/sam_api_provider.py
+++ b/samcli/lib/providers/sam_api_provider.py
@@ -148,7 +148,14 @@ class SamApiProvider(CfnBaseApiProvider):
         """
         prop = cors_dict.get(prop_name)
         if prop:
-            if (not isinstance(prop, string_types)) or (not (prop.startswith("'") and prop.endswith("'"))):
+            if not isinstance(prop, string_types) or prop.startswith("!"):
+                LOG.warning(
+                    "CORS Property %s was not fully resolved. Will proceed as if the Property was not defined.",
+                    prop_name,
+                )
+                return None
+
+            if not (prop.startswith("'") and prop.endswith("'")):
                 raise InvalidSamDocumentException(
                     "{} must be a quoted string " '(i.e. "\'value\'" is correct, but "value" is not).'.format(prop_name)
                 )

--- a/tests/integration/local/start_api/test_start_api.py
+++ b/tests/integration/local/start_api/test_start_api.py
@@ -1111,3 +1111,18 @@ class TestSwaggerIncludedFromSeparateFile(StartApiIntegBaseClass):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"hello": "world"})
+
+
+class TestUnresolvedCorsIntrinsic(StartApiIntegBaseClass):
+    template_path = "/testdata/start_api/template-with-unresolved-intrinsic-in-cors.yaml"
+
+    def setUp(self):
+        self.url = "http://127.0.0.1:{}".format(self.port)
+
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=600, method="thread")
+    def test_lambda_is_reachable_when_cors_is_an_unresolved_intrinsic(self):
+        response = requests.patch(self.url + "/anyandall", timeout=300)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"hello": "world"})

--- a/tests/integration/testdata/start_api/template-with-unresolved-intrinsic-in-cors.yaml
+++ b/tests/integration/testdata/start_api/template-with-unresolved-intrinsic-in-cors.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Api:
+    BinaryMediaTypes:
+      # These are equivalent to image/gif and image/png when deployed
+      - image~1png
+
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      Variables:
+        VarName: varValue
+      Cors:
+        AllowOrigin: !Sub
+          - "'https://${FrontEndDomainName}.${dnszone}'"
+          - {dnszone: !ImportValue mydomain-com-ZoneName}
+        AllowMethods: "'GET'"
+        AllowHeaders: "'origin, x-requested-with'"
+        MaxAge: "'510'"
+      DefinitionBody:
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: ./swagger.yaml
+
+  MyLambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: main.handler
+      Runtime: python3.6
+      CodeUri: .

--- a/tests/unit/commands/local/lib/test_sam_api_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_api_provider.py
@@ -808,6 +808,62 @@ class TestSamStageValues(TestCase):
 
 
 class TestSamCors(TestCase):
+    def test_provider_parse_cors_with_unresolved_intrinsic(self):
+        template = {
+            "Resources": {
+                "TestApi": {
+                    "Type": "AWS::Serverless::Api",
+                    "Properties": {
+                        "StageName": "Prod",
+                        "Cors": {"AllowOrigin": {"Fn:Sub": "Some string to sub"}},
+                        "DefinitionBody": {
+                            "paths": {
+                                "/path2": {
+                                    "post": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                                "/path": {
+                                    "get": {
+                                        "x-amazon-apigateway-integration": {
+                                            "type": "aws_proxy",
+                                            "uri": {
+                                                "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31"
+                                                "/functions/${NoApiEventFunction.Arn}/invocations"
+                                            },
+                                            "responses": {},
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    },
+                }
+            }
+        }
+
+        provider = ApiProvider(template)
+
+        routes = provider.routes
+        cors = Cors(
+            allow_origin=None,
+            allow_methods=",".join(sorted(["GET", "DELETE", "PUT", "POST", "HEAD", "OPTIONS", "PATCH"])),
+        )
+        route1 = Route(path="/path2", methods=["POST", "OPTIONS"], function_name="NoApiEventFunction")
+        route2 = Route(path="/path", methods=["GET", "OPTIONS"], function_name="NoApiEventFunction")
+
+        self.assertEqual(len(routes), 2)
+        self.assertIn(route1, routes)
+        self.assertIn(route2, routes)
+        self.assertEqual(provider.api.cors, cors)
+
     def test_provider_parse_cors_string(self):
         template = {
             "Resources": {


### PR DESCRIPTION
*Issue #, if available:*
#1432

*Why is this change necessary?*
This change allows for the Lambda behind an API to be reachable when SAM CLI fails to resolve an intrinsic function in the API Cors definition.

*How does it address the issue?*
When reading the CORS configuration, we check to see if the value is a string that starts with `!` (indicating it is an intrinsics, !Ref for example) or anything but a string. This will then log a message to tell customers we are ignoring this property due to the intrinsic being unresolved.

*What side effects does this change have?*
No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
