### PR TITLE
Version bump

### DIFF
--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = "0.53.0"
+__version__ = "1.0.0.rc1"

--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = "1.0.0.rc1"
+__version__ = "1.0.0rc1"


### PR DESCRIPTION
Resolve conflict between https://www.python.org/dev/peps/pep-0440/#pre-releases and https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning by changing approach.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
