### PR TITLE
bug: security prompt - instrinsics in definition body

### DIFF
--- a/samcli/commands/deploy/auth_utils.py
+++ b/samcli/commands/deploy/auth_utils.py
@@ -129,7 +129,9 @@ def _auth_definition_body_and_uri(definition_body, definition_uri):
     # https://swagger.io/docs/specification/authentication/
     for _, verb in swagger.get("paths", {}).items():
         for _property in verb.values():
-            _auths.append(bool(_property.get("security", False)))
+            # If there are instrinsics in play, they may not be resolved yet.
+            if isinstance(_property, dict):
+                _auths.append(bool(_property.get("security", False)))
 
     _auths.append(bool(swagger.get("security", False)))
 


### PR DESCRIPTION
Why is this change necessary?

* Instrinsics in defintion body are not resolved when checking for
security scheme, making it hard to do checks. So only do the checks if
the instrinsics in the paths are already resolved.

How does it address the issue?

* If defintion body now has instrinsics, it does not crash the sam cli
process.

*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
