### PR TITLE
fix: adding APPVEYOR_CONSOLE_DISABLE_PTY environment variable to fix random appveyor job failure.

### DIFF
--- a/appveyor-windows-build-dotnet.yml
+++ b/appveyor-windows-build-dotnet.yml
@@ -25,6 +25,7 @@ environment:
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 init:
   # Uncomment this for RDP

--- a/appveyor-windows-build-go.yml
+++ b/appveyor-windows-build-go.yml
@@ -25,6 +25,7 @@ environment:
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 init:
   # Uncomment this for RDP

--- a/appveyor-windows-build-java-container.yml
+++ b/appveyor-windows-build-java-container.yml
@@ -25,6 +25,7 @@ environment:
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 init:
   # Uncomment this for RDP

--- a/appveyor-windows-build-java-ruby-inprocess.yml
+++ b/appveyor-windows-build-java-ruby-inprocess.yml
@@ -13,6 +13,7 @@ environment:
   PYTHON_SCRIPTS: "C:\\Python37-x64\\Scripts"
   PYTHON_EXE: "C:\\Python37-x64\\python.exe"
   PYTHON_ARCH: '64'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 install:
 

--- a/appveyor-windows-build-nodejs.yml
+++ b/appveyor-windows-build-nodejs.yml
@@ -25,6 +25,7 @@ environment:
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 init:
   # Uncomment this for RDP

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -25,6 +25,7 @@ environment:
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 init:
   # Uncomment this for RDP

--- a/appveyor-windows-build-ruby.yml
+++ b/appveyor-windows-build-ruby.yml
@@ -25,6 +25,7 @@ environment:
   HOME: 'C:\Users\appveyor'
   HOMEDRIVE: 'C:'
   HOMEPATH: 'C:\Users\appveyor'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 init:
   # Uncomment this for RDP

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -26,6 +26,7 @@ environment:
   HOMEPATH: 'C:\Users\appveyor'
   NOSE_PARAMETERIZED_NO_WARN: 1
   AWS_S3: 'AWS_S3_37_WIN'
+  APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 init:
   # Uncomment this for RDP

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
       INSTALL_PY_37_PIP: 1
       INSTALL_PY_38_PIP: 1
       AWS_S3: 'AWS_S3_36'
+      APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "C:\\Python37-x64"
       PYTHON_VERSION: '3.7.5'
@@ -25,6 +26,7 @@ environment:
       INSTALL_PY_36_PIP: 1
       INSTALL_PY_38_PIP: 1
       AWS_S3: 'AWS_S3_37'
+      APPVEYOR_CONSOLE_DISABLE_PTY: true
 
     - PYTHON_HOME: "C:\\Python38-x64"
       PYTHON_VERSION: '3.8.2'
@@ -34,6 +36,7 @@ environment:
       INSTALL_PY_36_PIP: 1
       INSTALL_PY_37_PIP: 1
       AWS_S3: 'AWS_S3_38'
+      APPVEYOR_CONSOLE_DISABLE_PTY: true
 
 for:
   - 


### PR DESCRIPTION
*Issue #, if available:*
Sometimes our Appveyor build jobs fail with exit status 1. This fix is recommended by Appveyor team in email and [here](https://help.appveyor.com/discussions/problems/25166-byoc-100-cpu-usage-in-bash-shellsh-and-random-exited-with-code-1).

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
