### PR TITLE
Build for Layers

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -162,7 +162,7 @@ module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,50}$
 
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ test:
 	# Fail if coverage falls below 95%
 	pytest --cov samcli --cov-report term-missing --cov-fail-under 95 tests/unit
 
+test-cov-report:
+	# Run unit tests with html coverage report
+	pytest --cov samcli --cov-report html --cov-fail-under 95 tests/unit
+
 integ-test:
 	# Integration tests don't need code coverage
 	@echo Telemetry Status: $(SAM_CLI_TELEMETRY)

--- a/samcli/commands/build/command.py
+++ b/samcli/commands/build/command.py
@@ -180,7 +180,7 @@ def do_cli(  # pylint: disable=too-many-locals, too-many-statements
     ) as ctx:
         try:
             builder = ApplicationBuilder(
-                ctx.functions_to_build,
+                ctx.resources_to_build,
                 ctx.build_dir,
                 ctx.base_dir,
                 manifest_path_override=ctx.manifest_path_override,

--- a/samcli/commands/build/exceptions.py
+++ b/samcli/commands/build/exceptions.py
@@ -7,3 +7,9 @@ class InvalidBuildDirException(UserException):
     """
     Value provided to --build-dir is invalid
     """
+
+
+class MissingBuildMethodException(UserException):
+    """
+    Exception to be thrown when a layer is tried to build without BuildMethod
+    """

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -15,9 +15,9 @@ from aws_lambda_builders import RPC_PROTOCOL_VERSION as lambda_builders_protocol
 
 import samcli.lib.utils.osutils as osutils
 from samcli.lib.utils.colors import Colored
+from samcli.lib.providers.sam_base_provider import SamBaseProvider
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
-from .workflow_config import get_workflow_config, supports_build_in_container
-
+from .workflow_config import get_workflow_config, get_layer_subfolder, supports_build_in_container
 
 LOG = logging.getLogger(__name__)
 
@@ -40,6 +40,7 @@ class BuildError(Exception):
         self.wrapped_from = wrapped_from
         Exception.__init__(self, msg)
 
+
 class BuildInsideContainerError(Exception):
     pass
 
@@ -52,7 +53,7 @@ class ApplicationBuilder:
     """
 
     def __init__(self,
-                 functions_to_build,
+                 resources_to_build,
                  build_dir,
                  base_dir,
                  manifest_path_override=None,
@@ -82,7 +83,7 @@ class ApplicationBuilder:
         mode : str
             Optional, name of the build mode to use ex: 'debug'
         """
-        self._functions_to_build = functions_to_build
+        self._resources_to_build = resources_to_build
         self._build_dir = build_dir
         self._base_dir = base_dir
         self._manifest_path_override = manifest_path_override
@@ -106,13 +107,20 @@ class ApplicationBuilder:
 
         result = {}
 
-        for lambda_function in self._functions_to_build:
-
-            LOG.info("Building resource '%s'", lambda_function.name)
-            result[lambda_function.name] = self._build_function(lambda_function.name,
-                                                                lambda_function.codeuri,
-                                                                lambda_function.runtime,
-                                                                lambda_function.handler)
+        for function in self._resources_to_build.get('Function', []):
+            LOG.info("Building function '%s'", function.name)
+            result[function.name] = self._build_function(function.name,
+                                                         function.codeuri,
+                                                         function.runtime,
+                                                         function.handler)
+        for layer in self._resources_to_build.get('Layer', []):
+            LOG.info("Building layer '%s'", layer.name)
+            if layer.build_method is None:
+                raise Exception(
+                    f"Layer {layer.name} cannot be build without BuildMethod. Please provide BuildMethod in Metadata.")
+            result[layer.name] = self._build_layer(layer.name,
+                                                   layer.codeuri,
+                                                   layer.build_method)
 
         return result
 
@@ -151,13 +159,45 @@ class ApplicationBuilder:
 
             resource_type = resource.get("Type")
             properties = resource.setdefault("Properties", {})
-            if resource_type == "AWS::Serverless::Function":
+            if resource_type == SamBaseProvider.SERVERLESS_FUNCTION:
                 properties["CodeUri"] = artifact_relative_path
 
-            if resource_type == "AWS::Lambda::Function":
+            if resource_type == SamBaseProvider.LAMBDA_FUNCTION:
                 properties["Code"] = artifact_relative_path
 
+            if resource_type in [SamBaseProvider.SERVERLESS_LAYER, SamBaseProvider.LAMBDA_LAYER]:
+                properties["ContentUri"] = artifact_relative_path
+
         return template_dict
+
+    def _build_layer(self, layer_name, codeuri, runtime):
+        # Create the arguments to pass to the builder
+        # Code is always relative to the given base directory.
+        code_dir = str(pathlib.Path(self._base_dir, codeuri).resolve())
+
+        config = get_workflow_config(runtime, code_dir, self._base_dir)
+        subfolder = get_layer_subfolder(runtime)
+
+        # artifacts directory will be created by the builder
+        artifacts_dir = str(pathlib.Path(self._build_dir, layer_name, subfolder))
+
+        with osutils.mkdir_temp() as scratch_dir:
+            manifest_path = self._manifest_path_override or os.path.join(code_dir, config.manifest_name)
+
+            # By default prefer to build in-process for speed
+            build_method = self._build_function_in_process
+            if self._container_manager:
+                build_method = self._build_function_on_container
+
+            build_method(config,
+                         code_dir,
+                         artifacts_dir,
+                         scratch_dir,
+                         manifest_path,
+                         runtime,
+                         None)
+            # Not including subfolder in return so that we copy subfolder, instead of copying artifacts inside it.
+            return str(pathlib.Path(self._build_dir, layer_name))
 
     def _build_function(self, function_name, codeuri, runtime, handler):
         """

--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -15,6 +15,7 @@ from aws_lambda_builders import RPC_PROTOCOL_VERSION as lambda_builders_protocol
 
 import samcli.lib.utils.osutils as osutils
 from samcli.lib.utils.colors import Colored
+from samcli.commands.build.exceptions import MissingBuildMethodException
 from samcli.lib.providers.sam_base_provider import SamBaseProvider
 from samcli.local.docker.lambda_build_container import LambdaBuildContainer
 from .workflow_config import get_workflow_config, get_layer_subfolder, supports_build_in_container
@@ -107,16 +108,16 @@ class ApplicationBuilder:
 
         result = {}
 
-        for function in self._resources_to_build.get('Function', []):
+        for function in self._resources_to_build.functions:
             LOG.info("Building function '%s'", function.name)
             result[function.name] = self._build_function(function.name,
                                                          function.codeuri,
                                                          function.runtime,
                                                          function.handler)
-        for layer in self._resources_to_build.get('Layer', []):
+        for layer in self._resources_to_build.layers:
             LOG.info("Building layer '%s'", layer.name)
             if layer.build_method is None:
-                raise Exception(
+                raise MissingBuildMethodException(
                     f"Layer {layer.name} cannot be build without BuildMethod. Please provide BuildMethod in Metadata.")
             result[layer.name] = self._build_layer(layer.name,
                                                    layer.codeuri,

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -78,19 +78,19 @@ def get_layer_subfolder(runtime):
         "python3.6": "python",
         "python3.7": "python",
         "python3.8": "python",
-        "nodejs4.3": "nodejs/node_modules",
-        "nodejs6.10": "nodejs/node_modules",
-        "nodejs8.10": "nodejs/node_modules",
-        "nodejs10.x": "nodejs/node_modules",
-        "nodejs12.x": "nodejs/node_modules",
+        "nodejs4.3": "nodejs",
+        "nodejs6.10": "nodejs",
+        "nodejs8.10": "nodejs",
+        "nodejs10.x": "nodejs",
+        "nodejs12.x": "nodejs",
         "ruby2.5": "ruby/lib",
         "ruby2.7": "ruby/lib",
-        "java8": "java/lib",
-        "java11": "java/lib",
+        "java8": "java",
+        "java11": "java",
     }
 
     if runtime not in subfolders_by_runtime:
-        raise UnsupportedRuntimeException("'{}' runtime is not supported".format(runtime))
+        raise UnsupportedRuntimeException("'{}' runtime is not supported for layers".format(runtime))
 
     return subfolders_by_runtime[runtime]
 

--- a/samcli/lib/build/workflow_config.py
+++ b/samcli/lib/build/workflow_config.py
@@ -6,9 +6,7 @@ import os
 import logging
 from collections import namedtuple
 
-
 LOG = logging.getLogger(__name__)
-
 
 CONFIG = namedtuple('Capability', ["language", "dependency_manager", "application_framework", "manifest_name",
                                    "executable_search_paths"])
@@ -72,6 +70,29 @@ GO_MOD_CONFIG = CONFIG(
 
 class UnsupportedRuntimeException(Exception):
     pass
+
+
+def get_layer_subfolder(runtime):
+    subfolders_by_runtime = {
+        "python2.7": "python",
+        "python3.6": "python",
+        "python3.7": "python",
+        "python3.8": "python",
+        "nodejs4.3": "nodejs/node_modules",
+        "nodejs6.10": "nodejs/node_modules",
+        "nodejs8.10": "nodejs/node_modules",
+        "nodejs10.x": "nodejs/node_modules",
+        "nodejs12.x": "nodejs/node_modules",
+        "ruby2.5": "ruby/lib",
+        "ruby2.7": "ruby/lib",
+        "java8": "java/lib",
+        "java11": "java/lib",
+    }
+
+    if runtime not in subfolders_by_runtime:
+        raise UnsupportedRuntimeException("'{}' runtime is not supported".format(runtime))
+
+    return subfolders_by_runtime[runtime]
 
 
 def get_workflow_config(runtime, code_dir, project_dir):
@@ -172,8 +193,8 @@ def supports_build_in_container(config):
                                         "Try building without the container. Most .NET Core functions will build "
                                         "successfully.",
         _key(GO_MOD_CONFIG): "We do not support building Go Lambda functions within a container. "
-                                        "Try building without the container. Most Go functions will build "
-                                        "successfully.",
+                             "Try building without the container. Most Go functions will build "
+                             "successfully.",
     }
 
     thiskey = _key(config)
@@ -189,7 +210,6 @@ class BasicWorkflowSelector:
     """
 
     def __init__(self, configs):
-
         if not isinstance(configs, list):
             configs = [configs]
 
@@ -234,8 +254,8 @@ class ManifestWorkflowSelector(BasicWorkflowSelector):
                 return config
 
         raise ValueError("None of the supported manifests '{}' were found in the following paths '{}'".format(
-                         [config.manifest_name for config in self.configs],
-                         search_dirs))
+            [config.manifest_name for config in self.configs],
+            search_dirs))
 
     @staticmethod
     def _has_manifest(config, directory):

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -3,6 +3,7 @@ A provider class that can parse and return Lambda Functions from a variety of so
 source
 """
 import hashlib
+import logging
 from collections import namedtuple
 
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn, UnsupportedIntrinsic
@@ -46,9 +47,8 @@ class LayerVersion:
 
     LAYER_NAME_DELIMETER = "-"
 
-    def __init__(self, arn, codeuri):
+    def __init__(self, arn, codeuri, metadata=None):
         """
