### PR TITLE
Skip non-verb items when parsing swagger security

### DIFF
--- a/samcli/commands/deploy/auth_utils.py
+++ b/samcli/commands/deploy/auth_utils.py
@@ -129,7 +129,11 @@ def _auth_definition_body_and_uri(definition_body, definition_uri):
     # https://swagger.io/docs/specification/authentication/
     for _, verb in swagger.get("paths", {}).items():
         for _property in verb.values():
-            _auths.append(bool(_property.get("security", False)))
+            # A path object may have entries that are not verbs.
+            # We should first check whether _property is a dict
+            # https://swagger.io/specification/#path-item-object
+            if isinstance(_property, dict):
+                _auths.append(bool(_property.get("security", False)))
 
     _auths.append(bool(swagger.get("security", False)))
 


### PR DESCRIPTION
*Issue #, if available:*

No issue found.

*Why is this change necessary?*

The OpenAPI Specification states that a [Path Item Object](https://swagger.io/specification/#path-item-object) may have entries that are not verbs.

When parsing an API description with such features, SAM CLI fails with the following error:

>   File "/home/linuxbrew/.linuxbrew/Cellar/aws-sam-cli/0.49.0/libexec/lib/python3.7/site-packages/samcli/commands/deploy/auth_utils.py", line 132, in _auth_definition_body_and_uri
>    _auths.append(bool(_property.get("security", False)))
>AttributeError: 'list' object has no attribute 'get'

I was using a "parameters" item, which is a list, and [the code](https://github.com/awslabs/aws-sam-cli/blob/23212ef827a105d23339712adc9422c6cc55e12c/samcli/commands/deploy/auth_utils.py#L132) expects a dict.

*How does it address the issue?*

Given the current specification, only verbs are objects, so only verbs are parsed as a dict. It should be enough to check the variable type before trying to get the desired property.

*What side effects does this change have?*

None.

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

No changes.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
