### PR TITLE
fix: guided deploy doesn't update default capabilities that is provid…

### DIFF
--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -69,7 +69,7 @@ class GuidedContext:
     def guided_prompts(self, parameter_override_keys):
         default_stack_name = self.stack_name or "sam-app"
         default_region = self.region or "us-east-1"
-        default_capabilities = ("CAPABILITY_IAM",)
+        default_capabilities = self.capabilities[0] or ("CAPABILITY_IAM",)
         input_capabilities = None
 
         click.echo(

--- a/tests/unit/commands/deploy/test_guided_context.py
+++ b/tests/unit/commands/deploy/test_guided_context.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch, call, ANY
+from parameterized import parameterized, param
 
 import click
 
@@ -76,5 +77,47 @@ class TestGuidedContext(TestCase):
             call(f"\t{self.gc.start_bold}Stack Name{self.gc.end_bold}", default="test", type=click.STRING),
             call(f"\t{self.gc.start_bold}AWS Region{self.gc.end_bold}", default="region", type=click.STRING),
             call(f"\t{self.gc.start_bold}Capabilities{self.gc.end_bold}", default=["CAPABILITY_IAM"], type=ANY),
+        ]
+        self.assertEqual(expected_prompt_calls, patched_prompt.call_args_list)
+
+    @parameterized.expand(
+        [
+            param((("CAPABILITY_IAM",),)),
+            param((("CAPABILITY_AUTO_EXPAND",),)),
+            param((("CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM",),)),
+        ]
+    )
+    @patch("samcli.commands.deploy.guided_context.prompt")
+    @patch("samcli.commands.deploy.guided_context.confirm")
+    @patch("samcli.commands.deploy.guided_context.manage_stack")
+    @patch("samcli.commands.deploy.guided_context.auth_per_resource")
+    @patch("samcli.commands.deploy.guided_context.get_template_data")
+    def test_guided_prompts_with_given_capabilities(
+        self,
+        given_capabilities,
+        patched_get_template_data,
+        patchedauth_per_resource,
+        patched_manage_stack,
+        patched_confirm,
+        patched_prompt,
+    ):
+        self.gc.capabilities = given_capabilities
+        # Series of inputs to confirmations so that full range of questions are asked.
+        patched_confirm.side_effect = [True, False, "", True]
+        self.gc.guided_prompts(parameter_override_keys=None)
+        # Now to check for all the defaults on confirmations.
+        expected_confirmation_calls = [
+            call(f"\t{self.gc.start_bold}Confirm changes before deploy{self.gc.end_bold}", default=True),
+            call(f"\t{self.gc.start_bold}Allow SAM CLI IAM role creation{self.gc.end_bold}", default=True),
+            call(f"\t{self.gc.start_bold}Save arguments to samconfig.toml{self.gc.end_bold}", default=True),
+        ]
+        self.assertEqual(expected_confirmation_calls, patched_confirm.call_args_list)
+
+        # Now to check for all the defaults on prompts.
+        expected_capabilities = list(given_capabilities[0])
+        expected_prompt_calls = [
+            call(f"\t{self.gc.start_bold}Stack Name{self.gc.end_bold}", default="test", type=click.STRING),
+            call(f"\t{self.gc.start_bold}AWS Region{self.gc.end_bold}", default="region", type=click.STRING),
+            call(f"\t{self.gc.start_bold}Capabilities{self.gc.end_bold}", default=expected_capabilities, type=ANY),
         ]
         self.assertEqual(expected_prompt_calls, patched_prompt.call_args_list)


### PR DESCRIPTION
…ed via --capabilites option as CLI argument

*Issue #1955

*Why is this change necessary?*

As explained in the issue above, running guided deploy with --capabilities parameter doesn't respect the given parameters. Where it should update the default capabilities with the ones that is given by CLI parameter.

*How does it address the issue?*

In the guided context, default capabilities were assigned statically to `CAPABILITY_IAM`. With this commit it is changed to assign the default capabilities that is read from the CLI or from samconfig.toml file


*Checklist:*

- [x] Write unit tests
- [x] `make pr` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
