### PR TITLE
Add Debug Support for java8.al2 Runtime

### DIFF
--- a/samcli/local/docker/lambda_debug_settings.py
+++ b/samcli/local/docker/lambda_debug_settings.py
@@ -49,6 +49,13 @@ class LambdaDebugSettings:
                     + " ".join(debug_args_list)
                 },
             ),
+            Runtime.java8al2.value: DebugSettings(
+                entry,
+                debug_env_vars={
+                    "_JAVA_OPTIONS": f"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,quiet=y,address={debug_port} -XX:MaxHeapSize=2834432k -XX:MaxMetaspaceSize=163840k -XX:ReservedCodeCacheSize=81920k -XX:+UseSerialGC -XX:-TieredCompilation -Djava.net.preferIPv4Stack=true -Xshare:off"
+                    + " ".join(debug_args_list)
+                },
+            ),
             Runtime.java11.value: DebugSettings(
                 entry,
                 debug_env_vars={

--- a/tests/unit/local/docker/test_lambda_container.py
+++ b/tests/unit/local/docker/test_lambda_container.py
@@ -23,7 +23,12 @@ RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT = [
     Runtime.python27.value,
 ]
 
-RUNTIMES_WITH_DEBUG_ENV_VARS_ONLY = [Runtime.java11.value, Runtime.java8.value, Runtime.dotnetcore21.value]
+RUNTIMES_WITH_DEBUG_ENV_VARS_ONLY = [
+    Runtime.java11.value,
+    Runtime.java8.value,
+    Runtime.java8al2.value,
+    Runtime.dotnetcore21.value,
+]
 
 RUNTIMES_WITH_ENTRYPOINT_OVERRIDES = RUNTIMES_WITH_ENTRYPOINT + RUNTIMES_WITH_BOOTSTRAP_ENTRYPOINT
 


### PR DESCRIPTION
Was missing from original release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
