### PR TITLE
fix: print exception details for LambdaResponseParseException and rem…

### DIFF
--- a/samcli/local/apigw/local_apigw_service.py
+++ b/samcli/local/apigw/local_apigw_service.py
@@ -299,9 +299,7 @@ class LocalApigwService(BaseLocalService):
         # a response shape.
         invalid_keys = LocalApigwService._invalid_apig_response_keys(json_output)
         if bool(invalid_keys):
-            raise LambdaResponseParseException(
-                f"Invalid API Gateway Response Keys: {str(invalid_keys)} in {str(json_output)}"
-            )
+            raise LambdaResponseParseException(f"Invalid API Gateway Response Keys: {invalid_keys} in {json_output}")
 
         # If the customer doesn't define Content-Type default to application/json
         if "Content-Type" not in headers:


### PR DESCRIPTION
…ove redundant logging in upstreams methods

*Issue #1947

*Why is this change necessary?*
When debugging lambda functions locally, some of the exceptions are not printed in the console.

*How does it address the issue?*
Instead of printing the exception type, it is been changed to print exception details. Any upstream logging is removed for not having duplicate logs in the console.

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
