### PR TITLE
refactor: Bake Rapid into image on the fly

### DIFF
--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -24,8 +24,6 @@ class LambdaContainer(Container):
     # The Volume Mount path for debug files in docker
     _DEBUGGER_VOLUME_MOUNT_PATH = "/tmp/lambci_debug_files"
     _DEFAULT_CONTAINER_DBG_GO_PATH = _DEBUGGER_VOLUME_MOUNT_PATH + "/dlv"
-    _RAPID_SOURCE_PATH = Path(__file__).parent.joinpath("..", "rapid").resolve()
-    _RAPID_DESTINATION_MOUNT = {"bind": "/var/rapid", "mode": "ro"}
     _GO_BOOTSTRAP_SOURCE_PATH = Path(__file__).parent.joinpath("..", "go-bootstrap").resolve()
     _GO_BOOTSTRAP_DESTINATION_MOUNT = {"bind": "/var/runtime", "mode": "ro"}
 
@@ -150,7 +148,7 @@ class LambdaContainer(Container):
         :param DebugContext debug_options: DebugContext for the runtime of the container.
         :return dict: Dictionary containing volume map passed to container creation.
         """
-        volumes = {LambdaContainer._RAPID_SOURCE_PATH: LambdaContainer._RAPID_DESTINATION_MOUNT}
+        volumes = {}
 
         if debug_options and debug_options.debugger_path:
             volumes[debug_options.debugger_path] = LambdaContainer._DEBUGGER_VOLUME_MOUNT

--- a/samcli/local/docker/lambda_container.py
+++ b/samcli/local/docker/lambda_container.py
@@ -24,8 +24,6 @@ class LambdaContainer(Container):
     # The Volume Mount path for debug files in docker
     _DEBUGGER_VOLUME_MOUNT_PATH = "/tmp/lambci_debug_files"
     _DEFAULT_CONTAINER_DBG_GO_PATH = _DEBUGGER_VOLUME_MOUNT_PATH + "/dlv"
-    _GO_BOOTSTRAP_SOURCE_PATH = Path(__file__).parent.joinpath("..", "go-bootstrap").resolve()
-    _GO_BOOTSTRAP_DESTINATION_MOUNT = {"bind": "/var/runtime", "mode": "ro"}
 
     # Options for selecting debug entry point
     _DEBUG_ENTRYPOINT_OPTIONS = {"delvePath": _DEFAULT_CONTAINER_DBG_GO_PATH}
@@ -71,7 +69,7 @@ class LambdaContainer(Container):
         if not Runtime.has_value(runtime):
             raise ValueError("Unsupported Lambda runtime {}".format(runtime))
 
-        image = LambdaContainer._get_image(image_builder, runtime, layers)
+        image = LambdaContainer._get_image(image_builder, runtime, layers, debug_options)
         ports = LambdaContainer._get_exposed_ports(debug_options)
         entry, debug_env_vars = LambdaContainer._get_debug_settings(runtime, debug_options)
         additional_options = LambdaContainer._get_additional_options(runtime, debug_options)
@@ -152,14 +150,11 @@ class LambdaContainer(Container):
 
         if debug_options and debug_options.debugger_path:
             volumes[debug_options.debugger_path] = LambdaContainer._DEBUGGER_VOLUME_MOUNT
-            # Only add bootstrap if debugging go project.
-            if runtime == Runtime.go1x.value:
-                volumes[LambdaContainer._GO_BOOTSTRAP_SOURCE_PATH] = LambdaContainer._GO_BOOTSTRAP_DESTINATION_MOUNT
 
         return volumes
 
     @staticmethod
-    def _get_image(image_builder, runtime, layers):
+    def _get_image(image_builder, runtime, layers, debug_options):
         """
         Returns the name of Docker Image for the given runtime
 
@@ -177,7 +172,8 @@ class LambdaContainer(Container):
         str
             Name of Docker Image for the given runtime
         """
-        return image_builder.build(runtime, layers)
+        is_debug = bool(debug_options and debug_options.debugger_path)
+        return image_builder.build(runtime, layers, is_debug)
 
     @staticmethod
     def _get_debug_settings(runtime, debug_options=None):  # pylint: disable=too-many-branches

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -220,7 +220,7 @@ class LambdaImage:
             String representing the Dockerfile contents for the image
 
         """
-        dockerfile_content = f"FROM {base_image}\nADD init /var/rapid\n"
+        dockerfile_content = f"FROM {base_image}\nADD init /var/rapid\nRUN chmod +x /var/rapid/init\n"
         for layer in layers:
             dockerfile_content = dockerfile_content + f"ADD {layer.name} {LambdaImage._LAYERS_DIR}\n"
         return dockerfile_content

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -29,7 +29,6 @@ RUNTIMES_WITH_ENTRYPOINT_OVERRIDES = RUNTIMES_WITH_ENTRYPOINT + RUNTIMES_WITH_BO
 
 ALL_RUNTIMES = [r.value for r in Runtime]
 
