### PR TITLE
Remove liblzma and libxslt from AL2 build images

### DIFF
--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -29,8 +29,6 @@ RUN yum install -d1 --installroot=/rootfs -y \
   procps \
   libgmp3-dev \
   zlib1g-dev \
-  liblzma-dev \
-  libxslt-devel \
   libmpc-devel \
   && yum clean all
 

--- a/build-image-src/Dockerfile-nodejs10x
+++ b/build-image-src/Dockerfile-nodejs10x
@@ -26,8 +26,6 @@ RUN yum install -d1 --installroot=/rootfs -y \
   procps \
   libgmp3-dev \
   zlib1g-dev \
-  liblzma-dev \
-  libxslt-devel \
   libmpc-devel \
   && yum clean all
 

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -25,8 +25,6 @@ RUN yum install -d1 --installroot=/rootfs -y \
   procps \
   libgmp3-dev \
   zlib1g-dev \
-  liblzma-dev \
-  libxslt-devel \
   libmpc-devel \
   && yum clean all
 

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -21,8 +21,6 @@ RUN yum install -d1 --installroot=/rootfs -y \
   procps \
   libgmp3-dev \
   zlib1g-dev \
-  liblzma-dev \
-  libxslt-devel \
   libmpc-devel \
   && yum clean all
 

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -20,8 +20,6 @@ RUN yum install -d1 --installroot=/rootfs -y \
   procps \
   libgmp3-dev \
   zlib1g-dev \
-  liblzma-dev \
-  libxslt-devel \
   libmpc-devel \
   && yum clean all
 


### PR DESCRIPTION
Discovered a regression where on Ruby 2.7, the `nokogiri` dependency
would build without errors, but would not run on local testing or on AWS
Lambda itself.

On further investigation, it appears that `nokogiri` can compile with or
without `liblzma` present, but if it is present in the build
enviornment (pre-change) and it is not present on the invoke
environment (true in AL2 runtimes), you will experience runtime failures
attempting to require `nokogiri`.

I have been able to verify that with these changes, `nokogiri` builds
correctly for Ruby 2.7 and runs both locally and on AWS Lambda.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
