### PR TITLE
fix: Updating CFN polling frequency as per aws-cli change.

### DIFF
--- a/samcli/lib/deploy/deployer.py
+++ b/samcli/lib/deploy/deployer.py
@@ -401,9 +401,9 @@ class Deployer:
         else:
             raise RuntimeError("Invalid changeset type {0}".format(changeset_type))
 
-        # Poll every 5 seconds. Optimizing for the case when the stack has only
-        # minimal changes, such the Code for Lambda Function
-        waiter_config = {"Delay": 5, "MaxAttempts": 720}
+        # Poll every 30 seconds. Polling too frequently risks hitting rate limits
+        # on CloudFormation's DescribeStacks API
+        waiter_config = {"Delay": 30, "MaxAttempts": 120}
 
         try:
             waiter.wait(StackName=stack_name, WaiterConfig=waiter_config)

--- a/samcli/lib/utils/botoconfig.py
+++ b/samcli/lib/utils/botoconfig.py
@@ -14,5 +14,4 @@ def get_boto_config_with_user_agent(**kwargs):
         if gc.telemetry_enabled
         else f"aws-sam-cli/{__version__}",
         **kwargs,
-        retries={"max_attempts": 3, "mode": "adaptive"},
     )

--- a/samcli/lib/utils/botoconfig.py
+++ b/samcli/lib/utils/botoconfig.py
@@ -14,4 +14,5 @@ def get_boto_config_with_user_agent(**kwargs):
         if gc.telemetry_enabled
         else f"aws-sam-cli/{__version__}",
         **kwargs,
+        retries={"max_attempts": 3, "mode": "adaptive"},
     )


### PR DESCRIPTION
*Issue #, if available:*
We do hit throttling limit when polling cloudformation for describe stack. AwsCli recently made a change to update their polling frequency, this change is to add same values to sam-cli.
*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
