### PR TITLE
fix(start-api): Allow invoking when a function has a FunctionName

### DIFF
--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -65,6 +65,9 @@ class SamFunctionProvider(FunctionProvider):
             raise ValueError("Function name is required")
 
         for f in self.get_all():
+            if f.name == name:
+                return f
+
             if f.functionname == name:
                 return f
 

--- a/tests/integration/testdata/start_api/template.yaml
+++ b/tests/integration/testdata/start_api/template.yaml
@@ -16,6 +16,7 @@ Resources:
     Properties:
       Handler: main.handler
       Runtime: python3.6
+      FunctionName: customname
       CodeUri: .
       Timeout: 600
       Events:

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -15,9 +15,14 @@ class TestSamFunctionProviderEndToEnd(TestCase):
 
     TEMPLATE = {
         "Resources": {
-            "SamFunc1": {
+            "SamFunctions": {
                 "Type": "AWS::Serverless::Function",
-                "Properties": {"CodeUri": "/usr/foo/bar", "Runtime": "nodejs4.3", "Handler": "index.handler"},
+                "Properties": {
+                    "FunctionName": "SamFunc1",
+                    "CodeUri": "/usr/foo/bar",
+                    "Runtime": "nodejs4.3",
+                    "Handler": "index.handler",
+                },
             },
             "SamFunc2": {
                 "Type": "AWS::Serverless::Function",
@@ -83,7 +88,22 @@ class TestSamFunctionProviderEndToEnd(TestCase):
             (
                 "SamFunc1",
                 Function(
-                    name="SamFunc1",
+                    name="SamFunctions",
+                    functionname="SamFunc1",
+                    runtime="nodejs4.3",
+                    handler="index.handler",
+                    codeuri="/usr/foo/bar",
+                    memory=None,
+                    timeout=None,
+                    environment=None,
+                    rolearn=None,
+                    layers=[],
+                ),
+            ),
+            (
+                "SamFunctions",
+                Function(
+                    name="SamFunctions",
                     functionname="SamFunc1",
                     runtime="nodejs4.3",
                     handler="index.handler",

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -216,7 +216,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
 
         result = {f.name for f in self.provider.get_all()}
         expected = {
-            "SamFunc1",
+            "SamFunctions",
             "SamFunc2",
             "SamFunc3",
             "SamFuncWithFunctionNameOverride",


### PR DESCRIPTION
*Issue #, if available:*
#1885 

*Why is this change necessary?*
When using start-api, FunctionName gets prioritized over the LogicalId. This was caused by a recent change of supporting invoking with a FunctionName instead of a LogicalId, which is not expected. 

*How does it address the issue?*
We now first search for the LogicalId and if we don't find anything, we try the function name. This keeps local invoke working for both and for things like start-lambda and start-api, we can still reference by the logical id.

*What side effects does this change have?*
Not that I know of.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
