### PR TITLE
fix: showcase prompts and messages on deploying - auth

### DIFF
--- a/samcli/commands/deploy/auth_utils.py
+++ b/samcli/commands/deploy/auth_utils.py
@@ -1,0 +1,140 @@
+"""
+Utilities for checking authorization of certain resource types
+"""
+import logging
+
+from samcli.commands.local.lib.swagger.reader import SwaggerReader
+from samcli.lib.providers.sam_function_provider import SamFunctionProvider
+
+LOG = logging.getLogger(__name__)
+
+
+def auth_per_resource(parameter_overrides, template_dict):
+    """
+    Check if authentication has been set for the function resources defined in the template that have `Api` Event type.
+
+    Parameters
+    ----------
+    parameter_overrides: dict
+        list of parameter overrides for the parameters defined in the template
+    template_dict: dict
+        Raw dictionary of the defined SAM template
+
+    Returns
+    -------
+
+    List of tuples per function resource that have the `Api` or `HttpApi` event types, that describes the resource name
+    and if authorization is required per resource.
+
+    """
+
+    _auth_per_resource = []
+
+    sam_functions = SamFunctionProvider(
+        template_dict=template_dict, parameter_overrides=parameter_overrides, ignore_code_extraction_warnings=True
+    )
+    for sam_function in sam_functions.get_all():
+        # Only check for auth if there are function events defined.
+        if sam_function.events:
+            _auth_resource_event(sam_functions, sam_function, _auth_per_resource)
+
+    return _auth_per_resource
+
+
+def _auth_resource_event(sam_functions, sam_function, auth_resource_list):
+    """
+
+    Parameters
+    ----------
+    sam_functions: List of all functions with intrinscis resolved.
+    sam_function: Current function which has all intrinsics resolved.
+    auth_resource_list: List of tuples with function name and auth. eg: [("Name", True)]
+
+    Returns
+    -------
+
+    """
+    for event in sam_function.events.values():
+        for event_type, identifier in [("Api", "RestApiId"), ("HttpApi", "ApiId")]:
+            if event.get("Type") == event_type:
+                # Is there any auth defined directly on the function resource?
+                # NOTE(sriram-mv): How do we check this in more detail?
+                # Currently just checking for presence of Auth, not the details.
+                # https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-apifunctionauth.html
+                # https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-httpapifunctionauth.html
+                if event.get("Properties", {}).get("Auth", False):
+                    auth_resource_list.append((sam_function.name, True))
+                # Is there any auth defined on the referred http api or serverless api through the `id` construct?
+                elif _auth_id(sam_functions.resources, event.get("Properties", {}), identifier):
+                    auth_resource_list.append((sam_function.name, True))
+                else:
+                    auth_resource_list.append((sam_function.name, False))
+
+
+def _auth_id(resources_dict, event_properties, identifier):
+    """
+
+    Parameters
+    ----------
+    resources_dict: dict
+        Resolved resources defined in the SAM Template
+    event_properties: dict
+        Properties of given event supplied to a function resource
+    identifier: str
+        Id: `ApiId` or `RestApiId`
+
+    Returns
+    -------
+    bool
+        Returns if the given identifier under the event properties maps to a resource and has authorization enabled.
+
+    """
+    resource_name = event_properties.get(identifier, "")
+    api_resource = resources_dict.get(resource_name, {})
+    return any(
+        [
+            api_resource.get("Properties", {}).get("Auth", False),
+            _auth_definition_body_and_uri(
+                definition_body=api_resource.get("Properties", {}).get("DefinitionBody", {}),
+                definition_uri=api_resource.get("Properties", {}).get("DefinitionUri", None),
+            ),
+        ]
+    )
+
+
+def _auth_definition_body_and_uri(definition_body, definition_uri):
+    """
+
+    Parameters
+    ----------
+    definition_body: dict
+        inline definition body defined in the template
+    definition_uri: string
+        Either an s3 url or a local path to a definition uri
+
+    Returns
+    -------
+    bool
+        Is security defined on the swagger or not?
+
+
+    """
+
+    reader = SwaggerReader(definition_body=definition_body, definition_uri=definition_uri)
+    swagger = reader.read()
+    _auths = []
+    if not swagger:
+        swagger = {}
+    # NOTE(sriram-mv): Authorization and Authentication is indicated by the `security` scheme.
+    # https://swagger.io/docs/specification/authentication/
+    for _, verb in swagger.get("paths", {}).items():
+        for _property in verb.values():
+            _auths.append(bool(_property.get("security", False)))
+
+    _auths.append(bool(swagger.get("security", False)))
+
+    if swagger:
+        LOG.debug("Auth checks done on swagger are not exhaustive!")
+
+    # This is not an exhaustive check, but to check if there is some form of security setup.
+    return any(_auths)

