### PR TITLE
refactor: Build init.go with -s and -w flags to removed debug info

### DIFF
--- a/samcli/local/rapid/build.sh
+++ b/samcli/local/rapid/build.sh
@@ -1,1 +1,1 @@
-GOPROXY=direct GOARCH=amd64 GOOS=linux go build -o init
+GOPROXY=direct GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o init


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Why is this change necessary?*
The build script to build the init.go binary is 9.1Mb. If we remove the debug symbols we can reduce this to 6.6Mb. 

*How does it address the issue?*
adds -s and -w linker flags. 

-s: Omit the symbol table and debug information.
-w: Omit the DWARF symbol table.

*What side effects does this change have?*
None that I know of.

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
N/A

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
