### PR TITLE
bug: Static flask server won't cache response anymore

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -110,6 +110,9 @@ class LocalApigwService(BaseLocalService):
             static_folder=self.static_dir,  # Serve static files from this directory
         )
 
+        # Prevent the dev server from emitting headers that will make the browser cache response by default
+        self._app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0
+
         # This will normalize all endpoints and strip any trailing '/'
         self._app.url_map.strict_slashes = False
 

--- a/tests/unit/local/apigw/test_local_apigw_service.py
+++ b/tests/unit/local/apigw/test_local_apigw_service.py
@@ -149,6 +149,7 @@ class TestApiGatewayService(TestCase):
     @patch("samcli.local.apigw.local_apigw_service.Flask")
     def test_create_creates_flask_app_with_url_rules(self, flask):
         app_mock = Mock()
+        app_mock.config = {}
         flask.return_value = app_mock
 
         self.service._construct_error_handling = Mock()


### PR DESCRIPTION
*Issue #, if available:*
#2037

*Why is this change necessary?*
Developing on a local server that caches static file is error-prone and confusing, the best is not caching static assets. 

*How does it address the issue?*
Configuring Flask not to emit caching header

*What side effects does this change have?*
When running `sam local start-api` and requesting a static file caching headers won't be emitted anymore.

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
no

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ x ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ x ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