-
         Parameters
         ----------
         name str
@@ -56,6 +56,8 @@ class LayerVersion:
         codeuri str
             CodeURI of the layer. This should contain the path to the layer code
         """
+        if metadata is None:
+            metadata = {}
         if not isinstance(arn, str):
             raise UnsupportedIntrinsic("{} is an Unsupported Intrinsic".format(arn))
 
@@ -64,6 +66,7 @@ class LayerVersion:
         self.is_defined_within_template = bool(codeuri)
         self._name = LayerVersion._compute_layer_name(self.is_defined_within_template, arn)
         self._version = LayerVersion._compute_layer_version(self.is_defined_within_template, arn)
+        self._build_method = metadata.get("BuildMethod", None)
 
     @staticmethod
     def _compute_layer_version(is_defined_within_template, arn):
@@ -166,34 +169,15 @@ class LayerVersion:
     def codeuri(self, codeuri):
         self._codeuri = codeuri
 
+    @property
+    def build_method(self):
+        return self._build_method
+
     def __eq__(self, other):
         if isinstance(other, type(self)):
             return self.__dict__ == other.__dict__
 
         return False
-
-
-class FunctionProvider:
-    """
-    Abstract base class of the function provider.
-    """
-
-    def get(self, name):
-        """
-        Given name of the function, this method must return the Function object
-
-        :param string name: Name of the function
-        :return Function: namedtuple containing the Function information
-        """
-        raise NotImplementedError("not implemented")
-
-    def get_all(self):
-        """
-        Yields all the Lambda functions available in the provider.
-
-        :yields Function: namedtuple containing the function information
-        """
-        raise NotImplementedError("not implemented")
 
 
 class Api:
@@ -225,7 +209,6 @@ class Api:
 
 
 _CorsTuple = namedtuple("Cors", ["allow_origin", "allow_methods", "allow_headers", "max_age"])
-
 
 _CorsTuple.__new__.__defaults__ = (
     None,  # Allow Origin defaults to None

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -8,6 +8,8 @@ from collections import namedtuple
 
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn, UnsupportedIntrinsic
 
+LOG = logging.getLogger(__name__)
+
 # Named Tuple to representing the properties of a Lambda Function
 Function = namedtuple(
     "Function",
@@ -38,6 +40,37 @@ Function = namedtuple(
         "events",
     ],
 )
+
+
+class ResourcesToBuildCollector:
+    def __init__(self):
+        self.result = {"Function": [], "Layer": []}
+
+    def add_function(self, function):
+        self.result.get("Function").append(function)
+
+    def add_functions(self, functions):
+        self.result.get("Function").extend(functions)
+
+    def add_layer(self, layer):
+        self.result.get("Layer").append(layer)
+
+    def add_layers(self, layers):
+        self.result.get("Layer").extend(layers)
+
+    @property
+    def functions(self):
+        return self.result.get("Function")
+
+    @property
+    def layers(self):
+        return self.result.get("Layer")
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.__dict__ == other.__dict__
+
+        return False
 
 
 class LayerVersion:

--- a/samcli/lib/providers/sam_base_provider.py
+++ b/samcli/lib/providers/sam_base_provider.py
@@ -67,7 +67,7 @@ class SamBaseProvider:
 
     @staticmethod
     def _extract_sam_function_codeuri(
-            name, resource_properties, code_property_key, ignore_code_extraction_warnings=False
+        name, resource_properties, code_property_key, ignore_code_extraction_warnings=False
     ):
         """
         Extracts the SAM Function CodeUri from the Resource Properties
@@ -88,10 +88,10 @@ class SamBaseProvider:
         str
             Representing the local code path
         """
-        codeuri = resource_properties.get(code_property_key, SamBaseProvider._DEFAULT_CODEURI)
+        codeuri = resource_properties.get(code_property_key, SamBaseProvider.DEFAULT_CODEURI)
         # CodeUri can be a dictionary of S3 Bucket/Key or a S3 URI, neither of which are supported
         if isinstance(codeuri, dict) or (isinstance(codeuri, str) and codeuri.startswith("s3://")):
-            codeuri = SamBaseProvider._DEFAULT_CODEURI
+            codeuri = SamBaseProvider.DEFAULT_CODEURI
             if not ignore_code_extraction_warnings:
                 LOG.warning(
                     "Lambda function '%s' has specified S3 location for CodeUri which is unsupported. "

--- a/samcli/lib/providers/sam_base_provider.py
+++ b/samcli/lib/providers/sam_base_provider.py
@@ -17,6 +17,90 @@ class SamBaseProvider:
     Base class for SAM Template providers
     """
 
