### PR TITLE
feat: Print warning about using depreciated runtimes

### DIFF
--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -9,8 +9,7 @@ from json import JSONDecodeError
 import click
 
 from samcli.cli.cli_config_file import configuration_option, TomlProvider
-from samcli.commands.exceptions import UserException
-from samcli.cli.main import pass_context, common_options, global_cfg
+from samcli.cli.main import pass_context, common_options
 from samcli.local.common.runtime_template import RUNTIMES, SUPPORTED_DEP_MANAGERS
 from samcli.lib.telemetry.metrics import track_command
 
@@ -138,6 +137,8 @@ def do_cli(
     from samcli.commands.init.interactive_init_flow import do_interactive
     from samcli.commands.init.init_templates import InitTemplates
 
+    _deprecate_notification(runtime)
+
     # check for mutually exclusive parameters
     if location and app_template:
         msg = """
@@ -174,6 +175,19 @@ You can also re-run without the --no-interactive flag to be prompted for require
     else:
         # proceed to interactive state machine, which will call do_generate
         do_interactive(location, runtime, dependency_manager, output_dir, name, app_template, no_input)
+
+
+def _deprecate_notification(runtime):
+    from samcli.lib.utils.colors import Colored
+
+    depreciated_runtimes = {"dotnetcore1.0", "dotnetcore2.0"}
+    if runtime in depreciated_runtimes:
+        message = (
+            f"WARNING: {runtime} is no longer supported by AWS Lambda, please update to a newer supported runtime. SAM CLI "
+            f"will drop support for all deprecated runtimes {depreciated_runtimes} on May 1st. "
+            f"See issue: https://github.com/awslabs/aws-sam-cli/issues/1934 for more details."
+        )
+        LOG.warning(Colored().yellow(message))
 
 
 def _get_cookiecutter_template_context(name, runtime, extra_context):

--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -180,11 +180,11 @@ You can also re-run without the --no-interactive flag to be prompted for require
 def _deprecate_notification(runtime):
     from samcli.lib.utils.colors import Colored
 
-    depreciated_runtimes = {"dotnetcore1.0", "dotnetcore2.0"}
-    if runtime in depreciated_runtimes:
+    deprecated_runtimes = {"dotnetcore1.0", "dotnetcore2.0"}
+    if runtime in deprecated_runtimes:
         message = (
             f"WARNING: {runtime} is no longer supported by AWS Lambda, please update to a newer supported runtime. SAM CLI "
-            f"will drop support for all deprecated runtimes {depreciated_runtimes} on May 1st. "
+            f"will drop support for all deprecated runtimes {deprecated_runtimes} on May 1st. "
             f"See issue: https://github.com/awslabs/aws-sam-cli/issues/1934 for more details."
         )
         LOG.warning(Colored().yellow(message))

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -14,6 +14,7 @@ from aws_lambda_builders.exceptions import LambdaBuilderError
 from aws_lambda_builders import RPC_PROTOCOL_VERSION as lambda_builders_protocol_version
 
 import samcli.lib.utils.osutils as osutils
+from samcli.lib.utils.colors import Colored
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 from .workflow_config import get_workflow_config, supports_build_in_container
 
@@ -89,6 +90,9 @@ class ApplicationBuilder:
         self._container_manager = container_manager
         self._parallel = parallel
         self._mode = mode
+
+        self._depreciated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
+        self._colored = Colored()
 
     def build(self):
         """
@@ -176,6 +180,12 @@ class ApplicationBuilder:
         str
             Path to the location where built artifacts are available
         """
+
+        if runtime in self._depreciated_runtimes:
+            message = f"WARNING: {runtime} is no longer supported by AWS Lambda, please update to a newer supported runtime. SAM CLI " \
+                      f"will drop support for all deprecated runtimes {self._depreciated_runtimes} on May 1st. " \
+                      f"See issue: https://github.com/awslabs/aws-sam-cli/issues/1934 for more details."
+            LOG.warning(self._colored.yellow(message))
 
         # Create the arguments to pass to the builder
         # Code is always relative to the given base directory.

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -91,7 +91,7 @@ class ApplicationBuilder:
         self._parallel = parallel
         self._mode = mode
 
-        self._depreciated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
+        self._deprecated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
         self._colored = Colored()
 
     def build(self):
@@ -181,9 +181,9 @@ class ApplicationBuilder:
             Path to the location where built artifacts are available
         """
 
-        if runtime in self._depreciated_runtimes:
+        if runtime in self._deprecated_runtimes:
             message = f"WARNING: {runtime} is no longer supported by AWS Lambda, please update to a newer supported runtime. SAM CLI " \
-                      f"will drop support for all deprecated runtimes {self._depreciated_runtimes} on May 1st. " \
+                      f"will drop support for all deprecated runtimes {self._deprecated_runtimes} on May 1st. " \
                       f"See issue: https://github.com/awslabs/aws-sam-cli/issues/1934 for more details."
             LOG.warning(self._colored.yellow(message))
 

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -50,7 +50,7 @@ class SamFunctionProvider(FunctionProvider):
         # Store a map of function name to function information for quick reference
         self.functions = self._extract_functions(self.resources)
 
-        self._depreciated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
+        self._deprecated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
         self._colored = Colored()
 
     def get(self, name):
@@ -80,10 +80,10 @@ class SamFunctionProvider(FunctionProvider):
         return None
 
     def _deprecate_notification(self, runtime):
-        if runtime in self._depreciated_runtimes:
+        if runtime in self._deprecated_runtimes:
             message = (
                 f"WARNING: {runtime} is no longer supported by AWS Lambda, please update to a newer supported runtime. SAM CLI "
-                f"will drop support for all deprecated runtimes {self._depreciated_runtimes} on May 1st. "
+                f"will drop support for all deprecated runtimes {self._deprecated_runtimes} on May 1st. "
                 f"See issue: https://github.com/awslabs/aws-sam-cli/issues/1934 for more details."
             )
             LOG.warning(self._colored.yellow(message))

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -5,6 +5,7 @@ import logging
 
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
 from samcli.lib.providers.exceptions import InvalidLayerReference
+from samcli.lib.utils.colors import Colored
 from .provider import FunctionProvider, Function, LayerVersion
 from .sam_base_provider import SamBaseProvider
 
@@ -49,6 +50,9 @@ class SamFunctionProvider(FunctionProvider):
         # Store a map of function name to function information for quick reference
         self.functions = self._extract_functions(self.resources)
 
+        self._depreciated_runtimes = {"nodejs4.3", "nodejs6.10", "nodejs8.10", "dotnetcore2.0"}
+        self._colored = Colored()
+
     def get(self, name):
         """
         Returns the function given name or LogicalId of the function. Every SAM resource has a logicalId, but it may
@@ -66,12 +70,23 @@ class SamFunctionProvider(FunctionProvider):
 
         for f in self.get_all():
             if f.name == name:
+                self._deprecate_notification(f.runtime)
                 return f
 
             if f.functionname == name:
+                self._deprecate_notification(f.runtime)
                 return f
 
         return None
+
+    def _deprecate_notification(self, runtime):
+        if runtime in self._depreciated_runtimes:
+            message = (
+                f"WARNING: {runtime} is no longer supported by AWS Lambda, please update to a newer supported runtime. SAM CLI "
+                f"will drop support for all deprecated runtimes {self._depreciated_runtimes} on May 1st. "
+                f"See issue: https://github.com/awslabs/aws-sam-cli/issues/1934 for more details."
+            )
+            LOG.warning(self._colored.yellow(message))
 
     def get_all(self):
         """


### PR DESCRIPTION
*Issue #, if available:*
#1934

*Why is this change necessary?*
This is to add warnings for customers using build, invoke|start-api|start-lambda, and init commands with runtimes that are no longer supported by AWS Lambda.

*How does it address the issue?*
This is the first phase, so we can safely remove these depreciated runtimes in a future release.

*What side effects does this change have?*
None, just prints warnings when a customer uses a depreciated runtime.

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
N/A

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