--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -10,9 +10,10 @@ from click import prompt
 from click import confirm
 
 from samcli.commands._utils.options import _space_separated_list_func_type
-from samcli.commands._utils.template import get_template_parameters
+from samcli.commands._utils.template import get_template_parameters, get_template_data
 from samcli.commands.deploy.exceptions import GuidedDeployFailedError
 from samcli.commands.deploy.guided_config import GuidedConfig
+from samcli.commands.deploy.auth_utils import auth_per_resource
 from samcli.lib.bootstrap.bootstrap import manage_stack
 from samcli.lib.utils.colors import Colored
 
@@ -98,6 +99,8 @@ class GuidedContext:
                 type=FuncParamType(func=_space_separated_list_func_type),
             )
 
+        self.prompt_authorization(input_parameter_overrides)
+
         save_to_config = confirm(f"\t{self.start_bold}Save arguments to samconfig.toml{self.end_bold}", default=True)
 
         s3_bucket = manage_stack(profile=self.profile, region=region)
@@ -113,6 +116,18 @@ class GuidedContext:
         self._parameter_overrides = input_parameter_overrides if input_parameter_overrides else self.parameter_overrides
         self.save_to_config = save_to_config
         self.confirm_changeset = confirm_changeset
+
+    def prompt_authorization(self, parameter_overrides):
+        auth_required_per_resource = auth_per_resource(parameter_overrides, get_template_data(self.template_file))
+
+        for resource, authorization_required in auth_required_per_resource:
+            if not authorization_required:
+                auth_confirm = confirm(
+                    f"\t{self.start_bold}{resource} may not have authorization defined, Is this okay?{self.end_bold}",
+                    default=False,
+                )
+                if not auth_confirm:
+                    raise GuidedDeployFailedError(msg="Security Constraints Not Satisfied!")
 
     def prompt_parameters(self, parameter_override_keys, start_bold, end_bold):
         _prompted_param_overrides = {}

--- a/samcli/lib/providers/provider.py
+++ b/samcli/lib/providers/provider.py
@@ -33,6 +33,8 @@ Function = namedtuple(
         "rolearn",
         # List of Layers
         "layers",
+        # Event
+        "events",
     ],
 )
 

--- a/tests/integration/deploy/test_deploy_command.py
+++ b/tests/integration/deploy/test_deploy_command.py
@@ -455,7 +455,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\n\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\n\n\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack
@@ -475,7 +475,7 @@ class TestDeploy(PackageIntegBase, DeployIntegBase):
         deploy_command_list = self.get_deploy_command_list(template_file=template_path, guided=True)
 
         deploy_process_execute = run_command_with_input(
-            deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n".format(stack_name).encode()
+            deploy_command_list, "{}\n\nSuppliedParameter\n\n\n\n\n".format(stack_name).encode()
         )
 
         # Deploy should succeed with a managed stack

