### PR TITLE
fix: Use LogicalId for Env Vars fetching within the Env Var file

### DIFF
--- a/samcli/commands/local/lib/local_lambda.py
+++ b/samcli/commands/local/lib/local_lambda.py
@@ -84,7 +84,7 @@ class LocalLambdaRunner:
         function = self.provider.get(function_name)
 
         if not function:
-            all_functions = [f.functionname for f in self.provider.get_all()]
+            all_functions = [f.name for f in self.provider.get_all()]
             available_function_message = "{} not found. Possible options in your template: {}".format(
                 function_name, all_functions
             )
@@ -133,7 +133,7 @@ class LocalLambdaRunner:
             function_timeout = self.MAX_DEBUG_TIMEOUT
 
         return FunctionConfig(
-            name=function.functionname,
+            name=function.name,
             runtime=function.runtime,
             handler=function.handler,
             code_abs_path=code_abs_path,
@@ -163,7 +163,7 @@ class LocalLambdaRunner:
 
         """
 
-        name = function.functionname
+        name = function.name
 
         variables = None
         if function.environment and isinstance(function.environment, dict) and "Variables" in function.environment:

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -157,6 +157,24 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         process_stdout = stdout.strip()
         self.assertEqual(process_stdout.decode("utf-8"), '"MyVar"')
 
+    @parameterized.expand(
+        [("EchoCustomEnvVarWithFunctionNameDefinedFunction"), ("customname"),]
+    )
+    @pytest.mark.flaky(reruns=3)
+    def test_invoke_with_env_vars_with_functionname_defined(self, function_name):
+        command_list = self.get_command_list(
+            function_name, template_path=self.template_path, event_path=self.event_path, env_var_path=self.env_var_path,
+        )
+
+        process = Popen(command_list, stdout=PIPE)
+        try:
+            stdout, _ = process.communicate(timeout=TIMEOUT)
+        except TimeoutExpired:
+            process.kill()
+            raise
+        process_stdout = stdout.strip()
+        self.assertEqual(process_stdout.decode("utf-8"), '"MyVar"')
+
     @pytest.mark.flaky(reruns=3)
     def test_invoke_when_function_writes_stdout(self):
         command_list = self.get_command_list(

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -58,7 +58,11 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello World in a different dir"')
 
     @parameterized.expand(
-        [("MyReallyCoolFunction",), ("HelloWorldServerlessFunction",), ("HelloWorldServerlessWithFunctionNameRefFunction",)]
+        [
+            ("MyReallyCoolFunction",),
+            ("HelloWorldServerlessFunction",),
+            ("HelloWorldServerlessWithFunctionNameRefFunction",),
+        ]
     )
     @pytest.mark.flaky(reruns=3)
     def test_invoke_returns_execpted_results(self, function_name):

--- a/tests/integration/local/invoke/test_integrations_cli.py
+++ b/tests/integration/local/invoke/test_integrations_cli.py
@@ -57,10 +57,13 @@ class TestSamPython36HelloWorldIntegration(InvokeIntegBase):
 
         self.assertEqual(process_stdout.decode("utf-8"), '"Hello World in a different dir"')
 
+    @parameterized.expand(
+        [("MyReallyCoolFunction",), ("HelloWorldServerlessFunction",), ("HelloWorldServerlessWithFunctionNameRefFunction",)]
+    )
     @pytest.mark.flaky(reruns=3)
-    def test_invoke_returns_execpted_results(self):
+    def test_invoke_returns_execpted_results(self, function_name):
         command_list = self.get_command_list(
-            "HelloWorldServerlessFunction", template_path=self.template_path, event_path=self.event_path
+            function_name, template_path=self.template_path, event_path=self.event_path
         )
 
         process = Popen(command_list, stdout=PIPE)

--- a/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
+++ b/tests/integration/local/start_lambda/start_lambda_api_integ_base.py
@@ -19,6 +19,7 @@ class StartLambdaIntegBaseClass(TestCase):
         # files for integ tests
         cls.template = cls.integration_dir + cls.template_path
         cls.port = str(StartLambdaIntegBaseClass.random_port())
+        cls.env_var_path = cls.integration_dir + "/testdata/invoke/vars.json"
 
         cls.thread = threading.Thread(target=cls.start_lambda())
         cls.thread.setDaemon(True)
@@ -30,7 +31,9 @@ class StartLambdaIntegBaseClass(TestCase):
         if os.getenv("SAM_CLI_DEV"):
             command = "samdev"
 
-        cls.start_lambda_process = Popen([command, "local", "start-lambda", "-t", cls.template, "-p", cls.port])
+        cls.start_lambda_process = Popen(
+            [command, "local", "start-lambda", "-t", cls.template, "-p", cls.port, "--env-vars", cls.env_var_path]
+        )
 
         # we need to wait some time for start-lambda to start, hence the sleep
         time.sleep(5)

--- a/tests/integration/local/start_lambda/test_start_lambda.py
+++ b/tests/integration/local/start_lambda/test_start_lambda.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from time import time
 import json
+from parameterized import parameterized
 
 import pytest
 
@@ -162,6 +163,18 @@ class TestLambdaService(StartLambdaIntegBaseClass):
         response = self.lambda_client.invoke(FunctionName="echo-func-name-override")
 
         self.assertEqual(response.get("Payload").read().decode("utf-8"), "{}")
+        self.assertIsNone(response.get("FunctionError"))
+        self.assertEqual(response.get("StatusCode"), 200)
+
+    @parameterized.expand(
+        [("EchoCustomEnvVarWithFunctionNameDefinedFunction"), ("customname"),]
+    )
+    @pytest.mark.flaky(reruns=3)
+    @pytest.mark.timeout(timeout=300, method="thread")
+    def test_invoke_function_with_overrode_env_var_and_functionname_defined(self, function_name):
+        response = self.lambda_client.invoke(FunctionName=function_name)
+
+        self.assertEqual(response.get("Payload").read().decode("utf-8"), '"MyVar"')
         self.assertIsNone(response.get("FunctionError"))
         self.assertEqual(response.get("StatusCode"), 200)
 

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -18,6 +18,10 @@ Parameters:
     Type: String
     Default: ""
 
+  FunctionNameParam:
+    Type: String
+    Default: "MyReallyCoolFunction"
+
 Resources:
   HelloWorldServerlessFunction:
     Type: AWS::Serverless::Function
@@ -46,6 +50,15 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.sleep_handler
+      Runtime: python3.6
+      CodeUri: .
+      Timeout: 600
+
+  HelloWorldServerlessWithFunctionNameRefFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Ref FunctionNameParam
+      Handler: main.handler
       Runtime: python3.6
       CodeUri: .
       Timeout: 600

--- a/tests/integration/testdata/invoke/template.yml
+++ b/tests/integration/testdata/invoke/template.yml
@@ -58,7 +58,19 @@ Resources:
       CodeUri: .
       Environment:
         Variables:
-          CustomEnvVar: "MyVar"
+          CustomEnvVar: "MyOtherVar"
+      Timeout: 600
+
+  EchoCustomEnvVarWithFunctionNameDefinedFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: customname
+      Handler: main.custom_env_var_echo_hanler
+      Runtime: python3.6
+      CodeUri: .
+      Environment:
+        Variables:
+          CustomEnvVar: "MyOtherVar"
       Timeout: 600
 
   WriteToStderrFunction:

--- a/tests/integration/testdata/invoke/vars.json
+++ b/tests/integration/testdata/invoke/vars.json
@@ -1,5 +1,8 @@
 {
   "EchoCustomEnvVarFunction": {
     "CustomEnvVar": "MyVar"
+  },
+  "EchoCustomEnvVarWithFunctionNameDefinedFunction": {
+    "CustomEnvVar": "MyVar"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
#1888

*Why is this change necessary?*
Due to some changes in #1215, we started to expect the Env Var file to be keyed off of the function name instead of the LogicalId. This only happened when you had defined a `FunctionName` in your template. When it the FunctionName wasn't defined, we define it to be the LogicalId. I added more integration tests to cover these cases. I did fine a bug in our integration tests as well, that would have caught the issue initially. In our `sam local invoke` integration tests, we test that we can override a functions Env Vars through the `--env-vars` flag. However, what was defined in the template and what was in the override were the same string. So our tests was just always passing without actually validating the key was the one from the `--env-vars` file.

*How does it address the issue?*
Revert the use of `FunctionName` over the LogicalId when reading the Env Vars file.

*What side effects does this change have?*
None that I know of.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
