### PR TITLE
fix: remove redundant `print_deploy_args` call

### DIFF
--- a/samcli/commands/deploy/guided_context.py
+++ b/samcli/commands/deploy/guided_context.py
@@ -14,7 +14,7 @@ from samcli.commands._utils.template import get_template_parameters, get_templat
 from samcli.commands.deploy.exceptions import GuidedDeployFailedError
 from samcli.commands.deploy.guided_config import GuidedConfig
 from samcli.commands.deploy.auth_utils import auth_per_resource
-from samcli.commands.deploy.utils import sanitize_parameter_overrides, print_deploy_args
+from samcli.commands.deploy.utils import sanitize_parameter_overrides
 from samcli.lib.bootstrap.bootstrap import manage_stack
 from samcli.lib.utils.colors import Colored
 
@@ -164,15 +164,6 @@ class GuidedContext:
         guided_config.read_config_showcase()
 
         self.guided_prompts(_parameter_override_keys)
-
-        print_deploy_args(
-            stack_name=self.guided_stack_name,
-            s3_bucket=self.guided_s3_bucket,
-            region=self.guided_region,
-            capabilities=self._capabilities,
-            parameter_overrides=self._parameter_overrides,
-            confirm_changeset=self.confirm_changeset,
-        )
 
         if self.save_to_config:
             guided_config.save_config(

--- a/tests/unit/commands/deploy/test_command.py
+++ b/tests/unit/commands/deploy/test_command.py
@@ -98,7 +98,6 @@ class TestDeployCliCommand(TestCase):
     @patch("samcli.commands.package.package_context.PackageContext")
     @patch("samcli.commands.deploy.command.click")
     @patch("samcli.commands.deploy.deploy_context.DeployContext")
-    @patch("samcli.commands.deploy.guided_context.print_deploy_args")
     @patch("samcli.commands.deploy.guided_context.manage_stack")
     @patch("samcli.commands.deploy.guided_context.auth_per_resource")
     @patch("samcli.commands.deploy.guided_context.get_template_parameters")
@@ -114,7 +113,6 @@ class TestDeployCliCommand(TestCase):
         mock_get_template_parameters,
         mockauth_per_resource,
         mock_managed_stack,
-        mock_print_deploy_args,
         mock_deploy_context,
         mock_deploy_click,
         mock_package_context,
@@ -162,7 +160,6 @@ class TestDeployCliCommand(TestCase):
     @patch("samcli.commands.package.package_context.PackageContext")
     @patch("samcli.commands.deploy.command.click")
     @patch("samcli.commands.deploy.deploy_context.DeployContext")
-    @patch("samcli.commands.deploy.guided_context.print_deploy_args")
     @patch("samcli.commands.deploy.guided_context.manage_stack")
     @patch("samcli.commands.deploy.guided_context.auth_per_resource")
     @patch("samcli.commands.deploy.guided_context.get_template_parameters")
@@ -178,7 +175,6 @@ class TestDeployCliCommand(TestCase):
         mock_get_template_parameters,
         mockauth_per_resource,
         mock_managed_stack,
-        mock_print_deploy_args,
         mock_deploy_context,
         mock_deploy_click,
         mock_package_context,
@@ -261,7 +257,6 @@ class TestDeployCliCommand(TestCase):
     @patch("samcli.commands.package.package_context.PackageContext")
     @patch("samcli.commands.deploy.command.click")
     @patch("samcli.commands.deploy.deploy_context.DeployContext")
-    @patch("samcli.commands.deploy.guided_context.print_deploy_args")
     @patch("samcli.commands.deploy.guided_context.manage_stack")
     @patch("samcli.commands.deploy.guided_context.auth_per_resource")
     @patch("samcli.commands.deploy.guided_context.get_template_data")
@@ -281,7 +276,6 @@ class TestDeployCliCommand(TestCase):
         mock_get_template_data,
         mockauth_per_resource,
         mock_managed_stack,
-        mock_print_deploy_args,
         mock_deploy_context,
         mock_deploy_click,
         mock_package_context,
@@ -380,7 +374,6 @@ class TestDeployCliCommand(TestCase):
     @patch("samcli.commands.package.package_context.PackageContext")
     @patch("samcli.commands.deploy.command.click")
     @patch("samcli.commands.deploy.deploy_context.DeployContext")
-    @patch("samcli.commands.deploy.guided_context.print_deploy_args")
     @patch("samcli.commands.deploy.guided_context.auth_per_resource")
     @patch("samcli.commands.deploy.guided_context.get_template_data")
     @patch("samcli.commands.deploy.guided_context.manage_stack")
@@ -404,7 +397,6 @@ class TestDeployCliCommand(TestCase):
         mock_managed_stack,
         mock_get_template_data,
         mockauth_per_resource,
-        mock_print_deploy_args,
         mock_deploy_context,
         mock_deploy_click,
         mock_package_context,
@@ -484,7 +476,6 @@ class TestDeployCliCommand(TestCase):
     @patch("samcli.commands.package.package_context.PackageContext")
     @patch("samcli.commands.deploy.command.click")
     @patch("samcli.commands.deploy.deploy_context.DeployContext")
-    @patch("samcli.commands.deploy.guided_context.print_deploy_args")
     @patch("samcli.commands.deploy.guided_context.manage_stack")
     @patch("samcli.commands.deploy.guided_context.auth_per_resource")
     @patch("samcli.commands.deploy.guided_context.get_template_data")
@@ -500,7 +491,6 @@ class TestDeployCliCommand(TestCase):
         mock_get_template_data,
         mockauth_per_resource,
         mock_managed_stack,
-        mock_print_deploy_args,
         mock_deploy_context,
         mock_deploy_click,
         mock_package_context,


### PR DESCRIPTION
*Issue #, if available:*

*Why is this change necessary?*

*How does it address the issue?*

*What side effects does this change have?*

*Did you change a dependency in `requirements/base.txt`?*
    *If so, did you run `make update-reproducible-reqs`*

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [x] Write/update unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [x] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