+    SERVERLESS_FUNCTION = "AWS::Serverless::Function"
+    LAMBDA_FUNCTION = "AWS::Lambda::Function"
+    SERVERLESS_LAYER = "AWS::Serverless::LayerVersion"
+    LAMBDA_LAYER = "AWS::Lambda::LayerVersion"
+    DEFAULT_CODEURI = "."
+
+    def get(self, name):
+        """
+        Given name of the function, this method must return the Function object
+
+        :param string name: Name of the function
+        :return Function: namedtuple containing the Function information
+        """
+        raise NotImplementedError("not implemented")
+
+    def get_all(self):
+        """
+        Yields all the Lambda functions available in the provider.
+
+        :yields Function: namedtuple containing the function information
+        """
+        raise NotImplementedError("not implemented")
+
+    @staticmethod
+    def _extract_lambda_function_code(resource_properties, code_property_key):
+        """
+        Extracts the Lambda Function Code from the Resource Properties
+
+        Parameters
+        ----------
+        resource_properties dict
+            Dictionary representing the Properties of the Resource
+        code_property_key str
+            Property Key of the code on the Resource
+
+        Returns
+        -------
+        str
+            Representing the local code path
+        """
+
+        codeuri = resource_properties.get(code_property_key, SamBaseProvider.DEFAULT_CODEURI)
+
+        if isinstance(codeuri, dict):
+            codeuri = SamBaseProvider.DEFAULT_CODEURI
+
+        return codeuri
+
+    @staticmethod
+    def _extract_sam_function_codeuri(
+            name, resource_properties, code_property_key, ignore_code_extraction_warnings=False
+    ):
+        """
+        Extracts the SAM Function CodeUri from the Resource Properties
+
+        Parameters
+        ----------
+        name str
+            LogicalId of the resource
+        resource_properties dict
+            Dictionary representing the Properties of the Resource
+        code_property_key str
+            Property Key of the code on the Resource
+        ignore_code_extraction_warnings
+            Boolean to ignore log statements on code extraction from Resources.
+
+        Returns
+        -------
+        str
+            Representing the local code path
+        """
+        codeuri = resource_properties.get(code_property_key, SamBaseProvider._DEFAULT_CODEURI)
+        # CodeUri can be a dictionary of S3 Bucket/Key or a S3 URI, neither of which are supported
+        if isinstance(codeuri, dict) or (isinstance(codeuri, str) and codeuri.startswith("s3://")):
+            codeuri = SamBaseProvider._DEFAULT_CODEURI
+            if not ignore_code_extraction_warnings:
+                LOG.warning(
+                    "Lambda function '%s' has specified S3 location for CodeUri which is unsupported. "
+                    "Using default value of '%s' instead",
+                    name,
+                    codeuri,
+                )
+        return codeuri
+
     @staticmethod
     def get_template(template_dict, parameter_overrides=None):
         """

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -282,6 +282,6 @@ class SamFunctionProvider(SamBaseProvider):
                         layer_logical_id, layer_properties, "ContentUri", ignore_code_extraction_warnings
                     )
 
-                layers.append(LayerVersion(layer_logical_id, codeuri))
+                layers.append(LayerVersion(layer_logical_id, codeuri, layer_resource.get("Metadata", None)))
 
         return layers

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -20,12 +20,6 @@ class SamFunctionProvider(SamBaseProvider):
     It may or may not contain a function.
     """
 
-    _SERVERLESS_FUNCTION = "AWS::Serverless::Function"
-    _LAMBDA_FUNCTION = "AWS::Lambda::Function"
-    _SERVERLESS_LAYER = "AWS::Serverless::LayerVersion"
-    _LAMBDA_LAYER = "AWS::Lambda::LayerVersion"
-    _DEFAULT_CODEURI = "."
-
     def __init__(self, template_dict, parameter_overrides=None, ignore_code_extraction_warnings=False):
         """
         Initialize the class with SAM template data. The SAM template passed to this provider is assumed
@@ -119,12 +113,22 @@ class SamFunctionProvider(SamBaseProvider):
             resource_type = resource.get("Type")
             resource_properties = resource.get("Properties", {})
 
-            if resource_type == SamFunctionProvider._SERVERLESS_FUNCTION:
-                layers = SamFunctionProvider._parse_layer_info(resource_properties.get("Layers", []),resources, ignore_code_extraction_warnings=ignore_code_extraction_warnings)
-                result[name] = SamFunctionProvider._convert_sam_function_resource(name, resource_properties, layers, ignore_code_extraction_warnings=ignore_code_extraction_warnings)
+            if resource_type == SamFunctionProvider.SERVERLESS_FUNCTION:
+                layers = SamFunctionProvider._parse_layer_info(
+                    resource_properties.get("Layers", []),
+                    resources,
+                    ignore_code_extraction_warnings=ignore_code_extraction_warnings,
+                )
+                result[name] = SamFunctionProvider._convert_sam_function_resource(
+                    name, resource_properties, layers, ignore_code_extraction_warnings=ignore_code_extraction_warnings
+                )
 
-            elif resource_type == SamFunctionProvider._LAMBDA_FUNCTION:
-                layers = SamFunctionProvider._parse_layer_info(resource_properties.get("Layers", []), resources, ignore_code_extraction_warnings=ignore_code_extraction_warnings)
+            elif resource_type == SamFunctionProvider.LAMBDA_FUNCTION:
+                layers = SamFunctionProvider._parse_layer_info(
+                    resource_properties.get("Layers", []),
+                    resources,
+                    ignore_code_extraction_warnings=ignore_code_extraction_warnings,
+                )
                 result[name] = SamFunctionProvider._convert_lambda_function_resource(name, resource_properties, layers)
 
             # We don't care about other resource types. Just ignore them

--- a/samcli/lib/providers/sam_function_provider.py
+++ b/samcli/lib/providers/sam_function_provider.py
@@ -6,13 +6,13 @@ import logging
 from samcli.commands.local.cli_common.user_exceptions import InvalidLayerVersionArn
 from samcli.lib.providers.exceptions import InvalidLayerReference
 from samcli.lib.utils.colors import Colored
-from .provider import FunctionProvider, Function, LayerVersion
+from .provider import Function, LayerVersion
 from .sam_base_provider import SamBaseProvider
 
 LOG = logging.getLogger(__name__)
 
 
-class SamFunctionProvider(FunctionProvider):
+class SamFunctionProvider(SamBaseProvider):
     """
     Fetches and returns Lambda Functions from a SAM Template. The SAM template passed to this provider is assumed
     to be valid, normalized and a dictionary.
