### PR TITLE
Bumping Boto3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ chevron~=0.12
 click~=7.0
 Flask~=1.0.2
 #Need to add Schemas latest SDK.
-boto3~=1.13.0, >=1.13.0
+boto3~=1.14.23
 jmespath~=0.9.5
 PyYAML~=5.1
 cookiecutter~=1.6.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ chevron~=0.12
 click~=7.0
 Flask~=1.0.2
 #Need to add Schemas latest SDK.
-boto3~=1.14.23
+boto3~=1.14.0, >=1.14.23
 jmespath~=0.9.5
 PyYAML~=5.1
 cookiecutter~=1.6.0


### PR DESCRIPTION
*Issue #, if available:*
It generated an error when building the lambci python3.8 Docker image.

*Why is this change necessary?* 
Bumps to parity with aws-cli and gets rid of build errors on lambci python3.8 Docker image

*How does it address the issue?*
Eliminates the build error.

*What side effects does this change have?*
It bumps boto3 from 1.13.x to 1.14.x. 

*Did you change a dependency in `requirements/base.txt`?*
Yes.
    *If so, did you run `make update-reproducible-reqs`*
No. For security reasons I would feel better if a core maintainer updated the hashcodes.
*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Yes.