--- a/tests/unit/commands/deploy/test_auth_utils.py
+++ b/tests/unit/commands/deploy/test_auth_utils.py
@@ -1,0 +1,118 @@
+from collections import OrderedDict
+
+from unittest import TestCase
+
+from samcli.commands.deploy.auth_utils import auth_per_resource
+
+
+class TestAuthUtils(TestCase):
+    def setUp(self):
+        self.template_dict = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Transform": "AWS::Serverless-2016-10-31",
+            "Description": "\nSample SAM Template for Tests\n",
+            "Globals": OrderedDict([("Function", OrderedDict([("Timeout", 3)]))]),
+            "Resources": OrderedDict(
+                [
+                    (
+                        "HelloWorldFunction",
+                        OrderedDict(
+                            [
+                                ("Type", "AWS::Serverless::Function"),
+                                (
+                                    "Properties",
+                                    OrderedDict(
+                                        [
+                                            ("CodeUri", "HelloWorldFunction"),
+                                            ("Handler", "app.lambda_handler"),
+                                            ("Runtime", "python3.7"),
+                                            (
+                                                "Events",
+                                                OrderedDict(
+                                                    [
+                                                        (
+                                                            "HelloWorld",
+                                                            OrderedDict(
+                                                                [
+                                                                    ("Type", "Api"),
+                                                                    (
+                                                                        "Properties",
+                                                                        OrderedDict(
+                                                                            [("Path", "/hello"), ("Method", "get")]
+                                                                        ),
+                                                                    ),
+                                                                ]
+                                                            ),
+                                                        )
+                                                    ]
+                                                ),
+                                            ),
+                                        ]
+                                    ),
+                                ),
+                            ]
+                        ),
+                    )
+                ]
+            ),
+        }
+
+    def test_auth_per_resource_no_auth(self):
+        _auth_per_resource = auth_per_resource({}, self.template_dict)
+        self.assertEqual(_auth_per_resource, [("HelloWorldFunction", False)])
+
+    def test_auth_per_resource_auth_on_event_properties(self):
+        event_properties = self.template_dict["Resources"]["HelloWorldFunction"]["Properties"]["Events"]["HelloWorld"][
+            "Properties"
+        ]
+        # setup authorizer and auth explicitly on the event properties.
+        event_properties["Auth"] = {"ApiKeyRequired": True, "Authorizer": None}
+        self.template_dict["Resources"]["HelloWorldFunction"]["Properties"]["Events"]["HelloWorld"][
+            "Properties"
+        ] = event_properties
+        _auth_per_resource = auth_per_resource({}, self.template_dict)
+        self.assertEqual(_auth_per_resource, [("HelloWorldFunction", True)])
+
+    def test_auth_per_resource_defined_on_api_resource(self):
+        self.template_dict["Resources"]["HelloWorldApi"] = OrderedDict(
+            [
+                ("Type", "AWS::Serverless::Api"),
+                ("Properties", OrderedDict([("StageName", "Prod"), ("Auth", OrderedDict([("ApiKeyRequired", True)]))])),
+            ]
+        )
+        # setup the lambda function with a restapiId which has Auth defined.
+        self.template_dict["Resources"]["HelloWorldFunction"]["Properties"]["Events"]["HelloWorld"]["Properties"][
+            "RestApiId"
+        ] = {"Ref": "HelloWorldApi"}
+        _auth_per_resource = auth_per_resource({}, self.template_dict)
+        self.assertEqual(_auth_per_resource, [("HelloWorldFunction", True)])
+
+    def test_auth_supplied_via_definition_body_uri(self):
+        self.template_dict["Resources"]["HelloWorldApi"] = OrderedDict(
+            [
+                ("Type", "AWS::Serverless::Api"),
+                (
+                    "Properties",
+                    OrderedDict(
+                        [
+                            ("StageName", "Prod"),
+                            (
+                                "DefinitionBody",
+                                {
+                                    "swagger": "2.0",
+                                    "info": {"version": "1.0", "title": "local"},
+                                    "paths": {"/hello": {"get": {"security": ["OAuth2"]}}},
+                                },
+                            ),
+                        ]
+                    ),
+                ),
+            ]
+        )
+        # setup the lambda function with a restapiId which has definitionBody defined with auth on the route.
+        self.template_dict["Resources"]["HelloWorldFunction"]["Properties"]["Events"]["HelloWorld"]["Properties"][
+            "RestApiId"
+        ] = {"Ref": "HelloWorldApi"}
+        _auth_per_resource = auth_per_resource({}, self.template_dict)
+
+        self.assertEqual(_auth_per_resource, [("HelloWorldFunction", True)])

