### PR TITLE
Fix: Permission Set to Default for Files Added to Docker Image When Building

### DIFF
--- a/samcli/lib/utils/tar.py
+++ b/samcli/lib/utils/tar.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def create_tarball(tar_paths):
+def create_tarball(tar_paths, filter=None):
     """
     Context Manger that creates the tarball of the Docker Context to use for building the image
 
@@ -25,7 +25,7 @@ def create_tarball(tar_paths):
 
     with tarfile.open(fileobj=tarballfile, mode="w") as archive:
         for path_on_system, path_in_tarball in tar_paths.items():
-            archive.add(path_on_system, arcname=path_in_tarball)
+            archive.add(path_on_system, arcname=path_in_tarball, filter=filter)
 
     # Flush are seek to the beginning of the file
     tarballfile.flush()

--- a/samcli/local/docker/lambda_image.py
+++ b/samcli/local/docker/lambda_image.py
@@ -195,7 +195,13 @@ class LambdaImage:
             for layer in layers:
                 tar_paths[layer.codeuri] = "/" + layer.name
 
-            with create_tarball(tar_paths) as tarballfile:
+            # Set tar file permission to 777
+            # This is need for systems without unix like permission bits(Windows) while creating a unix image
+            def set_item_permission(tar_info):
+                tar_info.mode = 777
+                return tar_info
+
+            with create_tarball(tar_paths, filter=set_item_permission) as tarballfile:
                 try:
                     resp_stream = self.docker_client.api.build(
                         fileobj=tarballfile, custom_context=True, rm=True, tag=docker_tag, pull=not self.skip_pull_image


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-sam-cli/issues/1014

*Why is this change necessary?*
Layer file permission is set to default(0666) if the docker image tar file is built with a system that's not unix(Windows).

*How does it address the issue?*
Set all file permission to 0777 for files added to the docker image.

*What side effects does this change have?*
All files added to the docker image will have permission of 0777.

*Did you change a dependency in `requirements/base.txt`?*
No

*Checklist:*

- [ ] Write Design Document ([Do I need to write a design document?](https://github.com/awslabs/aws-sam-cli/blob/develop/DEVELOPMENT_GUIDE.rst#design-document))
- [ ] Write unit tests
- [ ] Write/update functional tests
- [ ] Write/update integration tests
- [ ] `make pr` passes
- [ ] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