@@ -43,7 +43,7 @@ class SamFunctionProvider(FunctionProvider):
         :param bool ignore_code_extraction_warnings: Ignores Log warnings
         """
 
-        self.template_dict = SamBaseProvider.get_template(template_dict, parameter_overrides)
+        self.template_dict = SamFunctionProvider.get_template(template_dict, parameter_overrides)
         self.ignore_code_extraction_warnings = ignore_code_extraction_warnings
         self.resources = self.template_dict.get("Resources", {})
 
@@ -120,21 +120,11 @@ class SamFunctionProvider(FunctionProvider):
             resource_properties = resource.get("Properties", {})
 
             if resource_type == SamFunctionProvider._SERVERLESS_FUNCTION:
-                layers = SamFunctionProvider._parse_layer_info(
-                    resource_properties.get("Layers", []),
-                    resources,
-                    ignore_code_extraction_warnings=ignore_code_extraction_warnings,
-                )
-                result[name] = SamFunctionProvider._convert_sam_function_resource(
-                    name, resource_properties, layers, ignore_code_extraction_warnings=ignore_code_extraction_warnings
-                )
+                layers = SamFunctionProvider._parse_layer_info(resource_properties.get("Layers", []),resources, ignore_code_extraction_warnings=ignore_code_extraction_warnings)
+                result[name] = SamFunctionProvider._convert_sam_function_resource(name, resource_properties, layers, ignore_code_extraction_warnings=ignore_code_extraction_warnings)
 
             elif resource_type == SamFunctionProvider._LAMBDA_FUNCTION:
-                layers = SamFunctionProvider._parse_layer_info(
-                    resource_properties.get("Layers", []),
-                    resources,
-                    ignore_code_extraction_warnings=ignore_code_extraction_warnings,
-                )
+                layers = SamFunctionProvider._parse_layer_info(resource_properties.get("Layers", []), resources, ignore_code_extraction_warnings=ignore_code_extraction_warnings)
                 result[name] = SamFunctionProvider._convert_lambda_function_resource(name, resource_properties, layers)
 
             # We don't care about other resource types. Just ignore them
@@ -170,42 +160,6 @@ class SamFunctionProvider(FunctionProvider):
         return SamFunctionProvider._build_function_configuration(name, codeuri, resource_properties, layers)
 
     @staticmethod
-    def _extract_sam_function_codeuri(
-        name, resource_properties, code_property_key, ignore_code_extraction_warnings=False
-    ):
-        """
-        Extracts the SAM Function CodeUri from the Resource Properties
-
-        Parameters
-        ----------
-        name str
-            LogicalId of the resource
-        resource_properties dict
-            Dictionary representing the Properties of the Resource
-        code_property_key str
-            Property Key of the code on the Resource
-        ignore_code_extraction_warnings
-            Boolean to ignore log statements on code extraction from Resources.
-
-        Returns
-        -------
-        str
-            Representing the local code path
-        """
-        codeuri = resource_properties.get(code_property_key, SamFunctionProvider._DEFAULT_CODEURI)
-        # CodeUri can be a dictionary of S3 Bucket/Key or a S3 URI, neither of which are supported
-        if isinstance(codeuri, dict) or (isinstance(codeuri, str) and codeuri.startswith("s3://")):
-            codeuri = SamFunctionProvider._DEFAULT_CODEURI
-            if not ignore_code_extraction_warnings:
-                LOG.warning(
-                    "Lambda function '%s' has specified S3 location for CodeUri which is unsupported. "
-                    "Using default value of '%s' instead",
-                    name,
-                    codeuri,
-                )
-        return codeuri
-
-    @staticmethod
     def _convert_lambda_function_resource(name, resource_properties, layers):  # pylint: disable=invalid-name
         """
         Converts a AWS::Serverless::Function resource to a Function configuration usable by the provider.
@@ -232,31 +186,6 @@ class SamFunctionProvider(FunctionProvider):
         LOG.debug("Found Lambda function with name='%s' and CodeUri='%s'", name, codeuri)
 
         return SamFunctionProvider._build_function_configuration(name, codeuri, resource_properties, layers)
-
-    @staticmethod
-    def _extract_lambda_function_code(resource_properties, code_property_key):
-        """
-        Extracts the Lambda Function Code from the Resource Properties
-
-        Parameters
-        ----------
-        resource_properties dict
-            Dictionary representing the Properties of the Resource
-        code_property_key str
-            Property Key of the code on the Resource
-
-        Returns
-        -------
-        str
-            Representing the local code path
-        """
-
-        codeuri = resource_properties.get(code_property_key, SamFunctionProvider._DEFAULT_CODEURI)
-
-        if isinstance(codeuri, dict):
-            codeuri = SamFunctionProvider._DEFAULT_CODEURI
-
-        return codeuri
 
     @staticmethod
     def _build_function_configuration(name, codeuri, resource_properties, layers):
@@ -336,8 +265,8 @@ class SamFunctionProvider(FunctionProvider):
                 layer_logical_id = layer.get("Ref")
                 layer_resource = resources.get(layer_logical_id)
                 if not layer_resource or layer_resource.get("Type", "") not in (
-                    SamFunctionProvider._SERVERLESS_LAYER,
-                    SamFunctionProvider._LAMBDA_LAYER,
+                    SamFunctionProvider.SERVERLESS_LAYER,
+                    SamFunctionProvider.LAMBDA_LAYER,
                 ):
                     raise InvalidLayerReference()
 
@@ -345,10 +274,10 @@ class SamFunctionProvider(FunctionProvider):
                 resource_type = layer_resource.get("Type")
                 codeuri = None
 
-                if resource_type == SamFunctionProvider._LAMBDA_LAYER:
+                if resource_type == SamFunctionProvider.LAMBDA_LAYER:
                     codeuri = SamFunctionProvider._extract_lambda_function_code(layer_properties, "Content")
 
-                if resource_type == SamFunctionProvider._SERVERLESS_LAYER:
+                if resource_type == SamFunctionProvider.SERVERLESS_LAYER:
                     codeuri = SamFunctionProvider._extract_sam_function_codeuri(
                         layer_logical_id, layer_properties, "ContentUri", ignore_code_extraction_warnings
                     )

--- a/samcli/lib/providers/sam_layer_provider.py
+++ b/samcli/lib/providers/sam_layer_provider.py
@@ -1,0 +1,101 @@
+"""
+Class that provides layers from a given SAM template
+"""
+import logging
+
+from .provider import LayerVersion
+from .sam_base_provider import SamBaseProvider
+
+LOG = logging.getLogger(__name__)
+
+
+class SamLayerProvider(SamBaseProvider):
+    """
+    Fetches and returns Layers from a SAM Template. The SAM template passed to this provider is assumed to be valid,
+    normalized and a dictionary.
+
+    It may or may not contain a layer.
+    """
+
+    def __init__(self, template_dict, parameter_overrides=None):
+        """
+        Initialize the class with SAM template data. The SAM template passed to this provider is assumed
+        to be valid, normalized and a dictionary. It should be normalized by running all pre-processing
+        before passing to this class. The process of normalization will remove structures like ``Globals``, resolve
+        intrinsic functions etc.
+        This class does not perform any syntactic validation of the template.
+
+        After the class is initialized, any changes to the ``template_dict`` will not be reflected in here.
+        You need to explicitly update the class with new template, if necessary.
+
+        Parameters
+        ----------
+        template_dict: SAM Template as a dictionary
+        parameter_overrides: Optional dictionary of values for SAM template parameters that might want to get
+            substituted within the template
+        """
+        self._template_dict = SamLayerProvider.get_template(template_dict, parameter_overrides)
+        self._resources = self._template_dict.get("Resources", {})
+        self._layers = self._extract_layers()
+
+    def get(self, name):
+        """
+        Returns the layer with given name or logical id.
+
+        Parameters
+        ----------
+        name: name or logical id of the layer.
+
+        Returns
+        -------
+        LayerVersion object of one layer.
+
+        """
+        if not name:
+            raise ValueError("Layer name is required")
+
+        for layer in self._layers:
+            if layer.name == name:
+                return layer
+        return None
+
+    def get_all(self):
+        """
+        Returns all Layers in template
+        Returns
+        -------
+        [LayerVersion] list of layer version objects.
+        """
+        return self._layers
+
+    def _extract_layers(self):
+        """
+        Extracts all resources with Type AWS::Lambda::LayerVersion and AWS::Serverless::LayerVersion and return a list
+        of those resources.
+        """
+        layers = []
+        for name, resource in self._resources.items():
+            if resource.get("Type") in [self.LAMBDA_LAYER, self.SERVERLESS_LAYER]:
+                layers.append(self._convert_lambda_layer_resource(name, resource))
+        return layers
+
+    def _convert_lambda_layer_resource(self, layer_logical_id, layer_resource):
+        """
+        Convert layer resource into {LayerVersion} object.
+        Parameters
+        ----------
+        layer_logical_id: LogicalID of resource.
+        layer_resource: resource in template.
+        """
+        # In the list of layers that is defined within a template, you can reference a LayerVersion resource.
+        # When running locally, we need to follow that Ref so we can extract the local path to the layer code.
+        layer_properties = layer_resource.get("Properties", {})
+        resource_type = layer_resource.get("Type")
+        codeuri = None
+
+        if resource_type == self.SERVERLESS_LAYER:
+            codeuri = SamLayerProvider._extract_sam_function_codeuri(layer_logical_id, layer_properties, "ContentUri")
+        if resource_type == self.LAMBDA_LAYER:
+            codeuri = SamLayerProvider._extract_lambda_function_code(layer_properties, "Content")
+
+        return LayerVersion(layer_logical_id, codeuri, layer_resource.get("Metadata", None))