--- a/tests/unit/commands/deploy/test_deploy_context.py
+++ b/tests/unit/commands/deploy/test_deploy_context.py
@@ -107,7 +107,6 @@ class TestSamDeployCommand(TestCase):
             self.assertEqual(self.deploy_command_context.deployer.create_and_wait_for_changeset.call_count, 1)
             self.assertEqual(self.deploy_command_context.deployer.execute_changeset.call_count, 1)
             self.assertEqual(self.deploy_command_context.deployer.wait_for_execute.call_count, 1)
-            self.assertEqual(self.deploy_command_context.deployer.get_stack_outputs.call_count, 1)
 
     @patch("boto3.Session")
     @patch.object(Deployer, "create_and_wait_for_changeset", MagicMock(return_value=({"Id": "test"}, "CREATE")))
@@ -126,10 +125,15 @@ class TestSamDeployCommand(TestCase):
             self.assertEqual(self.deploy_command_context.deployer.wait_for_execute.call_count, 0)
 
     @patch("boto3.Session")
+    @patch("samcli.commands.deploy.deploy_context.auth_per_resource")
+    @patch("samcli.commands.deploy.deploy_context.get_template_data")
     @patch.object(Deployer, "create_and_wait_for_changeset", MagicMock(return_value=({"Id": "test"}, "CREATE")))
     @patch.object(Deployer, "execute_changeset", MagicMock())
     @patch.object(Deployer, "wait_for_execute", MagicMock())
-    def test_template_valid_execute_changeset(self, patched_boto):
+    def test_template_valid_execute_changeset_with_parameters(
+        self, patched_template_data, patched_auth_required, patched_boto
+    ):
+        patched_auth_required.return_value = [("HelloWorldFunction", False)]
         with tempfile.NamedTemporaryFile(delete=False) as template_file:
             template_file.write(b'{"Parameters": {"a":"b","c":"d"}}')
             template_file.flush()

--- a/tests/unit/commands/deploy/test_guided_context.py
+++ b/tests/unit/commands/deploy/test_guided_context.py
@@ -20,8 +20,13 @@ class TestGuidedContext(TestCase):
     @patch("samcli.commands.deploy.guided_context.prompt")
     @patch("samcli.commands.deploy.guided_context.confirm")
     @patch("samcli.commands.deploy.guided_context.manage_stack")
-    def test_guided_prompts_check_defaults(self, patched_manage_stack, patched_confirm, patched_prompt):
+    @patch("samcli.commands.deploy.guided_context.auth_per_resource")
+    @patch("samcli.commands.deploy.guided_context.get_template_data")
+    def test_guided_prompts_check_defaults_non_public_resources(
+        self, patched_get_template_data, patchedauth_per_resource, patched_manage_stack, patched_confirm, patched_prompt
+    ):
         # Series of inputs to confirmations so that full range of questions are asked.
+        patchedauth_per_resource.return_value = [("HelloWorldFunction", True)]
         patched_confirm.side_effect = [True, False, "", True]
         patched_manage_stack.return_value = "managed_s3_stack"
         self.gc.guided_prompts(parameter_override_keys=None)
