### PR TITLE
Remove --location /path/to/template/folder docstr

### DIFF
--- a/samcli/commands/init/__init__.py
+++ b/samcli/commands/init/__init__.py
@@ -48,10 +48,6 @@ Common usage:
     $ sam init --location /path/to/template.zip
     \b
     $ sam init --location https://example.com/path/to/template.zip
-    \b
-    Initializes a new SAM project using custom template in a local path
-    \b
-    $ sam init --location /path/to/template/folder
 """
 
 


### PR DESCRIPTION
the `--location /path/to/template/folder` option listed in the doc string for the `sam init` command isn't supported by SAM, and https://github.com/awslabs/aws-sam-cli/blob/develop/samcli/lib/init/arbitrary_project.py#L41 indicates that it's explicitly not supported. 

This fix just removes this option from the doc string.

*Why is this change necessary?*

The doc string is misleading. You cannot pass a local path to the `--location` flag.

*How does it address the issue?*

This PR removes this option from `init`'s doc string.

*What side effects does this change have?*

None.

*Did you change a dependency in `requirements/base.txt`?*

No
