### PR TITLE
fix: removing temporary files on sam init with custom location fails …

### DIFF
--- a/samcli/lib/init/arbitrary_project.py
+++ b/samcli/lib/init/arbitrary_project.py
@@ -103,7 +103,7 @@ def _download_and_copy(download_fn, output_dir):
     output_dir
     """
 
-    with osutils.mkdir_temp() as tempdir:
+    with osutils.mkdir_temp(ignore_errors=True) as tempdir:
         downloaded_dir = download_fn(clone_to_dir=tempdir)
         osutils.copytree(downloaded_dir, output_dir, ignore=shutil.ignore_patterns("*.git"))
 

--- a/tests/unit/lib/init/test_arbitrary_project.py
+++ b/tests/unit/lib/init/test_arbitrary_project.py
@@ -46,6 +46,7 @@ class TestGenerateNonCookieCutterProject(TestCase):
             clone_mock.assert_called_with(repo_url=location, no_input=True, clone_to_dir=ANY)
 
             osutils_mock.copytree.assert_called_with("cloned_dir", self.output_dir, ignore=ANY)
+            osutils_mock.mkdir_temp.assert_called_with(ignore_errors=True)
 
     def test_must_fail_on_local_folders(self):
         location = str(Path("my", "folder"))


### PR DESCRIPTION
…on Windows due to permissions, changed to delete temporary folder with permission update

*Issue #2085*

*Why is this change necessary?*
Initiating a new project with custom location flag, prints error to the command line even though it succeeds cloning the given project location. The error is about cleaning the temporary folders.

*How does it address the issue?*
The regular flow has a way to clean out temporary folders by changing the permission first. It is been applied here as well.

*What side effects does this change have?*
None

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