--- a/samcli/local/lambdafn/exceptions.py
+++ b/samcli/local/lambdafn/exceptions.py
@@ -7,3 +7,9 @@ class FunctionNotFound(Exception):
     """
     Raised when the requested Lambda function is not found
     """
+
+
+class ResourceNotFound(Exception):
+    """
+    Raised when the requested resource is not found
+    """

--- a/tests/integration/buildcmd/build_integ_base.py
+++ b/tests/integration/buildcmd/build_integ_base.py
@@ -4,7 +4,6 @@ import shutil
 import tempfile
 import time
 import logging
-import subprocess
 import json
 from unittest import TestCase
 
@@ -65,6 +64,7 @@ class BuildIntegBase(TestCase):
         parameter_overrides=None,
         mode=None,
         function_identifier=None,
+        debug=False,
     ):
 
         command_list = [self.cmd, "build"]
@@ -88,6 +88,9 @@ class BuildIntegBase(TestCase):
 
         if use_container:
             command_list += ["--use-container"]
+
+        if debug:
+            command_list += ["--debug"]
 
         return command_list
 

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -20,7 +20,6 @@ TIMEOUT = 420  # 7 mins
     "Skip build tests on windows when running in CI unless overridden",
 )
 class TestBuildCommand_PythonFunctions(BuildIntegBase):
-
     EXPECTED_FILES_GLOBAL_MANIFEST = set()
     EXPECTED_FILES_PROJECT_MANIFEST = {
         "__init__.py",
@@ -32,8 +31,20 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
 
     FUNCTION_LOGICAL_ID = "Function"
 
+    @parameterized.expand(
+        [
+            ("python2.7", False),
+            ("python3.6", False),
+            ("python3.7", False),
+            ("python3.8", False),
+            ("python2.7", "use_container"),
+            ("python3.6", "use_container"),
+            ("python3.7", "use_container"),
+            ("python3.8", "use_container"),
+        ]
+    )
     @pytest.mark.flaky(reruns=3)
-    def test_with_default_requirements(self, runtime="python3.8", use_container=False):
+    def test_with_default_requirements(self, runtime, use_container):
         overrides = {"Runtime": runtime, "CodeUri": "Python", "Handler": "main.handler"}
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
@@ -79,7 +90,6 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
         self.verify_docker_container_cleanedup(runtime)
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
-
         self.assertTrue(build_dir.exists(), "Build directory should be created")
 
         build_dir_files = os.listdir(str(build_dir))
@@ -123,7 +133,6 @@ class TestBuildCommand_ErrorCases(BuildIntegBase):
     "Skip build tests on windows when running in CI unless overridden",
 )
 class TestBuildCommand_NodeFunctions(BuildIntegBase):
-
     EXPECTED_FILES_GLOBAL_MANIFEST = set()
     EXPECTED_FILES_PROJECT_MANIFEST = {"node_modules", "main.js"}
     EXPECTED_NODE_MODULES = {"minimal-request-promise"}
@@ -177,7 +186,6 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
         self.verify_docker_container_cleanedup(runtime)
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files, expected_modules):
-
         self.assertTrue(build_dir.exists(), "Build directory should be created")
 
         build_dir_files = os.listdir(str(build_dir))
@@ -204,7 +212,6 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
     "Skip build tests on windows when running in CI unless overridden",
 )
 class TestBuildCommand_RubyFunctions(BuildIntegBase):
-
     EXPECTED_FILES_GLOBAL_MANIFEST = set()
     EXPECTED_FILES_PROJECT_MANIFEST = {"app.rb"}
     EXPECTED_RUBY_GEM = "aws-record"
@@ -259,7 +266,6 @@ class TestBuildCommand_RubyFunctions(BuildIntegBase):
         self.verify_docker_container_cleanedup(runtime)
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files, expected_modules):
-
         self.assertTrue(build_dir.exists(), "Build directory should be created")
 
         build_dir_files = os.listdir(str(build_dir))
@@ -294,7 +300,6 @@ class TestBuildCommand_RubyFunctions(BuildIntegBase):
     "Skip build tests on windows when running in CI unless overridden",
 )
 class TestBuildCommand_Java(BuildIntegBase):
-
     EXPECTED_FILES_PROJECT_MANIFEST_GRADLE = {"aws", "lib", "META-INF"}
     EXPECTED_FILES_PROJECT_MANIFEST_MAVEN = {"aws", "lib"}
     EXPECTED_DEPENDENCIES = {"annotations-2.1.0.jar", "aws-lambda-java-core-1.1.0.jar"}
@@ -430,7 +435,6 @@ class TestBuildCommand_Java(BuildIntegBase):
     "Skip build tests on windows when running in CI unless overridden",
 )
 class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
-
     FUNCTION_LOGICAL_ID = "Function"
     EXPECTED_FILES_PROJECT_MANIFEST = {
         "Amazon.Lambda.APIGatewayEvents.dll",
@@ -518,7 +522,6 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
         self.assertEqual(process_execute.process.returncode, 1)
 
     def _verify_built_artifact(self, build_dir, function_logical_id, expected_files):
-
         self.assertTrue(build_dir.exists(), "Build directory should be created")
 
         build_dir_files = os.listdir(str(build_dir))
@@ -541,7 +544,6 @@ class TestBuildCommand_Dotnet_cli_package(BuildIntegBase):
     "Skip build tests on windows when running in CI unless overridden",
 )
 class TestBuildCommand_Go_Modules(BuildIntegBase):
-
     FUNCTION_LOGICAL_ID = "Function"
     EXPECTED_FILES_PROJECT_MANIFEST = {"hello-world"}
 
@@ -682,6 +684,146 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
 
         # Make sure the template has correct CodeUri for resource
         self._verify_resource_property(str(template_path), function_logical_id, "CodeUri", function_logical_id)