@@ -29,6 +34,39 @@ class TestGuidedContext(TestCase):
         expected_confirmation_calls = [
             call(f"\t{self.gc.start_bold}Confirm changes before deploy{self.gc.end_bold}", default=True),
             call(f"\t{self.gc.start_bold}Allow SAM CLI IAM role creation{self.gc.end_bold}", default=True),
+            call(f"\t{self.gc.start_bold}Save arguments to samconfig.toml{self.gc.end_bold}", default=True),
+        ]
+        self.assertEqual(expected_confirmation_calls, patched_confirm.call_args_list)
+
+        # Now to check for all the defaults on prompts.
+        expected_prompt_calls = [
+            call(f"\t{self.gc.start_bold}Stack Name{self.gc.end_bold}", default="test", type=click.STRING),
+            call(f"\t{self.gc.start_bold}AWS Region{self.gc.end_bold}", default="region", type=click.STRING),
+            call(f"\t{self.gc.start_bold}Capabilities{self.gc.end_bold}", default=["CAPABILITY_IAM"], type=ANY),
+        ]
+        self.assertEqual(expected_prompt_calls, patched_prompt.call_args_list)
+
+    @patch("samcli.commands.deploy.guided_context.prompt")
+    @patch("samcli.commands.deploy.guided_context.confirm")
+    @patch("samcli.commands.deploy.guided_context.manage_stack")
+    @patch("samcli.commands.deploy.guided_context.auth_per_resource")
+    @patch("samcli.commands.deploy.guided_context.get_template_data")
+    def test_guided_prompts_check_defaults_public_resources(
+        self, patched_get_template_data, patchedauth_per_resource, patched_manage_stack, patched_confirm, patched_prompt
+    ):
+        # Series of inputs to confirmations so that full range of questions are asked.
+        patchedauth_per_resource.return_value = [("HelloWorldFunction", False)]
+        patched_confirm.side_effect = [True, False, True, False, ""]
+        patched_manage_stack.return_value = "managed_s3_stack"
+        self.gc.guided_prompts(parameter_override_keys=None)
+        # Now to check for all the defaults on confirmations.
+        expected_confirmation_calls = [
+            call(f"\t{self.gc.start_bold}Confirm changes before deploy{self.gc.end_bold}", default=True),
+            call(f"\t{self.gc.start_bold}Allow SAM CLI IAM role creation{self.gc.end_bold}", default=True),
+            call(
+                f"\t{self.gc.start_bold}HelloWorldFunction may not have authorization defined, Is this okay?{self.gc.end_bold}",
+                default=False,
+            ),
             call(f"\t{self.gc.start_bold}Save arguments to samconfig.toml{self.gc.end_bold}", default=True),
         ]
         self.assertEqual(expected_confirmation_calls, patched_confirm.call_args_list)

--- a/tests/unit/commands/local/lib/test_local_lambda.py
+++ b/tests/unit/commands/local/lib/test_local_lambda.py
@@ -215,6 +215,7 @@ class TestLocalLambda_make_env_vars(TestCase):
             environment=self.environ,
             rolearn=None,
             layers=[],
+            events=None,
         )
 
         self.local_lambda.env_vars_values = env_vars_values
@@ -255,6 +256,7 @@ class TestLocalLambda_make_env_vars(TestCase):
             environment=self.environ,
             rolearn=None,
             layers=[],
+            events=None,
         )
 
         self.local_lambda.env_vars_values = env_vars_values
@@ -286,6 +288,7 @@ class TestLocalLambda_make_env_vars(TestCase):
             environment=environment_variable,
             rolearn=None,
             layers=[],
+            events=None,
         )
 
         self.local_lambda.env_vars_values = {}
@@ -347,6 +350,7 @@ class TestLocalLambda_get_invoke_config(TestCase):
             environment=None,
             rolearn=None,
             layers=layers,
+            events=None,
         )
 
         config = "someconfig"
@@ -392,6 +396,7 @@ class TestLocalLambda_get_invoke_config(TestCase):
             environment=None,
             rolearn=None,
             layers=[],
+            events=None,
         )
 
         config = "someconfig"

