### PR TITLE
fix: logging for samconfig

### DIFF
--- a/samcli/cli/cli_config_file.py
+++ b/samcli/cli/cli_config_file.py
@@ -15,10 +15,15 @@ from samcli.commands.exceptions import ConfigException
 from samcli.lib.config.exceptions import SamConfigVersionException
 from samcli.cli.context import get_cmd_names
 from samcli.lib.config.samconfig import SamConfig, DEFAULT_ENV
+from samcli.lib.utils.sam_logging import SamCliLogger
 
 __all__ = ("TomlProvider", "configuration_option", "get_ctx_defaults")
 
+# Adding Samconfig prefix to the formatter here to show explicitly that the log messages generated
+# are exclusively from the configuration file context.
+
 LOG = logging.getLogger(__name__)
+SamCliLogger.configure_logger(LOG, logging.Formatter("Samconfig: %(message)s"), logging.INFO)
 
 
 class TomlProvider:
@@ -43,25 +48,25 @@ class TomlProvider:
         """
 
         resolved_config = {}
-
         samconfig = SamConfig(config_dir)
-        LOG.debug("Config file location: %s", samconfig.path())
 
         if not samconfig.exists():
-            LOG.debug("Config file does not exist")
+            LOG.info("Config file does not exist")
             return resolved_config
 
+        LOG.info("Config file location : %s", samconfig.path())
+
         try:
-            LOG.debug("Getting configuration value for %s %s %s", cmd_names, self.section, config_env)
+            LOG.info("Getting configuration value for %s %s %s", cmd_names, self.section, config_env)
 
             # NOTE(TheSriram): change from tomlkit table type to normal dictionary,
             # so that click defaults work out of the box.
             samconfig.sanity_check()
             resolved_config = {k: v for k, v in samconfig.get_all(cmd_names, self.section, env=config_env).items()}
-            LOG.debug("Configuration values read from the file: %s", resolved_config)
+            LOG.info("Configuration values read from the file: %s", resolved_config)
 
         except KeyError as ex:
-            LOG.debug(
+            LOG.info(
                 "Error reading configuration file at %s with config_env=%s, command=%s, section=%s %s",
                 samconfig.path(),
                 config_env,
@@ -71,11 +76,11 @@ class TomlProvider:
             )
 
         except SamConfigVersionException as ex:
-            LOG.debug("%s %s", samconfig.path(), str(ex))
+            LOG.info("%s %s", samconfig.path(), str(ex))
             raise ConfigException(f"Syntax invalid in samconfig.toml: {str(ex)}")
 
         except Exception as ex:
-            LOG.debug("Error reading configuration file: %s %s", samconfig.path(), str(ex))
+            LOG.info("Error reading configuration file: %s %s", samconfig.path(), str(ex))
 
         return resolved_config
 


### PR DESCRIPTION
Why is this change necessary?

* Make it abundantly clear that a config file is being looked for during
cli invocation.

How does it address the issue?

* Removes obfuscation of the config file and the options with which SAM
CLI is being invoked with.

What side effects does this change have?

* There will always be a blurb printed to the console on "Samconfig",
irrespective of the command being used.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
