### PR TITLE
feat: dotnetcore3.1 support

### DIFF
--- a/appveyor-windows-build-dotnet.yml
+++ b/appveyor-windows-build-dotnet.yml
@@ -36,6 +36,9 @@ init:
 
 install:
 
+    # Install latest dotnetcore sdk
+    - "choco install dotnetcore-sdk"
+    - "refreshenv"
     # Make sure the temp directory exists for Python to use.
     - ps: "mkdir -Force D:\\tmp"
     - "SET PATH=%PYTHON_HOME%;%PATH%"

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -112,6 +112,7 @@ def get_workflow_config(runtime, code_dir, project_dir):
         "ruby2.7": BasicWorkflowSelector(RUBY_BUNDLER_CONFIG),
         "dotnetcore2.0": BasicWorkflowSelector(DOTNET_CLIPACKAGE_CONFIG),
         "dotnetcore2.1": BasicWorkflowSelector(DOTNET_CLIPACKAGE_CONFIG),
+        "dotnetcore3.1": BasicWorkflowSelector(DOTNET_CLIPACKAGE_CONFIG),
         "go1.x": BasicWorkflowSelector(GO_MOD_CONFIG),
 
         # When Maven builder exists, add to this list so we can automatically choose a builder based on the supported

--- a/samcli/lib/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
+++ b/samcli/lib/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/src/HelloWorld/HelloWorld.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
+    {%- elif cookiecutter.runtime == 'dotnetcore2.1' %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    {%- else %}
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     {%- endif %}
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
@@ -15,6 +17,5 @@
     <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
-  
 </Project>
 

--- a/samcli/lib/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
+++ b/samcli/lib/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/template.yaml
@@ -16,8 +16,10 @@ Resources:
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
       Runtime: {{ cookiecutter.runtime }}
+      {%- elif cookiecutter.runtime == 'dotnetcore2.1' %}
+      Runtime: {{ cookiecutter.runtime }}
       {%- else %}
-      Runtime: dotnetcore2.1
+      Runtime: dotnetcore3.1
       {%- endif %}
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:

--- a/samcli/lib/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
+++ b/samcli/lib/init/templates/cookiecutter-aws-sam-hello-dotnet/{{cookiecutter.project_name}}/test/HelloWorld.Test/HelloWorld.Tests.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    {%- else %}
+    {%- elif cookiecutter.runtime == 'dotnetcore2.1' %}
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    {%- else %}
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     {%- endif %}
   </PropertyGroup>
 

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -38,7 +38,7 @@ RUNTIME_DEP_TEMPLATE_MAPPING = {
     ],
     "dotnet": [
         {
-            "runtimes": ["dotnetcore2.1", "dotnetcore2.0", "dotnetcore1.0"],
+            "runtimes": ["dotnetcore3.1", "dotnetcore2.1", "dotnetcore2.0", "dotnetcore1.0"],
             "dependency_manager": "cli-package",
             "init_location": os.path.join(_templates, "cookiecutter-aws-sam-hello-dotnet"),
             "build": True,
@@ -77,6 +77,7 @@ RUNTIME_TO_DEPENDENCY_MANAGERS = {
     "ruby2.7": ["bundler"],
     "nodejs12.x": ["npm"],
     "nodejs10.x": ["npm"],
+    "dotnetcore3.1": ["cli-package"],
     "dotnetcore2.1": ["cli-package"],
     "dotnetcore2.0": ["cli-package"],
     "dotnetcore1.0": ["cli-package"],
@@ -104,6 +105,7 @@ INIT_RUNTIMES = [
     "ruby2.7",
     "go1.x",
     "java11",
+    "dotnetcore3.1",
     "dotnetcore2.1",
     # older nodejs runtimes
     "nodejs10.x",

--- a/samcli/local/common/runtime_template.py
+++ b/samcli/local/common/runtime_template.py
@@ -106,7 +106,6 @@ INIT_RUNTIMES = [
     "go1.x",
     "java11",
     "dotnetcore3.1",
-    "dotnetcore2.1",
     # older nodejs runtimes
     "nodejs10.x",
     # older python runtimes
@@ -118,6 +117,7 @@ INIT_RUNTIMES = [
     # older java runtimes
     "java8",
     # older dotnetcore runtimes
+    "dotnetcore2.1",
     "dotnetcore2.0",
     "dotnetcore1.0",
 ]

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -34,6 +34,7 @@ class Runtime(Enum):
     go1x = "go1.x"
     dotnetcore20 = "dotnetcore2.0"
     dotnetcore21 = "dotnetcore2.1"
+    dotnetcore31 = "dotnetcore3.1"
     provided = "provided"
 
     @classmethod

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -459,8 +459,10 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
         [
             ("dotnetcore2.0", "Dotnetcore2.0", None),
             ("dotnetcore2.1", "Dotnetcore2.1", None),
+            ("dotnetcore3.1", "Dotnetcore3.1", None),
             ("dotnetcore2.0", "Dotnetcore2.0", "debug"),
             ("dotnetcore2.1", "Dotnetcore2.1", "debug"),
+            ("dotnetcore3.1", "Dotnetcore3.1", "debug"),
         ]
     )
     @pytest.mark.flaky(reruns=3)
@@ -512,7 +514,9 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
 
         self.verify_docker_container_cleanedup(runtime)
 
-    @parameterized.expand([("dotnetcore2.0", "Dotnetcore2.0"), ("dotnetcore2.1", "Dotnetcore2.1")])
+    @parameterized.expand(
+        [("dotnetcore2.0", "Dotnetcore2.0"), ("dotnetcore2.1", "Dotnetcore2.1"), ("dotnetcore3.1", "Dotnetcore3.1")]
+    )
     @pytest.mark.flaky(reruns=3)
     def test_must_fail_with_container(self, runtime, code_uri):
         use_container = True

--- a/tests/integration/testdata/buildcmd/Dotnetcore3.1/HelloWorld.csproj
+++ b/tests/integration/testdata/buildcmd/Dotnetcore3.1/HelloWorld.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.1.3" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+
+</Project>
+

--- a/tests/integration/testdata/buildcmd/Dotnetcore3.1/Program.cs
+++ b/tests/integration/testdata/buildcmd/Dotnetcore3.1/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Newtonsoft.Json;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace HelloWorld
+{
+
+    public class Function
+    {
+
+        public string FunctionHandler(APIGatewayProxyRequest apigProxyEvent, ILambdaContext context)
+        {
+            return "{'message': 'Hello World'}";
+        }
+    }
+}

--- a/tests/integration/testdata/buildcmd/Dotnetcore3.1/aws-lambda-tools-defaults.json
+++ b/tests/integration/testdata/buildcmd/Dotnetcore3.1/aws-lambda-tools-defaults.json
@@ -11,14 +11,8 @@
   "profile":"",
   "region" : "",
   "configuration": "Release",
-  {%- if cookiecutter.runtime == 'dotnetcore2.0' %}
-  "framework": "netcoreapp2.0",
-  {%- elif cookiecutter.runtime == 'dotnetcore2.1' %}
-  "framework": "netcoreapp2.1",
-  {%- else %}
-  "framework" : "netcoreapp3.1",
-  {%- endif %}
-  "function-runtime":"{{ cookiecutter.runtime }}",
+  "framework": "netcoreapp3.1",
+  "function-runtime":"dotnetcore3.1",
   "function-memory-size" : 256,
   "function-timeout" : 30,
   "function-handler" : "HelloWorld::HelloWorld.Function::FunctionHandler"


### PR DESCRIPTION
Why is this change necessary?

* Add support for init, build, local invoke on dotnetcore3.1 runtimes.

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [x] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