+
+        all_artifacts = set(os.listdir(str(resource_artifact_dir)))
+        actual_files = all_artifacts.intersection(expected_files)
+        self.assertEqual(actual_files, expected_files)
+
+    def _get_python_version(self):
+        return "python{}.{}".format(sys.version_info.major, sys.version_info.minor)
+
+
+@skipIf(
+    ((IS_WINDOWS and RUNNING_ON_CI) and not CI_OVERRIDE),
+    "Skip build tests on windows when running in CI unless overridden",
+)
+class TestBuildCommand_LayerBuilds(BuildIntegBase):
+    template = "layers-functions-template.yaml"
+
+    EXPECTED_FILES_GLOBAL_MANIFEST = set()
+    EXPECTED_FILES_PROJECT_MANIFEST = {
+        "__init__.py",
+        "main.py",
+        "requirements.txt",
+    }
+    EXPECTED_LAYERS_FILES_PROJECT_MANIFEST = {
+        "__init__.py",
+        "layer.py",
+        "numpy",
+        "requirements.txt",
+    }
+
+    @parameterized.expand([("python3.7", False, "LayerOne"), ("python3.7", "use_container", "LayerOne")])
+    def test_build_single_layer(self, runtime, use_container, layer_identifier):
+        overrides = {"LayerBuildMethod": runtime, "LayerContentUri": "PyLayer"}
+        cmdlist = self.get_command_list(
+            use_container=use_container, parameter_overrides=overrides, function_identifier=layer_identifier
+        )
+
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
+
+        run_command(cmdlist, cwd=self.working_dir)
+
+        LOG.info("Default build dir: %s", self.default_build_dir)
+        self._verify_built_artifact(
+            self.default_build_dir,
+            layer_identifier,
+            self.EXPECTED_LAYERS_FILES_PROJECT_MANIFEST,
+            "ContentUri",
+            "python",
+        )
+
+    @parameterized.expand([("python3.7", False, "LayerTwo"), ("python3.7", "use_container", "LayerTwo")])
+    def test_build_fails_with_missing_metadata(self, runtime, use_container, layer_identifier):
+        overrides = {"LayerBuildMethod": runtime, "LayerContentUri": "PyLayer"}
+        cmdlist = self.get_command_list(
+            use_container=use_container, parameter_overrides=overrides, function_identifier=layer_identifier
+        )
+
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
+
+        run_command(cmdlist, cwd=self.working_dir)
+
+        self.assertFalse(self.default_build_dir.joinpath(layer_identifier).exists())
+
+    @parameterized.expand([("python3.7", False), ("python3.7", "use_container")])
+    def test_build_function_and_layer(self, runtime, use_container):
+        overrides = {
+            "LayerBuildMethod": runtime,
+            "LayerContentUri": "PyLayer",
+            "Runtime": runtime,
+            "CodeUri": "PythonWithLayer",
+            "Handler": "main.handler",
+        }
+        cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
+
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
+
+        run_command(cmdlist, cwd=self.working_dir)
+
+        LOG.info("Default build dir: %s", self.default_build_dir)
+        self._verify_built_artifact(
+            self.default_build_dir, "FunctionOne", self.EXPECTED_FILES_PROJECT_MANIFEST, "CodeUri"
+        )
+        self._verify_built_artifact(
+            self.default_build_dir, "LayerOne", self.EXPECTED_LAYERS_FILES_PROJECT_MANIFEST, "ContentUri", "python"
+        )
+
+        expected = {"pi": "3.14"}
+        self._verify_invoke_built_function(
+            self.built_template, "FunctionOne", self._make_parameter_override_arg(overrides), expected
+        )
+        self.verify_docker_container_cleanedup(runtime)
+
+    @parameterized.expand([("python3.7", False), ("python3.7", "use_container")])
+    def test_build_function_with_dependent_layer(self, runtime, use_container):
+        overrides = {
+            "LayerBuildMethod": runtime,
+            "LayerContentUri": "PyLayer",
+            "Runtime": runtime,
+            "CodeUri": "PythonWithLayer",
+            "Handler": "main.handler",
+        }
+        cmdlist = self.get_command_list(
+            use_container=use_container, parameter_overrides=overrides, function_identifier="FunctionOne"
+        )
+
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
+
+        run_command(cmdlist, cwd=self.working_dir)
+
+        LOG.info("Default build dir: %s", self.default_build_dir)
+        self._verify_built_artifact(
+            self.default_build_dir, "FunctionOne", self.EXPECTED_FILES_PROJECT_MANIFEST, "CodeUri"
+        )
+        self._verify_built_artifact(
+            self.default_build_dir, "LayerOne", self.EXPECTED_LAYERS_FILES_PROJECT_MANIFEST, "ContentUri", "python"
+        )
+
+        expected = {"pi": "3.14"}
+        self._verify_invoke_built_function(
+            self.built_template, "FunctionOne", self._make_parameter_override_arg(overrides), expected
+        )
+        self.verify_docker_container_cleanedup(runtime)
+
+    def _verify_built_artifact(
+        self, build_dir, resource_logical_id, expected_files, code_property_name, artifact_subfolder=""
+    ):
+        self.assertTrue(build_dir.exists(), "Build directory should be created")
+
+        build_dir_files = os.listdir(str(build_dir))
+        self.assertIn("template.yaml", build_dir_files)
+        self.assertIn(resource_logical_id, build_dir_files)
+
+        template_path = build_dir.joinpath("template.yaml")
+        resource_artifact_dir = build_dir.joinpath(resource_logical_id, artifact_subfolder)
+
+        # Make sure the template has correct CodeUri for resource
+        self._verify_resource_property(str(template_path), resource_logical_id, code_property_name, resource_logical_id)
 
         all_artifacts = set(os.listdir(str(resource_artifact_dir)))
         actual_files = all_artifacts.intersection(expected_files)

--- a/tests/integration/buildcmd/test_build_cmd.py
+++ b/tests/integration/buildcmd/test_build_cmd.py
@@ -32,24 +32,13 @@ class TestBuildCommand_PythonFunctions(BuildIntegBase):
 
     FUNCTION_LOGICAL_ID = "Function"
 
-    @parameterized.expand(
-        [
-            ("python2.7", False),
-            ("python3.6", False),
-            ("python3.7", False),
-            ("python3.8", False),
-            ("python2.7", "use_container"),
-            ("python3.6", "use_container"),
-            ("python3.7", "use_container"),
-            ("python3.8", "use_container"),
-        ]
-    )
     @pytest.mark.flaky(reruns=3)
