### PR TITLE
chore: Bump aws-lambda-builders and SAM CLI to 1.0.0

### DIFF
--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -53,10 +53,11 @@ install:
     - "python -m pip install --upgrade setuptools wheel virtualenv"
 
     # Upgrade pip in each python
-    - "python2.7 -m pip install --upgrade pip"
-    - "python3.6 -m pip install --upgrade pip"
-    - "python3.7 -m pip install --upgrade pip"
-    - "python3.8 -m pip install --upgrade pip"
+    - "C:\\Python27-x64\\python.exe -m pip install --upgrade pip"
+    - "C:\\Python36-x64\\python.exe -m pip install --upgrade pip"
+    # python is python3.7
+    - "python -m pip install --upgrade pip"
+    - "C:\\Python38\\python.exe -m pip install --upgrade pip"
 
     # Create new virtual environment with chosen python version and activate it
     - "python -m virtualenv venv"

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -53,7 +53,7 @@ install:
     - "python -m pip install --upgrade setuptools wheel virtualenv"
 
     # Upgrade pip in each python
-    - "C:\\Python27-x64\\python.exe -m pip install --upgrade pip"
+    - "C:\Python27\\python.exe -m pip install --upgrade pip"
     - "C:\\Python36-x64\\python.exe -m pip install --upgrade pip"
     # python is python3.7
     - "python -m pip install --upgrade pip"

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -53,7 +53,7 @@ install:
     - "python -m pip install --upgrade setuptools wheel virtualenv"
 
     # Upgrade pip in each python
-    - "C:\Python27\\python.exe -m pip install --upgrade pip"
+    - "C:\\Python27\\python.exe -m pip install --upgrade pip"
     - "C:\\Python36-x64\\python.exe -m pip install --upgrade pip"
     # python is python3.7
     - "python -m pip install --upgrade pip"

--- a/appveyor-windows-build-python.yml
+++ b/appveyor-windows-build-python.yml
@@ -52,6 +52,12 @@ install:
     # Upgrade setuptools, wheel and virtualenv
     - "python -m pip install --upgrade setuptools wheel virtualenv"
 
+    # Upgrade pip in each python
+    - "python2.7 -m pip install --upgrade pip"
+    - "python3.6 -m pip install --upgrade pip"
+    - "python3.7 -m pip install --upgrade pip"
+    - "python3.8 -m pip install --upgrade pip"
+
     # Create new virtual environment with chosen python version and activate it
     - "python -m virtualenv venv"
     - "venv\\Scripts\\activate"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,5 +12,5 @@ dateparser~=0.7
 python-dateutil~=2.6, <2.8.1
 requests==2.23.0
 serverlessrepo==0.1.9
-aws_lambda_builders==0.9.0
+aws_lambda_builders==1.0.0
 tomlkit==0.5.8

--- a/requirements/reproducible-linux.txt
+++ b/requirements/reproducible-linux.txt
@@ -17,10 +17,10 @@ aws-sam-translator==1.25.0 \
     --hash=sha256:5b31769d271fa6c7e87cde076ce819f9f9c7da324b3880f2cd0f5f5aa837e520 \
     --hash=sha256:f2d0585fc7dd071f136b543e9a614945cb80bbd3113a25f260797c126456dd25 \
     # via aws-sam-cli (setup.py)
-aws_lambda_builders==0.9.0 \
-    --hash=sha256:036cabf8aae2482aca4b37e4f6c36a2dd1df65b05eed6de605410c30ca3e4a63 \
-    --hash=sha256:660028424c8ce4677debbec33f56e37498f71170da80cc91fa322d1b2071bb0a \
-    --hash=sha256:f4c5c7a14652a6f6256cb0254e45ae5aa413dd4b62b9854cd5a3f01c4fe9c889 \
+aws_lambda_builders==1.0.0 \
+    --hash=sha256:757ed604e5d0948e0a3d0e444b24f5f4fff1016d82c5d02158ffacc5554acabd \
+    --hash=sha256:b9e7cd09b4f04574d96cdb880644e6c7fd1ad8bcc25c3aef3ed0268a5ada9a67 \
+    --hash=sha256:dc4501c641e0bc52605c0133e3d348770bc98aa9e2ac9937f717c0a658c4dbe8 \
     # via aws-sam-cli (setup.py)
 binaryornot==0.4.4 \
     --hash=sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061 \

--- a/samcli/__init__.py
+++ b/samcli/__init__.py
@@ -2,4 +2,4 @@
 SAM CLI version
 """
 
-__version__ = "1.0.0rc2"
+__version__ = "1.0.0"


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Why is this change necessary?*
Use the latest lambda builders and update SAM CLI's version to 1.0.0

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
yes
    *If so, did you run `make update-reproducible-reqs`*
yes

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
