### PR TITLE
Revert "fix: Force strings to be outputted when string starts with 0 …

### DIFF
--- a/samcli/yamlhelper.py
+++ b/samcli/yamlhelper.py
@@ -23,30 +23,6 @@ from botocore.compat import OrderedDict
 import yaml
 from yaml.resolver import ScalarNode, SequenceNode
 
-TAG_STR = "tag:yaml.org,2002:str"
-
-
-def string_representer(dumper, value):
-    """
-    Customer Yaml representer that will force the scalar to be quoted in a yaml.dump
-    if it scalar starts with a 0. This is needed to keep account ids a string instead
-    of turning into on int because yaml thinks it an octal.
-
-    Parameters
-    ----------
-    dumper yaml.dumper
-    value str
-        Value in template to resolve
-
-    Returns
-    -------
-
-    """
-    if value.startswith("0"):
-        return dumper.represent_scalar(TAG_STR, value, style="'")
-
-    return dumper.represent_scalar(TAG_STR, value)
-
 
 def intrinsics_multi_constructor(loader, tag_prefix, node):
     """
@@ -95,9 +71,8 @@ def yaml_dump(dict_to_dump):
     :param dict_to_dump:
     :return:
     """
-    CfnDumper.add_representer(OrderedDict, _dict_representer)
-    CfnDumper.add_representer(str, string_representer)
-    return yaml.dump(dict_to_dump, default_flow_style=False, Dumper=CfnDumper)
+    FlattenAliasDumper.add_representer(OrderedDict, _dict_representer)
+    return yaml.dump(dict_to_dump, default_flow_style=False, Dumper=FlattenAliasDumper)
 
 
 def _dict_constructor(loader, node):
@@ -119,6 +94,6 @@ def yaml_parse(yamlstr):
         return yaml.safe_load(yamlstr)
 
 
-class CfnDumper(yaml.SafeDumper):
+class FlattenAliasDumper(yaml.SafeDumper):
     def ignore_aliases(self, data):
         return True

--- a/tests/unit/test_yamlhelper.py
+++ b/tests/unit/test_yamlhelper.py
@@ -26,7 +26,6 @@ class TestYaml(TestCase):
         Key4: !SomeTag {"a": "1"}
         Key5: !GetAtt OneMore.Outputs.Arn
         Key6: !Condition OtherCondition
-        Key7: "012345678"
     """
 
     parsed_yaml_dict = {
@@ -37,7 +36,6 @@ class TestYaml(TestCase):
             "Key4": {"Fn::SomeTag": {"a": "1"}},
             "Key5": {"Fn::GetAtt": ["OneMore", "Outputs.Arn"]},
             "Key6": {"Condition": "OtherCondition"},
-            "Key7": "012345678",
         }
     }
 
@@ -49,15 +47,6 @@ class TestYaml(TestCase):
         formatted_str = yaml_dump(output)
         output_again = yaml_parse(formatted_str)
         self.assertEqual(output, output_again)
-
-    def test_yaml_dumps(self):
-        input_yaml_dict = {"Resource": {"Key7": "012345678"}}
-
-        expected_output = "Resource:\n  Key7: '012345678'\n"
-
-        output = yaml_dump(input_yaml_dict)
-
-        self.assertEqual(output, expected_output)
 
     def test_yaml_getatt(self):
         # This is an invalid syntax for !GetAtt. But make sure the code does


### PR DESCRIPTION
…(#1965)"

This reverts commit 4a13f0439720bd8b517e8af2757cedb91ba1750f.

*Issue #, if available:*

Reverting this commit as it is breaking our canaries.

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