-    def test_with_default_requirements(self, runtime, use_container):
+    def test_with_default_requirements(self, runtime="python3.8", use_container=False):
         overrides = {"Runtime": runtime, "CodeUri": "Python", "Handler": "main.handler"}
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
-        LOG.info("Running Command: {}", cmdlist)
+        LOG.info("Running Command: ")
+        LOG.info(cmdlist)
         run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(
@@ -121,7 +110,8 @@ class TestBuildCommand_ErrorCases(BuildIntegBase):
         overrides = {"Runtime": "unsupportedpython", "CodeUri": "Python"}
         cmdlist = self.get_command_list(parameter_overrides=overrides)
 
-        LOG.info("Running Command: {}", cmdlist)
+        LOG.info("Running Command:", cmdlist)
+        LOG.info(cmdlist)
         process_execute = run_command(cmdlist, cwd=self.working_dir)
         self.assertEqual(1, process_execute.process.returncode)
 
@@ -153,7 +143,8 @@ class TestBuildCommand_NodeFunctions(BuildIntegBase):
         overrides = {"Runtime": runtime, "CodeUri": "Node", "Handler": "ignored"}
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
-        LOG.info("Running Command: {}", cmdlist)
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
         run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(
@@ -234,7 +225,8 @@ class TestBuildCommand_RubyFunctions(BuildIntegBase):
         overrides = {"Runtime": runtime, "CodeUri": "Ruby", "Handler": "ignored"}
         cmdlist = self.get_command_list(use_container=use_container, parameter_overrides=overrides)
 
-        LOG.info("Running Command: {}".format(cmdlist))
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
         run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(
@@ -666,7 +658,8 @@ class TestBuildCommand_SingleFunctionBuilds(BuildIntegBase):
             use_container=use_container, parameter_overrides=overrides, function_identifier=function_identifier
         )
 
-        LOG.info("Running Command: {}", cmdlist)
+        LOG.info("Running Command:")
+        LOG.info(cmdlist)
         run_command(cmdlist, cwd=self.working_dir)
 
         self._verify_built_artifact(self.default_build_dir, function_identifier, self.EXPECTED_FILES_PROJECT_MANIFEST)

--- a/tests/integration/testdata/buildcmd/PyLayer/layer.py
+++ b/tests/integration/testdata/buildcmd/PyLayer/layer.py
@@ -1,0 +1,5 @@
+import numpy
+
+
+def layer_method():
+    return {"pi": "{0:.2f}".format(numpy.pi)}

--- a/tests/integration/testdata/buildcmd/PyLayer/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PyLayer/requirements.txt
@@ -1,0 +1,6 @@
+# These are some hard packages to build. Using them here helps us verify that building works on various platforms
+
+numpy~=1.15
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/PythonWithLayer/main.py
+++ b/tests/integration/testdata/buildcmd/PythonWithLayer/main.py
@@ -1,0 +1,5 @@
+import layer
+
+
+def handler(event, context):
+    return layer.layer_method()

--- a/tests/integration/testdata/buildcmd/PythonWithLayer/requirements.txt
+++ b/tests/integration/testdata/buildcmd/PythonWithLayer/requirements.txt
@@ -1,0 +1,5 @@
+# These are some hard packages to build. Using them here helps us verify that building works on various platforms
+
+# `cryptography` has a dependency on `pycparser` which, for some reason doesn't build inside a Docker container.
+# Turning this off until we resolve this issue: https://github.com/awslabs/aws-lambda-builders/issues/29
+# cryptography~=2.4

--- a/tests/integration/testdata/buildcmd/layers-functions-template.yaml
+++ b/tests/integration/testdata/buildcmd/layers-functions-template.yaml
@@ -1,0 +1,44 @@
+AWSTemplateFormatVersion : '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameteres:
+  Runtime:
+    Type: String
+  CodeUri:
+    Type: String
+  Handler:
+    Type: String
+  LayerContentUri:
+    Type: String
+  LayerBuildMethod:
+    Type: String
+
+Resources:
+
+  FunctionOne:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: !Ref Handler
+      Runtime: !Ref Runtime
+      CodeUri: !Ref CodeUri
+      Timeout: 600
+      Layers:
+        - !Ref LayerOne
+
+  LayerOne:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      Description: Layer one
+      ContentUri: !Ref LayerContentUri
+      CompatibleRuntimes:
+        - python3.7
+    Metadata:
+      BuildMethod: !Ref LayerBuildMethod
+
+  LayerTwo:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      Description: Layer two
+      ContentUri: !Ref LayerContentUri
+      CompatibleRuntimes:
+        - python3.7

--- a/tests/unit/commands/buildcmd/test_command.py
+++ b/tests/unit/commands/buildcmd/test_command.py
@@ -50,7 +50,7 @@ class TestDoCli(TestCase):
         )
 
         ApplicationBuilderMock.assert_called_once_with(
-            ctx_mock.functions_to_build,
+            ctx_mock.resources_to_build,
             ctx_mock.build_dir,
             ctx_mock.base_dir,
             manifest_path_override=ctx_mock.manifest_path_override,

--- a/tests/unit/commands/local/lib/test_provider.py
+++ b/tests/unit/commands/local/lib/test_provider.py
@@ -28,6 +28,13 @@ class TestLayerVersion(TestCase):
 
         self.assertEqual(layer_version.layer_arn, "arn:aws:lambda:region:account-id:layer:layer-name")
 
+    def test_layer_build_method_returned(self):
+        layer_version = LayerVersion(
+            "arn:aws:lambda:region:account-id:layer:layer-name:1", None, {"BuildMethod": "dummy_build_method"}
+        )
+
+        self.assertEqual(layer_version.build_method, "dummy_build_method")
+
     def test_codeuri_is_setable(self):
         layer_version = LayerVersion("arn:aws:lambda:region:account-id:layer:layer-name:1", None)
         layer_version.codeuri = "./some_value"

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -240,28 +240,28 @@ class TestSamFunctionProvider_init(TestCase):
     def setUp(self):
         self.parameter_overrides = {}
 
+    @patch.object(SamFunctionProvider, "get_template")
     @patch.object(SamFunctionProvider, "_extract_functions")
-    @patch("samcli.lib.providers.sam_function_provider.SamBaseProvider")
-    def test_must_extract_functions(self, SamBaseProviderMock, extract_mock):
+    def test_must_extract_functions(self, extract_mock, get_template_mock):
         extract_result = {"foo": "bar"}
         extract_mock.return_value = extract_result
 
         template = {"Resources": {"a": "b"}}
-        SamBaseProviderMock.get_template.return_value = template
+        get_template_mock.return_value = template
         provider = SamFunctionProvider(template, parameter_overrides=self.parameter_overrides)
 
-        extract_mock.assert_called_with({"a": "b"}, False)
-        SamBaseProviderMock.get_template.assert_called_with(template, self.parameter_overrides)
+        extract_mock.assert_called_with({"a": "b"})
+        get_template_mock.assert_called_with(template, self.parameter_overrides)
         self.assertEqual(provider.functions, extract_result)
 
+    @patch.object(SamFunctionProvider, "get_template")
     @patch.object(SamFunctionProvider, "_extract_functions")
-    @patch("samcli.lib.providers.sam_function_provider.SamBaseProvider")
-    def test_must_default_to_empty_resources(self, SamBaseProviderMock, extract_mock):
+    def test_must_default_to_empty_resources(self, extract_mock, get_template_mock):
         extract_result = {"foo": "bar"}
         extract_mock.return_value = extract_result
 
         template = {"a": "b"}  # Template does *not* have 'Resources' key
-        SamBaseProviderMock.get_template.return_value = template
+        get_template_mock.return_value = template
         provider = SamFunctionProvider(template, parameter_overrides=self.parameter_overrides)
 
         extract_mock.assert_called_with({}, False)  # Empty Resources value must be passed

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -250,7 +250,7 @@ class TestSamFunctionProvider_init(TestCase):
         get_template_mock.return_value = template
         provider = SamFunctionProvider(template, parameter_overrides=self.parameter_overrides)
 
-        extract_mock.assert_called_with({"a": "b"})
+        extract_mock.assert_called_with({"a": "b"}, False)
         get_template_mock.assert_called_with(template, self.parameter_overrides)
         self.assertEqual(provider.functions, extract_result)
 

--- a/tests/unit/commands/local/lib/test_sam_layer_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_layer_provider.py
@@ -13,7 +13,7 @@ class TestSamLayerProvider(TestCase):
                 "Type": "AWS::Serverless::LayerVersion",
                 "Properties": {
                     "LayerName": "Layer1",
-                    "ContentUri": "my_layer/",
+                    "ContentUri": "PyLayer/",
                     "CompatibleRuntimes": ["python3.8", "python3.6"],
                 },
                 "Metadata": {"BuildMethod": "python3.8"},
@@ -22,7 +22,7 @@ class TestSamLayerProvider(TestCase):
                 "Type": "AWS::Lambda::LayerVersion",
                 "Properties": {
                     "LayerName": "Layer1",
-                    "Content": "my_layer/",
+                    "Content": "PyLayer/",
                     "CompatibleRuntimes": ["python3.8", "python3.6"],
                 },
                 "Metadata": {"BuildMethod": "python3.8"},
@@ -31,7 +31,7 @@ class TestSamLayerProvider(TestCase):
                 "Type": "AWS::Serverless::LayerVersion",
                 "Properties": {
                     "LayerName": "Layer1",
-                    "ContentUri": "my_layer/",
+                    "ContentUri": "PyLayer/",
                     "CompatibleRuntimes": ["python3.8", "python3.6"],
                 },
             },
@@ -39,7 +39,7 @@ class TestSamLayerProvider(TestCase):
                 "Type": "AWS::Lambda::LayerVersion",
                 "Properties": {
                     "LayerName": "Layer1",
-                    "Content": "my_layer/",
+                    "Content": "PyLayer/",
                     "CompatibleRuntimes": ["python3.8", "python3.6"],
                 },
             },
