### PR TITLE
Add go_zip_and_upload function to us aws-lambda-go/cmd/build-lambda-zip

### DIFF
--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -25,11 +25,11 @@ import pathlib
 import contextlib
 from contextlib import contextmanager
 import uuid
-from samcli.lib.utils.osutils import is_windows, popen
 from urllib.parse import urlparse, parse_qs
 import shutil
 from botocore.utils import set_value_from_jmespath
 import jmespath
+from samcli.lib.utils.osutils import popen, is_windows
 
 from samcli.commands._utils.resources import (
     AWS_SERVERLESSREPO_APPLICATION,

--- a/samcli/lib/package/artifact_exporter.py
+++ b/samcli/lib/package/artifact_exporter.py
@@ -198,11 +198,9 @@ def go_zip_folder(folder_path):
     if not files:
         raise exceptions.UserException(message="no file in path")
     if len(files) > 1:
-        raise exceptions.UserException(
-            message="There are more than one file in path")
+        raise exceptions.UserException(message="There are more than one file in path")
 
-    p = popen([str(pathlib.Path.home()) + "\\go\\bin\\build-lambda-zip.exe",
-               "-o", zipfile_name, files[0]])
+    p = popen([str(pathlib.Path.home()) + "\\go\\bin\\build-lambda-zip.exe", "-o", zipfile_name, files[0]])
     _, err = p.communicate()
 
     if p.returncode != 0:

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -7,6 +7,8 @@ import shutil
 import stat
 import sys
 import tempfile
+import platform
+import subprocess
 from contextlib import contextmanager
 
 LOG = logging.getLogger(__name__)
@@ -155,3 +157,13 @@ def copytree(source, destination, ignore=None):
             copytree(new_source, new_destination, ignore=ignore)
         else:
             shutil.copy2(new_source, new_destination)
+
+
+def popen(command, _stdout=subprocess.PIPE, _stderr=subprocess.PIPE, env=None, cwd=None):
+    p = subprocess.Popen(command, stdout=_stdout,
+							stderr=_stderr, env=env, cwd=cwd)
+    return p
+
+
+def is_windows():
+    return platform.system().lower() == "windows"

--- a/samcli/lib/utils/osutils.py
+++ b/samcli/lib/utils/osutils.py
@@ -160,8 +160,7 @@ def copytree(source, destination, ignore=None):
 
 
 def popen(command, _stdout=subprocess.PIPE, _stderr=subprocess.PIPE, env=None, cwd=None):
-    p = subprocess.Popen(command, stdout=_stdout,
-							stderr=_stderr, env=env, cwd=cwd)
+    p = subprocess.Popen(command, stdout=_stdout, stderr=_stderr, env=env, cwd=cwd)
     return p
 
 


### PR DESCRIPTION
*Issue #, if available:*

#954 

*Why is this change necessary?*

Because on Windows occurs 'permission denied', 'PathError' in invoking lambda functions, if we us aws-sam-cli( sam deploy ).
You can see the problem in #954 .

*How does it address the issue?*

According to README.md of [aws-lambda-go](https://github.com/aws/aws-lambda-go), on Windows we have to do some special things. We have to use 'build-lambda-zip'.
So i added code which does it.

*What side effects does this change have?*

Yet, if we build .go file with 'sam build', there will be only one output file. 'build-lambda-zip' of aws-lambda-go can make a zip file for only one file. So, if the number of output files by 'sam build' is more than one, 'sam deploy' will fail.


*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
