### PR TITLE
fix: Building layers before functions

### DIFF
--- a/samcli/lib/build/app_builder.py
+++ b/samcli/lib/build/app_builder.py
@@ -108,13 +108,6 @@ class ApplicationBuilder:
 
         result = {}
 
-        for function in self._resources_to_build.functions:
-            LOG.info("Building function '%s'", function.name)
-            result[function.name] = self._build_function(function.name,
-                                                         function.codeuri,
-                                                         function.runtime,
-                                                         function.handler,
-                                                         function.metadata)
         for layer in self._resources_to_build.layers:
             LOG.info("Building layer '%s'", layer.name)
             if layer.build_method is None:
@@ -124,6 +117,14 @@ class ApplicationBuilder:
                                                    layer.codeuri,
                                                    layer.build_method,
                                                    layer.compatible_runtimes)
+
+        for function in self._resources_to_build.functions:
+            LOG.info("Building function '%s'", function.name)
+            result[function.name] = self._build_function(function.name,
+                                                         function.codeuri,
+                                                         function.runtime,
+                                                         function.handler,
+                                                         function.metadata)
 
         return result
 

--- a/tests/unit/lib/build_module/test_app_builder.py
+++ b/tests/unit/lib/build_module/test_app_builder.py
@@ -41,10 +41,10 @@ class TestApplicationBuilder_build(TestCase):
         self.assertEqual(
             result,
             {
-                self.func1.name: build_function_mock.return_value,
-                self.func2.name: build_function_mock.return_value,
                 self.layer1.name: build_layer_mock.return_value,
                 self.layer2.name: build_layer_mock.return_value,
+                self.func1.name: build_function_mock.return_value,
+                self.func2.name: build_function_mock.return_value,
             },
         )
 
@@ -55,6 +55,33 @@ class TestApplicationBuilder_build(TestCase):
             ],
             any_order=False,
         )
+
+        build_layer_mock.assert_has_calls(
+            [
+                call(self.layer1.name, self.layer1.codeuri, self.layer1.build_method, self.layer1.compatible_runtimes),
+                call(self.layer2.name, self.layer2.codeuri, self.layer2.build_method, self.layer2.compatible_runtimes),
+            ],
+            any_order=False,
+        )
+
+    def test_must_build_layers_before_functions(self):
+        build_function_mock = Mock()
+        build_layer_mock = Mock()
+
+        expected_order = {
+            self.layer1.name: build_layer_mock.return_value,
+            self.layer2.name: build_layer_mock.return_value,
+            self.func1.name: build_function_mock.return_value,
+            self.func2.name: build_function_mock.return_value,
+        }
+
+        self.builder._build_function = build_function_mock
+        self.builder._build_layer = build_layer_mock
+
+        result = self.builder.build()
+
+        for i, j in zip(result.items(), expected_order.items()):
+            self.assertEqual(i, j)
 
 
 class TestApplicationBuilderForLayerBuild(TestCase):


### PR DESCRIPTION
*Issue #, if available:*
Fix #2033 

*Why is this change necessary?*
Building layers before functions is required for compiled languages like Java, since the dependency (layer) should be available in local maven repository to be used on `pom.xml`.

*How does it address the issue?*
It changes the build order.

*What side effects does this change have?*
I can't see any.

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
NA

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [X] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [X] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
