### PR TITLE
fix(build): Do not treat urls as local paths

### DIFF
--- a/samcli/commands/_utils/template.py
+++ b/samcli/commands/_utils/template.py
@@ -209,7 +209,13 @@ def _resolve_relative_to(path, original_root, new_root):
     Updated path if the given path is a relative path. None, if the path is not a relative path.
     """
 
-    if not isinstance(path, str) or path.startswith("s3://") or os.path.isabs(path):
+    if (
+        not isinstance(path, str)
+        or path.startswith("s3://")
+        or path.startswith("http://")
+        or path.startswith("https://")
+        or os.path.isabs(path)
+    ):
         # Value is definitely NOT a relative path. It is either a S3 URi or Absolute path or not a string at all
         return None
 

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -134,7 +134,7 @@ class ApplicationBuilder:
                 # this resource was not built. So skip it
                 continue
 
-            # Artifacts are wrtoitten relative  the template because it makes the template portable
+            # Artifacts are written relative  the template because it makes the template portable
             #   Ex: A CI/CD pipeline build stage could zip the output folder and pass to a
             #   package stage running on a different machine
             artifact_relative_path = os.path.relpath(built_artifacts[logical_id], original_dir)

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -76,6 +76,13 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
             ),
         )
 
+        self._verify_resource_property(
+            str(self.built_template),
+            "ExampleNestedStack",
+            "TemplateURL",
+            "https://s3.amazonaws.com/examplebucket/exampletemplate.yml",
+        )
+
         expected = {"pi": "3.14"}
         self._verify_invoke_built_function(
             self.built_template, self.FUNCTION_LOGICAL_ID, self._make_parameter_override_arg(overrides), expected

--- a/tests/integration/testdata/buildcmd/template.yaml
+++ b/tests/integration/testdata/buildcmd/template.yaml
@@ -29,3 +29,8 @@ Resources:
     Properties:
       Command:
         ScriptLocation: SomeRelativePath
+
+  ExampleNestedStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/examplebucket/exampletemplate.yml

--- a/tests/unit/commands/_utils/test_template.py
+++ b/tests/unit/commands/_utils/test_template.py
@@ -96,6 +96,8 @@ class Test_update_relative_paths(TestCase):
     def setUp(self):
 
         self.s3path = "s3://foo/bar"
+        self.s3_full_url_https = "https://s3.amazonaws.com/examplebucket/exampletemplate.yml"
+        self.s3_full_url_http = "http://s3.amazonaws.com/examplebucket/exampletemplate.yml"
         self.abspath = os.path.abspath("tosomefolder")
         self.curpath = os.path.join("foo", "bar")
         self.src = os.path.abspath("src")  # /path/from/root/src
@@ -107,7 +109,7 @@ class Test_update_relative_paths(TestCase):
     def test_must_update_relative_metadata_paths(self, resource_type, properties):
 
         for propname in properties:
-            for path in [self.s3path, self.abspath, self.curpath]:
+            for path in [self.s3path, self.abspath, self.curpath, self.s3_full_url_https, self.s3_full_url_http]:
                 template_dict = {
                     "Metadata": {resource_type: {propname: path}, "AWS::Ec2::Instance": {propname: path}},
                     "Parameters": {"a": "b"},


### PR DESCRIPTION
*Issue #, if available:*
#1839

*Why is this change necessary?*
Previous to this change, if there was a full s3 url (https://s3.amazon....) as a value of a property that could be a local file, we treated it as a local file and updated the template to `../../https://s3.amazon...`. This creates an invalid template for build causing customers needing to maunally edit the built template.

*How does it address the issue?*
We now check if the value of the property starts with `http` or `https`.

*What side effects does this change have?*
No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