--- a/tests/unit/commands/local/lib/test_sam_function_provider.py
+++ b/tests/unit/commands/local/lib/test_sam_function_provider.py
@@ -98,6 +98,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
             (
@@ -113,6 +114,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
             (
@@ -128,6 +130,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
             (
@@ -143,6 +146,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
             (
@@ -158,6 +162,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
             (
@@ -173,6 +178,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
             (
@@ -188,6 +194,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
             (
@@ -203,6 +210,7 @@ class TestSamFunctionProviderEndToEnd(TestCase):
                     environment=None,
                     rolearn=None,
                     layers=[],
+                    events=None,
                 ),
             ),
         ]
@@ -242,7 +250,7 @@ class TestSamFunctionProvider_init(TestCase):
         SamBaseProviderMock.get_template.return_value = template
         provider = SamFunctionProvider(template, parameter_overrides=self.parameter_overrides)
 
-        extract_mock.assert_called_with({"a": "b"})
+        extract_mock.assert_called_with({"a": "b"}, False)
         SamBaseProviderMock.get_template.assert_called_with(template, self.parameter_overrides)
         self.assertEqual(provider.functions, extract_result)
 
@@ -256,7 +264,7 @@ class TestSamFunctionProvider_init(TestCase):
         SamBaseProviderMock.get_template.return_value = template
         provider = SamFunctionProvider(template, parameter_overrides=self.parameter_overrides)
 
-        extract_mock.assert_called_with({})  # Empty Resources value must be passed
+        extract_mock.assert_called_with({}, False)  # Empty Resources value must be passed
         self.assertEqual(provider.functions, extract_result)
         self.assertEqual(provider.resources, {})
 
@@ -273,7 +281,7 @@ class TestSamFunctionProvider_extract_functions(TestCase):
 
         result = SamFunctionProvider._extract_functions(resources)
         self.assertEqual(expected, result)
-        convert_mock.assert_called_with("Func1", {"a": "b"}, [])
+        convert_mock.assert_called_with("Func1", {"a": "b"}, [], ignore_code_extraction_warnings=False)
 
     @patch.object(SamFunctionProvider, "_convert_sam_function_resource")
     def test_must_work_with_no_properties(self, convert_mock):
@@ -291,7 +299,7 @@ class TestSamFunctionProvider_extract_functions(TestCase):
 
         result = SamFunctionProvider._extract_functions(resources)
         self.assertEqual(expected, result)
-        convert_mock.assert_called_with("Func1", {}, [])
+        convert_mock.assert_called_with("Func1", {}, [], ignore_code_extraction_warnings=False)
 
     @patch.object(SamFunctionProvider, "_convert_lambda_function_resource")
     def test_must_work_for_lambda_function(self, convert_mock):
@@ -341,6 +349,7 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
             environment="myenvironment",
             rolearn="myrole",
             layers=["Layer1", "Layer2"],
+            events=None,
         )
 
         result = SamFunctionProvider._convert_sam_function_resource(name, properties, ["Layer1", "Layer2"])
@@ -363,6 +372,7 @@ class TestSamFunctionProvider_convert_sam_function_resource(TestCase):
             environment=None,
             rolearn=None,
             layers=[],
+            events=None,
         )
 
         result = SamFunctionProvider._convert_sam_function_resource(name, properties, [])
@@ -425,6 +435,7 @@ class TestSamFunctionProvider_convert_lambda_function_resource(TestCase):
             environment="myenvironment",
             rolearn="myrole",
             layers=["Layer1", "Layer2"],
+            events=None,
         )
 
         result = SamFunctionProvider._convert_lambda_function_resource(name, properties, ["Layer1", "Layer2"])
@@ -447,6 +458,7 @@ class TestSamFunctionProvider_convert_lambda_function_resource(TestCase):
             environment=None,
             rolearn=None,
             layers=[],
+            events=None,
         )
 
         result = SamFunctionProvider._convert_lambda_function_resource(name, properties, [])
@@ -544,6 +556,7 @@ class TestSamFunctionProvider_get(TestCase):
             environment=None,
             rolearn=None,
             layers=[],
+            events=None,
         )
         provider.functions = {"func1": function}
 


### PR DESCRIPTION
Why is this change necessary?

* If Auth is determined to be not present with a degree of possibility,
a prompt is shown to ask the user if they are explicitly okay with such
a configuration.

How does it address the issue?

* Showcase to the user that there may be a potential issue with how the
template resources have been configured.

What side effects does this change have?

* Extra prompt on guided mode.

*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
