### PR TITLE
fix: usage for run_command method.

### DIFF
--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -138,7 +138,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
 
         deploy_command_list.append("--no-confirm-changeset")
 
-        deploy_process_execute = self.run_command(deploy_command_list)
+        deploy_process_execute = run_command(deploy_command_list)
         self.assertEqual(deploy_process_execute.process.returncode, 0)
 
     @parameterized.expand(["aws-serverless-function.yaml"])


### PR DESCRIPTION
*Issue #, if available:*
Missed a spot in previous fix commit. run_command is moved out of the class, hence self.run_command is failing.

And this time I tested in dev canary https://ci.appveyor.com/project/AWSSAMCLI/aws-sam-cli-canary-linux-dev
*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
