### PR TITLE
chore: Force producing reproducible-linux.txt from python3.7 env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ black-check:
 pr: init dev black-check
 
 update-reproducible-reqs:
-	python3 -m venv venv-update-reproducible-requirements
+	python3.7 -m venv venv-update-reproducible-requirements
 	venv-update-reproducible-requirements/bin/pip install --upgrade pip-tools pip
 	venv-update-reproducible-requirements/bin/pip install -r requirements/base.txt
 	venv-update-reproducible-requirements/bin/pip-compile --generate-hashes --allow-unsafe -o requirements/reproducible-linux.txt


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Why is this change necessary?*
We need to produce the reproducible-linux.txt file from the same python version otherwise things will conflict. We standardized on python3.7 to match our MSI and brew bottles.

*How does it address the issue?*

*What side effects does this change have?*
n/a

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
n/a

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
