### PR TITLE
fix: split BuildError - showcase deeper exception

### DIFF
--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -12,7 +12,7 @@ from samcli.commands._utils.options import (
     parameter_override_option,
 )
 from samcli.cli.main import pass_context, common_options as cli_framework_options, aws_creds_options
-from samcli.lib.build.app_builder import BuildInsideContanerError
+from samcli.lib.build.app_builder import BuildInsideContainerError
 from samcli.lib.telemetry.metrics import track_command
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
 
@@ -218,13 +218,14 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
             click.secho(msg, fg="yellow")
 
         except (
-            UnsupportedRuntimeException,
-            BuildError,
-            BuildInsideContanerError,
-            UnsupportedBuilderLibraryVersionError,
-            ContainerBuildNotSupported,
+                UnsupportedRuntimeException,
+                BuildError,
+                BuildInsideContainerError,
+                UnsupportedBuilderLibraryVersionError,
+                ContainerBuildNotSupported,
         ) as ex:
             click.secho("\nBuild Failed", fg="red")
+
             # Some Exceptions have a deeper wrapped exception that needs to be surfaced
             # from deeper than just one level down.
             deep_wrap = getattr(ex, "wrapped_from", None)

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -39,7 +39,7 @@ class BuildError(Exception):
         self.wrapped_from = wrapped_from
         Exception.__init__(self, msg)
 
-class BuildInsideContanerError(Exception):
+class BuildInsideContainerError(Exception):
     pass
 
 
@@ -243,7 +243,7 @@ class ApplicationBuilder:
                           mode=self._mode,
                           options=options)
         except LambdaBuilderError as ex:
-            raise BuildError(ex.__class__.__name__, str(ex))
+            raise BuildError(wrapped_from=ex.__class__.__name__, msg=str(ex))
 
         return artifacts_dir
 
@@ -257,7 +257,7 @@ class ApplicationBuilder:
                                      options):
 
         if not self._container_manager.is_docker_reachable:
-            raise BuildInsideContanerError("Docker is unreachable. Docker needs to be running to build inside a container.")
+            raise BuildInsideContainerError("Docker is unreachable. Docker needs to be running to build inside a container.")
 
         container_build_supported, reason = supports_build_in_container(config)
         if not container_build_supported:
@@ -330,7 +330,7 @@ class ApplicationBuilder:
 
             if 400 <= err_code < 500:
                 # Like HTTP 4xx - customer error
-                raise BuildInsideContanerError(msg)
+                raise BuildInsideContainerError(msg)
 
             if err_code == 505:
                 # Like HTTP 505 error code: Version of the protocol is not supported

--- a/tests/unit/commands/buildcmd/test_command.py
+++ b/tests/unit/commands/buildcmd/test_command.py
@@ -7,7 +7,12 @@ from parameterized import parameterized
 
 from samcli.commands.build.command import do_cli, _get_mode_value_from_envvar
 from samcli.commands.exceptions import UserException
-from samcli.lib.build.app_builder import BuildError, UnsupportedBuilderLibraryVersionError
+from samcli.lib.build.app_builder import (
+    BuildError,
+    UnsupportedBuilderLibraryVersionError,
+    BuildInsideContanerError,
+    ContainerBuildNotSupported,
+)
 from samcli.lib.build.workflow_config import UnsupportedRuntimeException
 from samcli.local.lambdafn.exceptions import FunctionNotFound
 
@@ -59,7 +64,9 @@ class TestDoCli(TestCase):
     @parameterized.expand(
         [
             (UnsupportedRuntimeException(),),
-            (BuildError(),),
+            (BuildInsideContanerError(),),
+            (BuildError(wrapped_from=Exception, msg="Test"),),
+            (ContainerBuildNotSupported(),),
             (UnsupportedBuilderLibraryVersionError(container_name="name", error_msg="msg"),),
         ]
     )

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -12,7 +12,7 @@ from samcli.lib.build.app_builder import (
     BuildError,
     LambdaBuilderError,
     ContainerBuildNotSupported,
-    BuildInsideContanerError,
+    BuildInsideContainerError,
 )
 
 
@@ -271,7 +271,7 @@ class TestApplicationBuilder_build_function_on_container(TestCase):
 
         self.container_manager.is_docker_reachable = False
 
-        with self.assertRaises(BuildInsideContanerError) as ctx:
+        with self.assertRaises(BuildInsideContainerError) as ctx:
             self.builder._build_function_on_container(
                 config, "source_dir", "artifacts_dir", "scratch_dir", "manifest_path", "runtime", {}
             )
@@ -316,7 +316,7 @@ class TestApplicationBuilder_parse_builder_response(TestCase):
         msg = "invalid params"
         data = {"error": {"code": 488, "message": msg}}
 
-        with self.assertRaises(BuildInsideContanerError) as ctx:
+        with self.assertRaises(BuildInsideContainerError) as ctx:
             self.builder._parse_builder_response(json.dumps(data), self.image_name)
 
         self.assertEqual(str(ctx.exception), msg)

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -12,6 +12,7 @@ from samcli.lib.build.app_builder import (
     BuildError,
     LambdaBuilderError,
     ContainerBuildNotSupported,
+    BuildInsideContanerError,
 )
 
 
@@ -270,7 +271,7 @@ class TestApplicationBuilder_build_function_on_container(TestCase):
 
         self.container_manager.is_docker_reachable = False
 
-        with self.assertRaises(BuildError) as ctx:
+        with self.assertRaises(BuildInsideContanerError) as ctx:
             self.builder._build_function_on_container(
                 config, "source_dir", "artifacts_dir", "scratch_dir", "manifest_path", "runtime", {}
             )
@@ -315,7 +316,7 @@ class TestApplicationBuilder_parse_builder_response(TestCase):
         msg = "invalid params"
         data = {"error": {"code": 488, "message": msg}}
 
-        with self.assertRaises(BuildError) as ctx:
+        with self.assertRaises(BuildInsideContanerError) as ctx:
             self.builder._parse_builder_response(json.dumps(data), self.image_name)
 
         self.assertEqual(str(ctx.exception), msg)


### PR DESCRIPTION
Why is this change necessary?

* Telemetry does not capture correct level of detail today.

How does it address the issue?

* Show the deeper cause of Exception and emit to Telemetry.

What side effects does this change have?

* None

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