@@ -77,10 +77,10 @@ class TestSamLayerProvider(TestCase):
 
     @parameterized.expand(
         [
-            ("ServerlessLayer", LayerVersion("ServerlessLayer", "my_layer/", {"BuildMethod": "python3.8"})),
-            ("LambdaLayer", LayerVersion("LambdaLayer", "my_layer/", {"BuildMethod": "python3.8"})),
-            ("ServerlessLayerNoBuild", LayerVersion("ServerlessLayerNoBuild", "my_layer/", None)),
-            ("LambdaLayerNoBuild", LayerVersion("LambdaLayerNoBuild", "my_layer/", None)),
+            ("ServerlessLayer", LayerVersion("ServerlessLayer", "PyLayer/", {"BuildMethod": "python3.8"})),
+            ("LambdaLayer", LayerVersion("LambdaLayer", "PyLayer/", {"BuildMethod": "python3.8"})),
+            ("ServerlessLayerNoBuild", LayerVersion("ServerlessLayerNoBuild", "PyLayer/", None)),
+            ("LambdaLayerNoBuild", LayerVersion("LambdaLayerNoBuild", "PyLayer/", None)),
             ("ServerlessLayerS3Content", LayerVersion("ServerlessLayerS3Content", ".", None)),
             ("LambdaLayerS3Content", LayerVersion("LambdaLayerS3Content", ".", None)),
         ]

--- a/tests/unit/commands/local/lib/test_sam_layer_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_layer_provider.py
@@ -1,0 +1,110 @@
+from unittest import TestCase
+
+from parameterized import parameterized
+
+from samcli.lib.providers.provider import LayerVersion
+from samcli.lib.providers.sam_layer_provider import SamLayerProvider
+
+
+class TestSamLayerProvider(TestCase):
+    TEMPLATE = {
+        "Resources": {
+            "ServerlessLayer": {
+                "Type": "AWS::Serverless::LayerVersion",
+                "Properties": {
+                    "LayerName": "Layer1",
+                    "ContentUri": "my_layer/",
+                    "CompatibleRuntimes": ["python3.8", "python3.6"],
+                },
+                "Metadata": {"BuildMethod": "python3.8"},
+            },
+            "LambdaLayer": {
+                "Type": "AWS::Lambda::LayerVersion",
+                "Properties": {
+                    "LayerName": "Layer1",
+                    "Content": "my_layer/",
+                    "CompatibleRuntimes": ["python3.8", "python3.6"],
+                },
+                "Metadata": {"BuildMethod": "python3.8"},
+            },
+            "ServerlessLayerNoBuild": {
+                "Type": "AWS::Serverless::LayerVersion",
+                "Properties": {
+                    "LayerName": "Layer1",
+                    "ContentUri": "my_layer/",
+                    "CompatibleRuntimes": ["python3.8", "python3.6"],
+                },
+            },
+            "LambdaLayerNoBuild": {
+                "Type": "AWS::Lambda::LayerVersion",
+                "Properties": {
+                    "LayerName": "Layer1",
+                    "Content": "my_layer/",
+                    "CompatibleRuntimes": ["python3.8", "python3.6"],
+                },
+            },
+            "ServerlessLayerS3Content": {
+                "Type": "AWS::Serverless::LayerVersion",
+                "Properties": {
+                    "LayerName": "Layer1",
+                    "ContentUri": "s3://dummy-bucket/my-layer.zip",
+                    "CompatibleRuntimes": ["python3.8", "python3.6"],
+                },
+            },
+            "LambdaLayerS3Content": {
+                "Type": "AWS::Lambda::LayerVersion",
+                "Properties": {
+                    "LayerName": "Layer1",
+                    "Content": {"S3Bucket": "dummy-bucket", "S3Key": "layer.zip"},
+                    "CompatibleRuntimes": ["python3.8", "python3.6"],
+                },
+            },
+            "SamFunc": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    # CodeUri is unsupported S3 location
+                    "CodeUri": "s3://bucket/key",
+                    "Runtime": "nodejs4.3",
+                    "Handler": "index.handler",
+                },
+            },
+        }
+    }
+
+    def setUp(self):
+        self.parameter_overrides = {}
+        self.provider = SamLayerProvider(self.TEMPLATE, parameter_overrides=self.parameter_overrides)
+
+    @parameterized.expand(
+        [
+            ("ServerlessLayer", LayerVersion("ServerlessLayer", "my_layer/", {"BuildMethod": "python3.8"})),
+            ("LambdaLayer", LayerVersion("LambdaLayer", "my_layer/", {"BuildMethod": "python3.8"})),
+            ("ServerlessLayerNoBuild", LayerVersion("ServerlessLayerNoBuild", "my_layer/", None)),
+            ("LambdaLayerNoBuild", LayerVersion("LambdaLayerNoBuild", "my_layer/", None)),
+            ("ServerlessLayerS3Content", LayerVersion("ServerlessLayerS3Content", ".", None)),
+            ("LambdaLayerS3Content", LayerVersion("LambdaLayerS3Content", ".", None)),
+        ]
+    )
+    def test_get_must_return_each_layer(self, name, expected_output):
+        actual = self.provider.get(name)
+        self.assertEqual(actual, expected_output)
+
+    def test_get_all_must_return_all_layers(self):
+        result = [f.arn for f in self.provider.get_all()]
+        expected = [
+            "ServerlessLayer",
+            "LambdaLayer",
+            "ServerlessLayerNoBuild",
+            "LambdaLayerNoBuild",
+            "ServerlessLayerS3Content",
+            "LambdaLayerS3Content",
+        ]
+
+        self.assertEqual(result, expected)
+
+    def test_provider_ignores_non_layer_resource(self):
+        self.assertIsNone(self.provider.get("SamFunc"))
+
+    def test_fails_with_empty_name(self):
+        with self.assertRaises(ValueError):
+            self.provider.get("")

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import Mock, call, patch
 from pathlib import Path
 
+from samcli.lib.providers.provider import ResourcesToBuildCollector
 from samcli.lib.build.app_builder import (
     ApplicationBuilder,
     UnsupportedBuilderLibraryVersionError,
@@ -23,9 +24,10 @@ class TestApplicationBuilder_build(TestCase):
         self.layer1 = Mock()
         self.layer2 = Mock()
 
-        self.builder = ApplicationBuilder(
-            {"Function": [self.func1, self.func2], "Layer": [self.layer1, self.layer2]}, "builddir", "basedir"
-        )
+        resources_to_build_collector = ResourcesToBuildCollector()
+        resources_to_build_collector.add_functions([self.func1, self.func2])
+        resources_to_build_collector.add_layers([self.layer1, self.layer2])
+        self.builder = ApplicationBuilder(resources_to_build_collector, "builddir", "basedir")
 
     def test_must_iterate_on_functions_and_layers(self):
         build_function_mock = Mock()

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -20,18 +20,30 @@ class TestApplicationBuilder_build(TestCase):
     def setUp(self):
         self.func1 = Mock()
         self.func2 = Mock()
-        self.builder = ApplicationBuilder([self.func1, self.func2], "builddir", "basedir")
+        self.layer1 = Mock()
+        self.layer2 = Mock()
 
-    def test_must_iterate_on_functions(self):
+        self.builder = ApplicationBuilder(
+            {"Function": [self.func1, self.func2], "Layer": [self.layer1, self.layer2]}, "builddir", "basedir"
+        )
+
+    def test_must_iterate_on_functions_and_layers(self):
         build_function_mock = Mock()
+        build_layer_mock = Mock()
 
         self.builder._build_function = build_function_mock
+        self.builder._build_layer = build_layer_mock
 
         result = self.builder.build()
 
         self.assertEqual(
             result,
-            {self.func1.name: build_function_mock.return_value, self.func2.name: build_function_mock.return_value},
+            {
+                self.func1.name: build_function_mock.return_value,
+                self.func2.name: build_function_mock.return_value,
+                self.layer1.name: build_layer_mock.return_value,
+                self.layer2.name: build_layer_mock.return_value,
+            },
         )
 
         build_function_mock.assert_has_calls(
@@ -79,7 +91,6 @@ class TestApplicationBuilder_update_template(TestCase):
         self.assertEqual(actual, expected_result)
 
     def test_must_skip_if_no_artifacts(self):
-
         built_artifacts = {}
         actual = self.builder.update_template(self.template_dict, "/foo/bar/template.txt", built_artifacts)
 


### PR DESCRIPTION
*Issue #, if available:*
Adding ability to build layers. If a user want to build a layer then simply add following:
```
Metadata:
  BuildMethod: <runtime>
```
to the layer in the template. This will pick the build method for that runtime (as it does for Lambda Function). After that Layer can be build by one of the following two commands:
`sam build`
`sam build LayerLogicalId`

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [x] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests *(WIP...)*
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
