### PR TITLE
Update hash function to be location independent

### DIFF
--- a/samcli/lib/utils/hash.py
+++ b/samcli/lib/utils/hash.py
@@ -57,7 +57,7 @@ def dir_checksum(directory, followlinks=True):
         for filepath in [os.path.join(dirpath, filename) for filename in filenames]:
             # Look at filename and contents.
             # Encode file's checksum to be utf-8 and bytes.
-            md5_dir.update(filepath.encode("utf-8"))
+            md5_dir.update(os.path.relpath(filepath, directory).encode("utf-8"))
             filepath_checksum = file_checksum(filepath)
             md5_dir.update(filepath_checksum.encode("utf-8"))
     return md5_dir.hexdigest()

--- a/tests/unit/lib/utils/test_hash.py
+++ b/tests/unit/lib/utils/test_hash.py
@@ -13,6 +13,18 @@ class TestHash(TestCase):
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def test_dir_hash_independent_of_location(self):
+        temp_dir1 = os.path.join(self.temp_dir, "temp-dir-1")
+        os.mkdir(temp_dir1)
+        with open(os.path.join(temp_dir1, "test-file"), "w+") as f:
+            f.write("Testfile")
+        checksum1 = dir_checksum(temp_dir1)
+
+        temp_dir2 = shutil.move(temp_dir1, os.path.join(self.temp_dir, "temp-dir-2"))
+        checksum2 = dir_checksum(temp_dir2)
+
+        self.assertEqual(checksum1, checksum2)
+
     def test_dir_hash_same_contents_diff_file_per_directory(self):
         _file = tempfile.NamedTemporaryFile(delete=False, dir=self.temp_dir)
         _file.write(b"Testfile")


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-sam-cli/issues/2110

*Why is this change necessary?*

AWS CodeBuild uses transient locations as root folders for a build. As the absolute path was used to calculated the directory hash it always resulted in a new hash thus prompting a redeploy even when no code change had been made.

*How does it address the issue?*

It uses the relative path of the directory instead of the absolute.

*What side effects does this change have?*

None

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