-RAPID_PATH = Path(__file__).parent.joinpath("..", "..", "..", "..", "samcli", "local", "rapid").resolve()
 GO_BOOTSTRAP_PATH = Path(__file__).parent.joinpath("..", "..", "..", "..", "samcli", "local", "go-bootstrap").resolve()
 
 
@@ -248,7 +247,7 @@ class TestLambdaContainer_get_additional_options(TestCase):
 class TestLambdaContainer_get_additional_volumes(TestCase):
     @parameterized.expand([param(r) for r in RUNTIMES_WITH_ENTRYPOINT if r.startswith("go")])
     def test_no_additional_volumes_when_debug_options_is_none(self, runtime):
-        expected = {RAPID_PATH: {"bind": "/var/rapid", "mode": "ro"}}
+        expected = {}
 
         debug_options = DebugContext(debug_ports=None)
 
@@ -257,7 +256,7 @@ class TestLambdaContainer_get_additional_volumes(TestCase):
 
     @parameterized.expand([param(r) for r in RUNTIMES_WITH_ENTRYPOINT if r.startswith("go")])
     def test_no_additional_volumes_when_debuggr_path_is_none(self, runtime):
-        expected = {RAPID_PATH: {"bind": "/var/rapid", "mode": "ro"}}
+        expected = {}
         debug_options = DebugContext(debug_ports=[1234])
 
         result = LambdaContainer._get_additional_volumes(runtime, debug_options)
@@ -267,7 +266,6 @@ class TestLambdaContainer_get_additional_volumes(TestCase):
     @parameterized.expand([param(r) for r in RUNTIMES_WITH_ENTRYPOINT if r.startswith("go")])
     def test_additional_volumes_returns_volume_with_debugger_path_is_set(self, runtime):
         expected = {
-            RAPID_PATH: {"bind": "/var/rapid", "mode": "ro"},
             "/somepath": {"bind": "/tmp/lambci_debug_files", "mode": "ro"},
             GO_BOOTSTRAP_PATH: {"bind": "/var/runtime", "mode": "ro"},
         }

--- a/tests/unit/local/docker/test_lambda_image.py
+++ b/tests/unit/local/docker/test_lambda_image.py
@@ -129,7 +129,7 @@ class TestLambdaImage(TestCase):
         docker_client_mock = Mock()
         docker_patch.from_env.return_value = docker_client_mock
 
-        expected_docker_file = "FROM python\nADD init /var/rapid\nADD layer1 /opt\n"
+        expected_docker_file = "FROM python\nADD init /var/rapid\nRUN chmod +x /var/rapid/init\nADD layer1 /opt\n"
 
         layer_mock = Mock()
         layer_mock.name = "layer1"

--- a/tests/unit/local/docker/test_lambda_image.py
+++ b/tests/unit/local/docker/test_lambda_image.py
@@ -33,7 +33,7 @@ class TestLambdaImage(TestCase):
 
         lambda_image = LambdaImage("layer_downloader", False, False, docker_client=docker_client_mock)
 
-        self.assertEqual(lambda_image.build("python3.6", []), "amazon/aws-sam-cli-emulation-image-python3.6:latest")
+        self.assertEqual(lambda_image.build("python3.6", []), "amazon/aws-sam-cli-emulation-image-python3.6:rapid")
 
     @patch("samcli.local.docker.lambda_image.LambdaImage._build_image")
     @patch("samcli.local.docker.lambda_image.LambdaImage._generate_docker_image_version")
@@ -129,7 +129,7 @@ class TestLambdaImage(TestCase):
         docker_client_mock = Mock()
         docker_patch.from_env.return_value = docker_client_mock
 
-        expected_docker_file = "FROM python\nADD layer1 /opt\n"
+        expected_docker_file = "FROM python\nADD init /var/rapid\nADD layer1 /opt\n"
 
         layer_mock = Mock()
         layer_mock.name = "layer1"


### PR DESCRIPTION
*Issue #, if available:*
This is an alternative solution to #2098 

*Why is this change necessary?*
We need RAPID inside the container at runtime. The options are mounting or created an image on they fly. Mounting requires the path to be sharable to docker and if it not, the invoke will fail which is a regressions in rc1.

*How does it address the issue?*
Instead of mounting or allowing customers to give the path to an alternative rapid, we will just build the image locally that has rapid baked into it. This will ensure we can set permissions on this binary (if needed). This should get around the initially issue found in #2095 where we could not mount the rapid binary due to share settings of docker. The implementation creates a tar and sends that to the docker build (through the sdk). If we have access to the file (which we should) then we can create the tar and therefore not have to deal with docker share settings.

*What side effects does this change have?*
None that I know of

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*
N/A

Extra details:
If we decide to go this route, we should consider doing the same for the custom go boostrap that enabled debugging for go.

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
